### PR TITLE
Point homepage at the documentation page (v0.4.1)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -33,7 +33,7 @@
         "name": "Orwa Mahmoud",
         "url": "https://github.com/orwa-mahmoud"
       },
-      "homepage": "https://github.com/orwa-mahmoud/claude-nightshift",
+      "homepage": "https://orwamahmoud.com/nightshift/",
       "repository": "https://github.com/orwa-mahmoud/claude-nightshift",
       "license": "MIT"
     }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,12 +1,12 @@
 {
   "name": "nightshift",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",
     "url": "https://github.com/orwa-mahmoud"
   },
-  "homepage": "https://github.com/orwa-mahmoud/claude-nightshift",
+  "homepage": "https://orwamahmoud.com/nightshift/",
   "repository": "https://github.com/orwa-mahmoud/claude-nightshift",
   "license": "MIT",
   "keywords": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.4.1 — a page of its own
+
+- `homepage` in both manifests points at <https://orwamahmoud.com/nightshift/>, which explains what
+  the plugin does and what it deliberately does not. `repository` still points at the source, so the
+  two fields no longer say the same thing.
+
 ## v0.4.0 — guards look where the commit lands
 
 ### Guards


### PR DESCRIPTION
`homepage` and `repository` carried the same URL in both manifests, so a marketplace listing had no link to anything but the source. `homepage` now resolves to the documentation page; `repository` keeps the source.

Patch release: metadata only, no behaviour change and nothing in `hooks/`, `skills/` or `adapters/` touched.

- `.claude-plugin/plugin.json` — `homepage`, version `0.4.0` → `0.4.1`
- `.claude-plugin/marketplace.json` — `homepage`
- `CHANGELOG.md` — `## v0.4.1` section, which the release job publishes as the notes

Local: 98/98 bats, shellcheck clean, `claude plugin validate . --strict` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)