### PR TITLE
Deny the identity and repo overrides the commit guards cannot read (v0.4.2)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.4.1",
+  "version": "0.4.2",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.4.2 — overrides the guards can't read are denied
+
+### Guards
+
+- A commit that relocates itself with `--git-dir` or `--work-tree` is denied whenever a commit
+  guard is configured. The guards resolve `git -C <dir>` and `cd <dir> &&`, but those two flags
+  point the commit past that resolution — the guard would inspect one repository while the commit
+  lands in another. Unverifiable means denied, exactly like the ambiguous-repo case.
+- With an expected identity configured, a commit that overrides identity on the command line —
+  `-c user.email=`, `--author`, or a `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL` prefix — is denied.
+  The guard reads the repository's configuration, and with an override present that read
+  describes nothing.
+- The no-push recipe is now `git .*push`, so config injection (`git -c k=v push`) cannot slip
+  between the words. Commit messages remain scrubbed first: a message *mentioning* a flag is not
+  a use of it.
+
+### Docs
+
+- The fine print states what the gate re-injects: the full working standard, at every stop
+  attempt, so it never decays out of context — alongside what it cannot prove.
+
 ## v0.4.1 — a page of its own
 
 - `homepage` in both manifests points at <https://orwamahmoud.com/nightshift/>, which explains what

--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ Zero-config by default; every knob below is off until you set it (unset ⇒ the 
 
 | Env var | Effect |
 |---|---|
-| `NIGHTSHIFT_FORBIDDEN_COMMANDS` | deny any Bash command matching this `grep -E` pattern during a shift — your own site rules. `git push` keeps pushing yours for the night; `rm -rf\|docker\|terraform` fences the rest. Env vars are fixed at session start, so only you can set or lift a rule — never the agent mid-run |
+| `NIGHTSHIFT_FORBIDDEN_COMMANDS` | deny any Bash command matching this `grep -E` pattern during a shift — your own site rules. `git .*push` keeps pushing yours for the night (the `.*` also catches `git -c k=v push`); `rm -rf\|docker\|terraform` fences the rest. Env vars are fixed at session start, so only you can set or lift a rule — never the agent mid-run |
 | `NIGHTSHIFT_EXPECTED_EMAIL` | during a shift, deny commits authored under any other identity |
 | `NIGHTSHIFT_PROTECTED_DIRS` | during a shift, space/pipe-separated dir names never to `git add/commit/tag/remote` |
 | `NIGHTSHIFT_NEVER_COMMIT_PATTERNS` | during a shift, deny a commit whose diff matches this `grep -E` pattern — the index, widened to the working tree when the command stages implicitly (`git commit -a`) |
@@ -271,9 +271,10 @@ Read this before you trust it overnight:
   arms anything. `/nightshift:start` is the boundary: from there the gate will not let the agent
   stop and the ask-tool is denied, which is what you want at 3am and pure friction at 3pm. Arm it
   when you're leaving.
-- **Ticks are self-certified.** The gate checks *boxes*, not *work* — it guarantees the agent
-  can't quietly stop with work outstanding, not that a ticked box is truly done. The contract and
-  your item gate raise that bar; they don't eliminate the gap.
+- **Ticks are self-certified.** The gate re-injects the full working standard — no stubs, gate
+  green, never fake a tick — at every stop attempt, so it never decays out of context; what it
+  proves is that the agent couldn't quietly stop with work outstanding, not that the work behind
+  a tick is good. The contract and your item gate raise that bar; they don't eliminate the gap.
 - **Completion beats cost by default.** A stuck run is held and red-flagged, not ended — so a
   finite list with no deadline can keep retrying until you look in. Bound it when cost matters
   more: `NIGHTSHIFT_STALL_MAX=N` clocks out a stuck run, an open-ended walkthrough *requires*

--- a/hooks/hardhat.sh
+++ b/hooks/hardhat.sh
@@ -9,7 +9,7 @@
 #   NIGHTSHIFT_EXPECTED_EMAIL        commits must be authored by this identity
 #   NIGHTSHIFT_NEVER_COMMIT_PATTERNS staged diff (git diff --cached) must not match this grep -E pattern
 #   NIGHTSHIFT_FORBIDDEN_COMMANDS    deny any command matching this grep -E pattern during a shift
-#                                    (the no-push recipe: set it to 'git push')
+#                                    (the no-push recipe: set it to 'git .*push')
 #
 # The two commit guards read git, so they resolve the repository the commit lands in (see
 # repo_root in lib.sh) rather than assuming it is the project dir. When that repository cannot
@@ -115,6 +115,21 @@ fi
 # which the recommended layout puts one level below the project dir. Resolve it once, and fail
 # closed: a guard that cannot see the repo denies rather than waving the commit through.
 if is_commit && { [ -n "$EXPECTED_EMAIL" ] || [ -n "$NEVER_COMMIT_PATTERNS" ]; }; then
+  # `--git-dir`/`--work-tree` relocate the commit somewhere the resolution below does not follow,
+  # so the guards would inspect one repository while the commit lands in another. Unverifiable —
+  # deny, exactly like the ambiguous-repo case: a guard that cannot look never approves.
+  if printf '%s' "$SCRUBBED" | grep -qE -- '--git-dir|--work-tree'; then
+    deny "BLOCKED: --git-dir/--work-tree point this commit somewhere the configured commit guards cannot verify. Run the commit from inside the repository instead."
+  fi
+
+  # The identity guard reads the repository's configuration, and a command can override identity
+  # past that read — `-c user.email=`, `--author`, or a GIT_*_EMAIL prefix. With an override
+  # present the config describes nothing, so it is denied rather than misread.
+  if [ -n "$EXPECTED_EMAIL" ] && printf '%s' "$SCRUBBED" |
+    grep -qE -- '-c[[:space:]]*user\.email=|--author|GIT_(AUTHOR|COMMITTER)_EMAIL='; then
+    deny "BLOCKED: this commit overrides the author identity on the command line, which the expected-identity guard cannot verify. Commit with the repository's configured identity."
+  fi
+
   # A command can name its own repository — `git -C <dir> commit`, `cd <dir> && git commit` —
   # and that is where the commit lands, whatever the session's working directory says.
   REPO="$(target_repo "$CMD" "${CWD:-$PROJECT_DIR}")"

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -243,3 +243,73 @@ load helpers
   run hardhat_bash "$w" "git push" NIGHTSHIFT_FORBIDDEN_COMMANDS='git push'
   is_deny "$output"
 }
