### PR TITLE
docs: name the category in the opening line

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 > **Claude works the night shift: it can't clock out until the punch list is done — and the site
 > has safety rules.**
 
-A [Claude Code](https://claude.com/claude-code) plugin for long, unattended runs (hours → days).
-You write the checklist. Hooks keep the agent on site until every box is ticked, under rules you
-set and it can't bend. You go to sleep.
+A [Claude Code](https://claude.com/claude-code) plugin for long, unattended runs (hours → days) —
+a harness for the accountability half of an agent loop. You write the checklist. Hooks keep the
+agent on site until every box is ticked, under rules you set and it can't bend. You go to sleep.
 
 Overview and FAQ: <https://orwamahmoud.com/nightshift/>
 


### PR DESCRIPTION
"Agent harness" is the noun the agent-reliability conversation settled on this year — the term was coined in February, and [awesome-harness-engineering](https://github.com/ai-boost/awesome-harness-engineering) is already at 3.3k stars. The README never used the word, so nobody arriving from that conversation recognises this as one.

One clause, in the paragraph GitHub search and the marketplace blurb both read:

> A Claude Code plugin for long, unattended runs (hours → days) — **a harness for the accountability half of an agent loop.**

"The accountability half" is deliberate: nightshift covers stop conditions, permissions, parked decisions and receipts. It does not do orchestration, memory or evals, and shouldn't read as claiming to.

The tagline and everything else are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)