### PR TITLE
Work orders for /nightshift:hunt; example docs polish

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,8 @@ Everything is named from a real construction site — learn one term, guess the 
 | **site inspection** | interval commands | the scheduled heavy inspection (coverage, dead code, Sonar) every N items or H hours |
 | **walkthrough** | template item | the open-ended scan → fix loop that hunts defects until the clock runs out |
 | **coverage hunt** · **defect hunt** · **standing loop** | walkthrough presets | the three famous overnight jobs, ready to run |
-| **hunt** | `/nightshift:hunt` | stages a ready-made walkthrough into the drafting table; enters the punch list only on your word |
+| **hunt** | `/nightshift:hunt` | writes a ready-made walkthrough as a work order; cuts it into the punch list only on your word |
+| **work order** | `.nightshift/work-orders.md` | a prepared job ticket — the item plus its hours, clock not running until the cut |
 | **snag log** | `.nightshift/snag-log.md` | findings ledger across runs — cycle 4 never re-reports cycle 1 |
 | **parking lot** | `.nightshift/parking-lot.md` | decisions for the human — parked with a default chosen, the run continues |
 | **park, don't ask** | hardhat rule | during a shift the ask-tool is denied — the question is parked with a default chosen; answer mid-run in the session and the agent applies it |
@@ -158,11 +159,13 @@ the clock says stop. Every cycle rotates a fresh lens — real-bug traces, UX fr
 contract drift, dead code — walks the live UI, and runs your quality tooling at every site
 inspection. An empty cycle doesn't end it; it means dig deeper. Only the whistle ends it.
 
