### PR TITLE
Community templates: code of conduct, PR template, issue forms

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,36 @@
+name: 🐛 Bug report
+description: Something in the plugin misbehaves — a hook, a skill, or the stop-gate.
+title: "[bug]: "
+labels: [bug]
+body:
+  - type: dropdown
+    id: harness
+    attributes:
+      label: Harness
+      options:
+        - Claude Code
+        - Cursor
+        - Other (say which below)
+    validations:
+      required: true
+  - type: input
+    id: version
+    attributes:
+      label: Plugin version
+      placeholder: e.g. 0.2.0
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: What did the agent / gate do, and what should it have done instead?
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Minimal reproduction
+      description: Punch-list state + the steps that trigger it. Transcript snippets help a lot.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 📖 Documentation
+    url: https://github.com/orwa-mahmoud/claude-nightshift/tree/main/docs
+    about: Setup, the punch-list contract, gates, and the stop-gate explained.
+  - name: 🔒 Security — gate-bypass reports
+    url: https://github.com/orwa-mahmoud/claude-nightshift/security/advisories/new
+    about: Ways to make the stop-gate lie go here, privately — not in a public issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: 💡 Feature request
+description: Propose an improvement. Note the scope rule — the plugin stays small and strict.
+title: "[feat]: "
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the situation where the current plugin falls short.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed behaviour
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Including "do nothing" — per CONTRIBUTING, features that widen scope are usually declined.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,20 @@
+<!-- Thanks for contributing to claude-nightshift! -->
+
+## What does this PR do?
+
+<!-- A short summary of the change and the motivation. Link any related issue: "Closes #12". -->
+
+## Type of change
+
+- [ ] Bug fix (non-breaking change that fixes an issue)
+- [ ] Adapter (support for another harness)
+- [ ] Docs / chore / refactor (no behaviour change)
+- [ ] Gate behaviour change (discussed in an issue first — see CONTRIBUTING)
+
+## Checklist
+
+- [ ] `shellcheck` and the `bats` suite pass locally.
+- [ ] Shell stays portable: macOS bash 3.2 / zsh — no newer bashisms, no GNU-only flags.
+- [ ] If the stop-gate changed: the PR description shows a transcript of one
+      blocked stop and one permitted stop.
+- [ ] Docs updated if commands, hooks, or the contract changed.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,28 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include being
+respectful of differing opinions, giving and gracefully accepting constructive
+feedback, and focusing on what is best for the community.
+
+Unacceptable behavior includes harassment, trolling, insulting or derogatory
+comments, and publishing others' private information without permission.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the project maintainers. All complaints will be reviewed and
+investigated promptly and fairly.
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org),
+version 2.1.


### PR DESCRIPTION
Fills the three remaining community-file gaps:

- **CODE_OF_CONDUCT.md** — Contributor Covenant, byte-identical to adapttable's (contact = project maintainers, no personal email)
- **PR template** — mirrors CONTRIBUTING: shellcheck+bats, bash-3.2 portability, and the blocked/permitted-stop transcript requirement for gate changes
- **Issue forms** — bug report (harness dropdown, plugin version, repro), feature request (with the scope rule stated), and a config that routes gate-bypass reports to the private security advisory instead of public issues (blank issues off, matching adapttable)

No discussions link — discussions are disabled on this repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)