+
+# The commit guards resolve `git -C` and `cd X &&`, but --git-dir/--work-tree relocate a commit
+# past that resolution — the guard would inspect one repository while the commit lands in
+# another. Unverifiable must mean denied, not misread.
+@test "a --git-dir commit is denied when a commit guard is configured" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git --git-dir=/somewhere/else/.git commit -m x" \
+    NIGHTSHIFT_EXPECTED_EMAIL=dev@example.com
+  is_deny "$output"
+}
+
+@test "a --work-tree commit is denied when a commit guard is configured" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git --work-tree=/somewhere/else commit -am x" \
+    NIGHTSHIFT_NEVER_COMMIT_PATTERNS='SECRET'
+  is_deny "$output"
+}
+
+@test "--git-dir passes when no commit guard is configured" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git --git-dir=/somewhere/else/.git commit -m x"
+  is_allow
+}
+
+@test "a commit message mentioning --git-dir is not a match" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git commit -m 'document the --git-dir flag'" \
+    NIGHTSHIFT_EXPECTED_EMAIL=dev@example.com
+  is_allow
+}
+
+# The identity guard reads the repo's config, and a command line can override identity past that
+# read. Every visible override form is denied when an expected identity is configured.
+@test "an inline -c user.email override is denied when an identity is expected" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git -c user.email=evil@example.com commit -m x" \
+    NIGHTSHIFT_EXPECTED_EMAIL=dev@example.com
+  is_deny "$output"
+}
+
+@test "an --author override is denied when an identity is expected" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git commit --author='Evil <evil@example.com>' -m x" \
+    NIGHTSHIFT_EXPECTED_EMAIL=dev@example.com
+  is_deny "$output"
+}
+
+@test "a GIT_AUTHOR_EMAIL prefix is denied when an identity is expected" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "GIT_AUTHOR_EMAIL=evil@example.com git commit -m x" \
+    NIGHTSHIFT_EXPECTED_EMAIL=dev@example.com
+  is_deny "$output"
+}
+
+# The README's no-push recipe is `git .*push` so that config injection cannot slip between the
+# words. This pins the recipe itself.
+@test "the no-push recipe catches git -c k=v push" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git -c http.proxy=x push origin main" \
+    NIGHTSHIFT_FORBIDDEN_COMMANDS='git .*push'
+  is_deny "$output"
+}


### PR DESCRIPTION
Found in a full source review, closed before any user hit it. One family of fail-open paths in the commit guards, plus one docs correction.

**Guards** (`hooks/hardhat.sh`):

- `--git-dir` / `--work-tree` point a commit past the repo resolution (`git -C`, `cd X &&`), so the guards inspected one repository while the commit landed in another. Both are now denied whenever a commit guard is configured — unverifiable means denied, exactly like the existing ambiguous-repo case.
- With an expected identity configured, identity overridden on the command line — `-c user.email=`, `--author`, or a `GIT_AUTHOR_EMAIL`/`GIT_COMMITTER_EMAIL` prefix — is denied: the config read the guard depends on describes nothing when an override is present.
- The no-push recipe becomes `git .*push`, so config injection (`git -c k=v push`) cannot slip between the words.

**Docs:** the fine print now states what the gate re-injects — the full working standard, at every stop attempt, so it never decays out of context — alongside what it cannot prove.

Eight new tests (106 total), including the false-positive pin: a commit *message* mentioning `--git-dir` is not a use of it.

Local: 106/106 bats, shellcheck clean, `claude plugin validate . --strict` passes, `release-notes.sh 0.4.2` extracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)