-None of them is a command you babysit — `/nightshift:hunt` stages the one you pick into the
-drafting table (never touching drafts already there), you promote it to the punch list with a
-word, and `/nightshift:start` demands the hours (a walkthrough may not start without a deadline —
-that's your cost cap). Prefer to hand-roll? The items live in
-[`walkthrough-item.md`](skills/nightshift/references/walkthrough-item.md) — paste and tweak.
+None of them is a command you babysit — `/nightshift:hunt` writes the one you pick as a **work
+order**: the item plus its hours, parked in `.nightshift/work-orders.md` with the clock not
+running. Say "start now" and it cuts the order into the punch list, arms the deadline, and the
+gate takes over — or leave it parked and `/nightshift:start` offers it when you're ready. Either
+way a walkthrough never runs without its cost cap. Prefer to hand-roll? The items live in
+[`walkthrough-item.md`](skills/nightshift/references/walkthrough-item.md) — paste and tweak, and
+`start` asks the hours.
 
 ## Owner knobs
 

--- a/commands/hunt.md
+++ b/commands/hunt.md
@@ -1,46 +1,49 @@
 ---
-description: Stage a ready-made overnight job — coverage hunt, defect hunt, or the standing loop — into the drafting table; promoted to the punch list only on the owner's word.
+description: Write a ready-made overnight job — coverage hunt, defect hunt, or the standing loop — as a work order with its hours; cut into the punch list only when the owner says start.
 ---
 
-Stage a walkthrough for `$CLAUDE_PROJECT_DIR`. Propose, never impose: the punch list changes only
+Prepare a work order for `$CLAUDE_PROJECT_DIR`. Propose, never impose: the punch list changes only
 on an explicit yes. If `.nightshift/` does not exist, stop and point to `/nightshift:setup` first.
 
 ## 1. Offer the jobs
 
 Present the three presets from
 `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/walkthrough-item.md`, one line each, and ask
-which one:
+which one — and how many hours it gets (every preset is open-ended; the hours are its only cost
+cap):
 
 - **Coverage hunt** — meaningful tests until the whistle.
 - **Defect hunt** — review → fix until a full pass finds nothing new, or the whistle.
 - **Standing loop** — improve and discover; only the clock ends it.
 
-## 2. Stage it — never clobber
+## 2. Write the work order
 
-Append the chosen preset item to `.nightshift/drafting-table.md`, wrapped in a session banner so
-this staging can never tangle with drafts already sitting there:
+Append the chosen preset and its hours to `.nightshift/work-orders.md` — hunt's own file; the
+drafting table stays the owner's room. Never clobber orders already sitting there — append below
+them:
 
 ```text
-— staged by /nightshift:hunt · <ISO date time> · start —
+## Work order — <ISO date time>
+Hours: <N>
+
 - [ ] **<the preset item, verbatim>**
   ...
-— staged by /nightshift:hunt · <ISO date time> · end —
 ```
 
-Existing drafts stay untouched, wherever they are in the file. The drafting table is the owner's
-room: they may edit the staged item directly, or ask you to reorganize the whole table — do it
-with them, then continue.
+The hours are inert while the order sits here — the clock starts only at the cut.
 
-## 3. Promote on the owner's word
+## 3. Ask: start now?
 
-Show the staged item and ask, with three first-class answers:
+One question. On **yes**:
 
-- **promote** — copy the item under `## Items` in `.nightshift/punch-list.md`, exactly as staged
-  (banners stay behind in the drafting table),
-- **edit** — rework it with the owner first, then promote what they approve,
-- **leave** — it stays drafted; nothing enters the punch list; fully respected.
+- **cut** the item — move it from `work-orders.md` under `## Items` in
+  `.nightshift/punch-list.md`; the order entry is removed, the punch list is the only place it
+  lives now,
+- write `.nightshift/deadline` as a UNIX epoch: `now + hours*3600`,
+- append a `shift started · work order · <preset> · <N>h` line to `.nightshift/shift-log.md`.
 
-## 4. Point at the clock
+From that second the site is live: the clock-out gate holds every session here — this one
+included — until the list is done, a stop-work order lands, or the whistle blows.
 
-Remind the owner: `/nightshift:start` demands hours for any walkthrough — the deadline is the cost
-cap, and the standing loop ends at nothing else.
+On **no**: the order stays parked with its hours, costing nothing; `/nightshift:start` offers it
+when the owner is ready. Fully respected either way.

--- a/commands/setup.md
+++ b/commands/setup.md
@@ -14,7 +14,8 @@ For each target below, copy the template only if the target does not already exi
 - `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/parking-lot-template.md`  → `.nightshift/parking-lot.md`
 - `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/snag-log-template.md`     → `.nightshift/snag-log.md`
 
-Create `.nightshift/shift-log.md` with a one-line header if it does not exist.
+Create `.nightshift/shift-log.md` and `.nightshift/work-orders.md` with a one-line header each if
+they do not exist.
 
 ## 2. Private by default
 

--- a/commands/start.md
+++ b/commands/start.md
@@ -6,6 +6,10 @@ Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 
 ## 1. Preflight
 
+- If `.nightshift/work-orders.md` holds a pending order, offer to cut it in: on yes, move its item
+  under `## Items` and write `.nightshift/deadline` from the order's recorded hours
+  (`now + hours*3600`) — the deadline question below is then already answered. Declining leaves
+  the order parked; never cut without a yes.
 - `.nightshift/punch-list.md` exists and has at least one open `- [ ]` under `## Items`. If not, stop
   and tell the user to run `/nightshift:setup` and add items first.
 - The working tree is clean enough to commit per item (warn if not).

--- a/examples/adapttable-overnight.md
+++ b/examples/adapttable-overnight.md
@@ -7,8 +7,7 @@ checkable in the public pull request, its commits, and the npm registry.
 
 ## The punch list, as the shift left it
 
-Nine top-level boxes (sub-bullets, Verify and Commit lines omitted here — the item anatomy is in
-[`overnight-webapp.md`](overnight-webapp.md)):
+Nine top-level boxes (sub-bullets, Verify and Commit lines omitted here):
 
 ```markdown
 - [x] **1. CSV export button on the toolbar (issue #61).**
@@ -39,10 +38,6 @@ One branch, one conventional commit per item (plus one lockfile chore), timestam
 04:18  feat(grouping): docs, e2e smoke, showcase demo + changesets (closes #62)
 ```
 
-Every overnight commit carries the driving agent's `Co-authored-by` trailer (a Cursor agent, in
-this run); two daytime follow-up commits on the same branch carry Claude Code's — two different
-agents, one punch list, one gate.
-
 ## What the contract enforced
 
 - **One gate-green commit per item** — the repo's own `pnpm check` (format, lint, typecheck, 95%+
@@ -63,7 +58,5 @@ agents, one punch list, one gate.
   <https://github.com/orwa-mahmoud/adapttable/commit/e36b3eec5adae638cc528bf141a1d27f97455cfd>
 - Last overnight commit (04:18, closes the grouping RFC):
   <https://github.com/orwa-mahmoud/adapttable/commit/4546dcdde4654c45e940bff0bebbb650dd3228ba>
-- A daytime follow-up carrying the other agent's trailer:
-  <https://github.com/orwa-mahmoud/adapttable/commit/4236aaffe1f2fdcfcc105a4448e3aac3921f2c80>
 - Outcome: issues #61, #25, #60, #62 closed by the merge; the standing locale issue #24 got a
   progress comment and stays open; v1.2.0 published to npm the same day.

--- a/examples/self-build.md
+++ b/examples/self-build.md
@@ -26,27 +26,29 @@ The one-commit-per-item history below is the proof: read it top to bottom and yo
 
 ## The receipts — one conventional commit per item, real timestamps
 
-```text
-2026-07-13 21:57 · chore: plugin scaffold, manifests, license
-2026-07-13 21:57 · ci: shellcheck + test workflow
-2026-07-13 22:03 · feat(hooks): clock-out gate — punch-list file is the only truth
-2026-07-13 22:04 · feat(hooks): stall red-tag + stop-work order + quitting time — bounded, interruptible runs
-2026-07-13 22:08 · feat(hooks): hardhat — mechanical safety, zero-config core
-2026-07-13 22:09 · feat(hooks): park-don't-ask — a question can't kill the shift
-2026-07-13 22:11 · feat(hooks): morning whistle — optional shift-end ping
-2026-07-13 22:27 · test: bats coverage for gate + hardhat + stall + stop-work + deadline + degradation
-2026-07-13 22:36 · feat(templates): punch list, parking lot, snag log, walkthrough presets
-2026-07-13 22:38 · feat(skill): the nightshift brain
-2026-07-13 22:42 · feat(commands): setup, start, status, stop
-2026-07-13 22:44 · feat(gates): stack-aware inspections — item gates + site inspections
-2026-07-13 22:47 · feat(adapters): foreman — universal outer loop for any agent cli
-2026-07-13 22:47 · test: gates detection + foreman termination paths
-2026-07-13 22:49 · docs: example shift
-2026-07-13 22:50 · docs: readme — story, vocabulary, honest caveats
-```
+All on 2026-07-13, timestamps local; every line links to its commit:
 
-The shift then closed with `docs: nightshift built nightshift — the receipts` (this file) and the
-SonarQube site inspection. For the live, complete list, run `git log --oneline` in this repo.
+- `21:57` · [chore: plugin scaffold, manifests, license](https://github.com/orwa-mahmoud/claude-nightshift/commit/07d5927)
+- `21:57` · [ci: shellcheck + test workflow](https://github.com/orwa-mahmoud/claude-nightshift/commit/b41d9cd)
+- `22:03` · [feat(hooks): clock-out gate — punch-list file is the only truth](https://github.com/orwa-mahmoud/claude-nightshift/commit/b8e561a)
+- `22:04` · [feat(hooks): stall red-tag + stop-work order + quitting time — bounded, interruptible runs](https://github.com/orwa-mahmoud/claude-nightshift/commit/11e0ea2)
+- `22:08` · [feat(hooks): hardhat — mechanical safety, zero-config core](https://github.com/orwa-mahmoud/claude-nightshift/commit/60f2380)
+- `22:09` · [feat(hooks): park-don't-ask — a question can't kill the shift](https://github.com/orwa-mahmoud/claude-nightshift/commit/1965b9c)
+- `22:11` · [feat(hooks): morning whistle — optional shift-end ping](https://github.com/orwa-mahmoud/claude-nightshift/commit/5dc7630)
+- `22:27` · [test: bats coverage for gate + hardhat + stall + stop-work + deadline + degradation](https://github.com/orwa-mahmoud/claude-nightshift/commit/41d8d1d)
+- `22:36` · [feat(templates): punch list, parking lot, snag log, walkthrough presets](https://github.com/orwa-mahmoud/claude-nightshift/commit/a8f0c1d)
+- `22:38` · [feat(skill): the nightshift brain](https://github.com/orwa-mahmoud/claude-nightshift/commit/381f01b)
+- `22:42` · [feat(commands): setup, start, status, stop](https://github.com/orwa-mahmoud/claude-nightshift/commit/bd1e2f1)
+- `22:44` · [feat(gates): stack-aware inspections — item gates + site inspections](https://github.com/orwa-mahmoud/claude-nightshift/commit/3a9b647)
+- `22:47` · [feat(adapters): foreman — universal outer loop for any agent cli](https://github.com/orwa-mahmoud/claude-nightshift/commit/46006ff)
+- `22:47` · [test: gates detection + foreman termination paths](https://github.com/orwa-mahmoud/claude-nightshift/commit/763426e)
+- `22:49` · [docs: example shift](https://github.com/orwa-mahmoud/claude-nightshift/commit/1d5e2d3)
+- `22:50` · [docs: readme — story, vocabulary, honest caveats](https://github.com/orwa-mahmoud/claude-nightshift/commit/7a39de0)
+
+The shift then closed with
+[docs: nightshift built nightshift — the receipts](https://github.com/orwa-mahmoud/claude-nightshift/commit/12c7031)
+(this file) and the SonarQube site inspection. For the live, complete list, run `git log --oneline`
+in this repo.
 
 ## What enforced it
 

--- a/tests/walkthroughs.bats
+++ b/tests/walkthroughs.bats
@@ -17,18 +17,25 @@ HUNT="$BATS_TEST_DIRNAME/../commands/hunt.md"
   grep -qi 'report mode' "$WALK"
 }
 
-@test "hunt stages to the drafting table and never clobbers existing drafts" {
-  grep -q 'drafting-table.md' "$HUNT"
+@test "hunt writes the order and its hours to work-orders.md" {
+  grep -q 'work-orders.md' "$HUNT"
+  grep -q 'Hours:' "$HUNT"
   grep -qi 'never clobber' "$HUNT"
-  grep -qi 'stay untouched' "$HUNT"
 }
 
-@test "hunt promotes only on the owner's word" {
-  grep -qi 'promote' "$HUNT"
-  grep -qi 'explicit yes' "$HUNT"
+@test "hunt cuts into the punch list only on a yes" {
+  grep -qi 'start now' "$HUNT"
+  grep -qi 'cut' "$HUNT"
   grep -q 'punch-list.md' "$HUNT"
+  grep -qi 'explicit yes' "$HUNT"
 }
 
-@test "hunt points at the mandatory walkthrough deadline" {
-  grep -qi 'demands hours' "$HUNT"
+@test "the cut arms the deadline from the recorded hours" {
+  grep -q 'hours\*3600' "$HUNT"
+  grep -qi 'clock starts only at the cut' "$HUNT"
+}
+
+@test "start offers pending work orders and setup scaffolds the file" {
+  grep -q 'work-orders.md' "$BATS_TEST_DIRNAME/../commands/start.md"
+  grep -q 'work-orders.md' "$BATS_TEST_DIRNAME/../commands/setup.md"
 }


### PR DESCRIPTION
## What's in here

**`feat(hunt)`: work orders — the item and its hours park together; the cut starts the clock**

`/nightshift:hunt` no longer stages into the drafting table. The chosen preset and its hours land in `.nightshift/work-orders.md` (the drafting table stays the owner's room; existing orders are never clobbered), and the hours sit inert until the order is cut. One question — start now?

- **yes** → the item moves under `## Items`, the deadline is armed from the recorded hours (`now + hours*3600`), the `shift started` line is logged, and the gate is live
- **no** → the order parks at zero cost; `/nightshift:start` offers it in preflight

This closes the gap where a promoted walkthrough could go live without its cost cap. `setup` scaffolds the file; the README gets the **work order** vocabulary row.

**`docs(examples)`: tighten the adapttable write-up; link every self-build receipt**

The adapttable example drops the item-anatomy cross-reference and the agent-trailer aside — the punch list, commit log, and public links carry the story. Every receipt line in the self-build snapshot now links to its commit.

## Verification

- bats: **68/68** pass · shellcheck clean · `claude plugin validate . --strict` pass

No version bump: `plugin.json` is already 0.3.0 and the v0.3.0 tag + Release will be recreated after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)