### PR TITLE
The shift knows its own session (v0.5.1)

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.5.1 — the shift knows its own session
+
+Live dogfooding with two tabs in one project exposed the guess in v0.5.0: the watchman read "the
+newest transcript" for the Esc tell and revived with `--continue`, and with a second session in
+the project both could point at the wrong conversation.
+
+- **The shift records its own identity.** Every hook receives the session id and transcript path;
+  the first session to work under an active shift writes them to `.nightshift/.shift-session`,
+  once. A second tab never overwrites the record.
+- **The Esc tell reads the shift's own transcript** — a helper tab's interrupt proves nothing and
+  is ignored. No record yet falls back to the newest transcript in the project.
+- **The revival is `claude --resume <that id> -p`** — the shift's exact conversation, with
+  everything it knew before the crash: hours of context, decisions, where it stood mid-item. A
+  vanished session degrades to `--continue`, and the last retry of a wake still falls back to a
+  fresh session.
+- **The clean-exit marker is the shift's alone** — `SessionEnd` writes it only when the ending
+  session matches the record, so closing an unrelated tab in the same project no longer stands
+  the watchman down.
+- `start` and the hunt cut clear the record with the other markers; setup gitignores it in the
+  receipts repo.
+
 ## v0.5.0 — the night watchman
 
 A Stop hook can only act inside a living session. A session killed by an API outage, a crash, or

--- a/adapters/watchman.sh
+++ b/adapters/watchman.sh
@@ -12,12 +12,13 @@
 #
 #   --interval  minutes between wakes (default $NIGHTSHIFT_WATCH, else 20; 0 exits immediately —
 #               the "disabled" spelling)
-#   --agent     the resume command (default "claude --continue -p": the revival chains onto the
-#               SAME conversation, so the morning transcript is one unbroken thread — in the
-#               terminal and the IDE extension alike). Invoked from the project dir as
-#               <agent> "<resume prompt>". On the default agent only, the last retry of a wake
-#               falls back to a fresh "claude -p": if the transcript itself is what broke,
-#               --continue would fail every wake forever, and the punch list on disk is enough
+#   --agent     the resume command. Default: the SHIFT'S OWN conversation, by id — the hooks
+#               record the first working session into .nightshift/.shift-session, and the
+#               revival is "claude --resume <that id> -p", one unbroken thread in the terminal
+#               and the IDE extension alike. No record (or a vanished session) degrades to
+#               "claude --continue -p". On the default agent only, the last retry of a wake
+#               falls back to a fresh "claude -p": if the conversation itself is what broke,
+#               resuming it would fail every wake forever, and the punch list on disk is enough
 #               for a fresh session to carry on.
 #   --max-wakes bound the number of wakes (0 = unbounded; tests use this)
 #
@@ -35,11 +36,13 @@
 #
 # Esc still means stop. Claude Code records a user interrupt in the session transcript
 # ("Request interrupted by user"), and a 500 or a crash never writes one — that is the tell. At a
-# quiet wake the watchman reads the tail of the newest transcript: interrupt there -> the owner
-# paused it, stand by and keep watching; no interrupt (or no transcript at all) -> it died or
-# errored with nobody there, revive it. Unreadable defaults to reviving: waking a paused session
-# costs an apology, a lost night costs the night. $NIGHTSHIFT_WATCH_TRANSCRIPTS overrides the
-# transcript directory (tests use it).
+# quiet wake the watchman reads the tail of THE SHIFT'S OWN transcript (recorded in
+# .shift-session by the hooks): interrupt there -> the owner paused it, stand by and keep
+# watching; no interrupt -> it died or errored with nobody there, revive it. A second tab's Esc
+# proves nothing and is ignored. With no record yet, the newest transcript in the project is the
+# fallback tell. Unreadable defaults to reviving: waking a paused session costs an apology, a
+# lost night costs the night. $NIGHTSHIFT_WATCH_TRANSCRIPTS overrides the transcript directory
+# (tests use it).
 #
 # API outages: per wake, up to 3 spawn attempts spaced by $NIGHTSHIFT_WATCH_RETRY (default
 # "30 120" seconds). Wakes that fail entirely back the interval off — double per consecutive
@@ -112,6 +115,23 @@ deadline_passed() {
   [ "$(date +%s)" -ge "$dl" ]
 }
 
+# The hooks write the shift's identity (session id, transcript path) at first work. Read fresh
+# each use — the record appears after the watchman was armed.
+shift_session_id() { sed -n 1p "$NS/.shift-session" 2>/dev/null; }
+shift_transcript() { sed -n 2p "$NS/.shift-session" 2>/dev/null; }
+
+# The default agent resumes the shift's own conversation by id; no record degrades to --continue.
+# An owner-supplied agent is used verbatim.
+resolve_agent() {
+  local sid
+  if [ "$AGENT_IS_DEFAULT" -eq 1 ]; then
+    sid="$(shift_session_id)"
+    if [ -n "$sid" ]; then printf 'claude --resume %s -p' "$sid"; else printf 'claude --continue -p'; fi
+  else
+    printf '%s' "$AGENT"
+  fi
+}
+
 PROMPT="Resume the nightshift. Read .nightshift/punch-list.md and work its open items per the contract, one at a time; run the item gate before each commit; tick what you finish. Leave pushing to the owner unless the punch list says otherwise. Park owner decisions in parking-lot.md. Stop only when every box is ticked or a stop-work order exists."
 
 # One spawn attempt; the resumed session may legitimately run for hours. shellcheck disable:
@@ -127,10 +147,14 @@ spawn() { # $1 optionally overrides the agent for this one attempt
 # session that already moved on.
 owner_paused() {
   local f latest=""
-  for f in "$TRANSCRIPTS"/*.jsonl; do
-    [ -f "$f" ] || continue
-    if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then latest="$f"; fi
-  done
+  latest="$(shift_transcript)"
+  if [ -z "$latest" ] || [ ! -f "$latest" ]; then
+    latest=""
+    for f in "$TRANSCRIPTS"/*.jsonl; do
+      [ -f "$f" ] || continue
+      if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then latest="$f"; fi
+    done
+  fi
   [ -n "$latest" ] || return 1
   tail -n 25 "$latest" 2>/dev/null | grep -q "Request interrupted by user"
 }
@@ -158,12 +182,12 @@ while :; do
   if [ -f "$NS/.ended" ] || [ ! -f "$PUNCH" ]; then exit 0; fi
   if [ "$(open_boxes)" -eq 0 ]; then
     log_line "watchman: every box ticked but the shift never clocked out — spawning the clock-out"
-    spawn || true
+    spawn "$(resolve_agent)" || true
     exit 0
   fi
   if deadline_passed; then
     log_line "watchman: quitting time passed with the site dead — spawning the clock-out"
-    spawn || true
+    spawn "$(resolve_agent)" || true
     exit 0
   fi
   if [ -f "$NS/.session-end" ]; then
@@ -197,7 +221,7 @@ while :; do
         break
       fi
       log_line "watchman: site quiet ${INTERVAL_MIN}m+ with open boxes — resume attempt $attempt"
-      if spawn; then revived=0; break; fi
+      if spawn "$(resolve_agent)"; then revived=0; break; fi
       [ -n "$spacing" ] || break
       sleep "$spacing"
     done

--- a/hooks/clock-out-gate.sh
+++ b/hooks/clock-out-gate.sh
@@ -27,6 +27,16 @@ set -u
 # shellcheck source=hooks/lib.sh
 . "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
 
+# The Stop payload carries the session's identity; a tty guard keeps manual runs from hanging.
+if [ -t 0 ]; then INPUT=""; else INPUT="$(cat)"; fi
+if command -v jq >/dev/null 2>&1; then
+  SID="$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+  TPATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)"
+else
+  SID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  TPATH="$(printf '%s' "$INPUT" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+fi
+
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
@@ -120,6 +130,12 @@ end_shift() {
 
 if [ -f "$PUNCH" ]; then OPEN="$(open_boxes)"; TICKED="$(ticked_boxes)"; else OPEN=0; TICKED=0; fi
 TOTAL=$((OPEN + TICKED))
+
+# Record the shift's own session, once — same contract as hardhat's record.
+if [ -f "$PUNCH" ] && [ "$OPEN" -gt 0 ] && [ ! -f "$ENDED" ] \
+  && [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
+  printf '%s\n%s\n' "$SID" "${TPATH:-}" >"$NS/.shift-session"
+fi
 
 # 1. Stop-work order — honor at once; open boxes are left open on purpose (an honest snapshot).
 if [ -f "$STOP" ]; then

--- a/hooks/hardhat.sh
+++ b/hooks/hardhat.sh
@@ -44,6 +44,8 @@ if command -v jq >/dev/null 2>&1; then
   TOOL="$(printf '%s' "$INPUT" | jq -r '.tool_name // empty' 2>/dev/null || true)"
   CMD="$(printf '%s' "$INPUT" | jq -r '.tool_input.command // empty' 2>/dev/null || true)"
   CWD="$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null || true)"
+  SID="$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+  TPATH="$(printf '%s' "$INPUT" | jq -r '.transcript_path // empty' 2>/dev/null || true)"
 else
   # No jq: pull the fields out of the raw JSON with sed so the guard still works. Extract the
   # command value rather than falling back to the whole payload — the quote-scrub below would
@@ -51,6 +53,8 @@ else
   TOOL="$(printf '%s' "$INPUT" | sed -n 's/.*"tool_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
   CMD="$(printf '%s' "$INPUT" | sed -n 's/.*"command"[[:space:]]*:[[:space:]]*"\(.*\)".*/\1/p')"
   CWD="$(printf '%s' "$INPUT" | sed -n 's/.*"cwd"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  SID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  TPATH="$(printf '%s' "$INPUT" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 fi
 [ -n "$CMD" ] || CMD="$INPUT"
 
@@ -77,6 +81,14 @@ SCRUBBED="$(printf '%s' "$CMD" | sed -E "s/(-m|--message)([[:space:]]*|=)'[^']*'
 if [ ! -f "$PUNCH" ] || [ -f "$ENDED" ] \
    || ! grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]' "$PUNCH" 2>/dev/null; then
   exit 0
+fi
+
+# The shift records its own identity: the first session to work under an active shift writes its
+# session id and transcript path, once. The watchman reads THIS session's transcript for the Esc
+# tell and revives THIS conversation by id — never a guess at "the newest". Any later session in
+# the same project (a second tab, a helper) never overwrites the record.
+if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
+  printf '%s\n%s\n' "$SID" "${TPATH:-}" >"$NS/.shift-session"
 fi
 
 # An unparseable owner pattern makes grep exit 2, which a plain `if` reads as "no match" — the

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -22,6 +22,18 @@ if [ ! -f "$PUNCH" ] || [ -f "$NS/.ended" ] \
 fi
 
 # jq preferred, sed fallback — same policy as hardhat: a missing jq never disables the hook.
+# Only the shift's own session ending is the owner's hand on the door — a helper tab closing in
+# the same project proves nothing about the shift.
+if command -v jq >/dev/null 2>&1; then
+  SID="$(printf '%s' "$INPUT" | jq -r '.session_id // empty' 2>/dev/null || true)"
+else
+  SID="$(printf '%s' "$INPUT" | sed -n 's/.*"session_id"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+fi
+if [ -f "$NS/.shift-session" ]; then
+  REC="$(sed -n 1p "$NS/.shift-session" 2>/dev/null)"
+  [ -n "$REC" ] && [ "$SID" != "$REC" ] && exit 0
+fi
+
 if command -v jq >/dev/null 2>&1; then
   REASON="$(printf '%s' "$INPUT" | jq -r '.reason // "unknown"' 2>/dev/null || printf 'unknown')"
 else

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -39,7 +39,8 @@ One question. On **yes**:
 
 - **clear every stale run-control marker first** — remove them all if present:
   `.nightshift/STOP`, `.nightshift/.stall`, `.nightshift/.notified`, `.nightshift/.ended`,
-  `.nightshift/deadline`, `.nightshift/.session-end`, and `.nightshift/.watchman-tick`; if
+  `.nightshift/deadline`, `.nightshift/.session-end`, `.nightshift/.shift-session`, and
+  `.nightshift/.watchman-tick`; if
   `.nightshift/.watchman` holds a live pid, kill it first. The two commonest endings, the whistle and a stall auto-end, both leave
   STOP and a spent deadline behind; cutting on top of them makes the whole hunt a no-op,
 - **cut** the item — move it from `work-orders.md` under `## Items` in

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -28,7 +28,8 @@ they do not exist.
 - Give `.nightshift/` its own local-only receipts repo so state stays versioned without touching the
   project history: if `.nightshift/.git` does not exist, `git init` inside `.nightshift/`, add a
   `.nightshift/.gitignore` that ignores the transient markers `STOP`, `.stall`, `.notified`,
-  `deadline`, `.session-end`, `.watchman`, and `.watchman-tick`, and make one initial commit. **Never add a remote to it, never push it.**
+  `deadline`, `.session-end`, `.shift-session`, `.watchman`, and `.watchman-tick`, and make one
+  initial commit. **Never add a remote to it, never push it.**
 
 ## 3. Gates — ask, never impose
 

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -10,7 +10,8 @@ Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 - **Clear every stale run-control marker first**, before anything writes a new one — last night's
   leftovers would otherwise end tonight's shift at its first stop attempt. Remove them all if
   present: `.nightshift/STOP`, `.nightshift/.stall`, `.nightshift/.notified`, `.nightshift/.ended`,
-  `.nightshift/deadline`, `.nightshift/.session-end`, and `.nightshift/.watchman-tick`. If
+  `.nightshift/deadline`, `.nightshift/.session-end`, `.nightshift/.shift-session`, and
+  `.nightshift/.watchman-tick`. If
   `.nightshift/.watchman` holds a live pid, kill it — last night's watchman must not double-arm
   tonight's. A shift that reached the whistle leaves the deadline behind; keeping it means the
   gate clocks the next one out immediately, zero items done.

--- a/tests/clock-out-gate.bats
+++ b/tests/clock-out-gate.bats
@@ -255,3 +255,11 @@ load helpers
   is_release
   grep -q 'stopped by owner' "$wl"
 }
+
+@test "the gate records the shift session while blocking" {
+  p="$(new_project)"
+  punch_open "$p"
+  run gate "$p"
+  is_block "$output"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "test-shift-session" ]
+}

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -313,3 +313,25 @@ load helpers
     NIGHTSHIFT_FORBIDDEN_COMMANDS='git .*push'
   is_deny "$output"
 }
+
+# The shift records its own identity: the first session to work under an active shift writes
+# .shift-session, and a second tab never overwrites it — the watchman must know WHICH
+# conversation to read and revive, not guess at the newest.
+@test "the first working session records itself and is never overwritten" {
+  p="$(new_project)"
+  punch_open "$p"
+  jq -nc '{tool_name:"Bash",session_id:"first-tab",transcript_path:"/tmp/a.jsonl",tool_input:{command:"echo hi"}}' |
+    CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "first-tab" ]
+  jq -nc '{tool_name:"Bash",session_id:"second-tab",transcript_path:"/tmp/b.jsonl",tool_input:{command:"echo hi"}}' |
+    CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "first-tab" ]
+}
+
+@test "no active shift means no session record" {
+  p="$(new_project)"
+  punch_done "$p"
+  jq -nc '{tool_name:"Bash",session_id:"s1",transcript_path:"",tool_input:{command:"echo hi"}}' |
+    CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ ! -f "$p/.nightshift/.shift-session" ]
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -43,11 +43,12 @@ receipts_init() {
 punch_open() { printf '## Items\n- [ ] **1. first.**\n- [x] **2. done.**\n' >"$1/.nightshift/punch-list.md"; }
 punch_done() { printf '## Items\n- [x] **1. first.**\n- [x] **2. done.**\n' >"$1/.nightshift/punch-list.md"; }
 
-# gate <project> [ENV=VAL ...]
+# gate <project> [ENV=VAL ...] — pipes a minimal Stop payload; the gate reads stdin now.
 gate() {
   local p="$1"
   shift
-  env "$@" CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/clock-out-gate.sh"
+  jq -nc '{hook_event_name:"Stop",session_id:"test-shift-session",transcript_path:""}' |
+    env "$@" CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/clock-out-gate.sh"
 }
 
 # hardhat_bash <project> <command> [ENV=VAL ...]

--- a/tests/hooks-json.bats
+++ b/tests/hooks-json.bats
@@ -23,7 +23,7 @@ load helpers
   cp "$BATS_TEST_DIRNAME"/../hooks/*.sh "$dir/hooks/"
   p="$(new_project)"
   cmd="$(jq -r '.hooks.Stop[0].hooks[0].command' "$BATS_TEST_DIRNAME/../hooks/hooks.json")"
-  CLAUDE_PLUGIN_ROOT="$dir" CLAUDE_PROJECT_DIR="$p" run sh -c "$cmd"
+  CLAUDE_PLUGIN_ROOT="$dir" CLAUDE_PROJECT_DIR="$p" run sh -c "printf '{}' | $cmd"
   [ "$status" -eq 0 ]
 }
 
@@ -62,6 +62,6 @@ load helpers
   is_deny "$out"
 
   cmd="$(jq -r '.hooks.Stop[0].hooks[0].command' "$root/hooks/hooks.json")"
-  out="$(CLAUDE_PLUGIN_ROOT="$root" CLAUDE_PROJECT_DIR="$p" sh -c "$cmd")"
+  out="$(printf '{}' | CLAUDE_PLUGIN_ROOT="$root" CLAUDE_PROJECT_DIR="$p" sh -c "$cmd")"
   is_block "$out"
 }

--- a/tests/walkthroughs.bats
+++ b/tests/walkthroughs.bats
@@ -22,7 +22,7 @@ HUNT="$BATS_TEST_DIRNAME/../skills/hunt/SKILL.md"
 # last night silently ended the next shift at its first stop attempt.
 @test "every path that starts a shift clears every stale marker" {
   for f in start hunt; do
-    for m in STOP .stall .notified .ended deadline .session-end .watchman-tick .watchman; do
+    for m in STOP .stall .notified .ended deadline .session-end .shift-session .watchman-tick .watchman; do
       grep -qF "$m" "$BATS_TEST_DIRNAME/../skills/$f/SKILL.md" \
         || { echo "skills/$f/SKILL.md does not clear $m"; return 1; }
     done

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -185,3 +185,63 @@ STUB
   ! grep -qE '^- \[ \]' "$P/.nightshift/punch-list.md"
   [ "$(calls)" -eq 2 ]
 }
+
+# The Esc tell reads the SHIFT'S recorded transcript — a second tab's interrupt proves nothing.
+@test "the shift's own transcript decides Esc, not the newest in the project" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"[Request interrupted by user]"}\n' >"$T/shift.jsonl"
+  sleep 0.01
+  printf '{"type":"message","content":"other tab, still working"}\n' >"$T/other.jsonl" # newer, clean
+  printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 3
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'standing by' "$P/.nightshift/shift-log.md"
+}
+
+@test "another tab's Esc does not block the revival of a dead shift session" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
+  sleep 0.01
+  printf '{"type":"message","content":"[Request interrupted by user]"}\n' >"$T/other.jsonl" # newer!
+  printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 5
+  [ "$status" -eq 0 ]
+  ! grep -qE '^- \[ \]' "$P/.nightshift/punch-list.md"
+}
+
+# The default revival is the shift's exact conversation, by id — with the layered fallback.
+@test "the default agent resumes the recorded session by id" {
+  printf 'abc-123\n\n' >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *--resume*) echo "resume:$1 $2" >>.nightshift/agent-calls; exit 1 ;;
+  *--continue*) echo "continue" >>.nightshift/agent-calls; exit 1 ;;
+  *) echo fresh >>.nightshift/agent-calls
+     awk 'BEGIN{d=0} !d && /^- \[ \]/{sub(/\[ \]/,"[x]");d=1} {print}' .nightshift/punch-list.md >.nightshift/pl.tmp
+     mv .nightshift/pl.tmp .nightshift/punch-list.md ;;
+esac
+STUB
+  chmod +x "$BIN/claude"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --max-wakes 4
+  [ "$status" -eq 0 ]
+  grep -q 'resume:--resume abc-123' "$P/.nightshift/agent-calls"
+  [ "$(grep -c fresh "$P/.nightshift/agent-calls")" -eq 1 ]
+}
+
+@test "session-end writes the marker only for the shift's own session" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'right-id\n\n' >"$p/.nightshift/.shift-session"
+  printf '{"reason":"exit","session_id":"wrong-id"}' | CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
+  [ ! -f "$p/.nightshift/.session-end" ]
+  printf '{"reason":"exit","session_id":"right-id"}' | CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
+  grep -q 'clean session end (exit)' "$p/.nightshift/.session-end"
+}


### PR DESCRIPTION
Live dogfooding with two tabs in one project exposed the guess in v0.5.0: the watchman read "the newest transcript" for the Esc tell and revived with `--continue` — and with a second session in the project, both could point at the wrong conversation.

**Now the shift records its own identity.** Every hook receives the session id and transcript path in its payload; the first session to work under an active shift writes them to `.nightshift/.shift-session`, once — a second tab never overwrites the record. From there:

- **The Esc tell reads the shift's own transcript.** A helper tab's interrupt proves nothing and is ignored; a dead shift session is revived even if some other tab was Esc'd. No record yet falls back to the newest-transcript heuristic.
- **The revival is `claude --resume <that id> -p`** — the shift's exact conversation, with everything it knew before the crash: hours of context, decisions, where it stood mid-item. A vanished session degrades to `--continue`; the last retry of a wake still falls back to a fresh session, which needs only the punch list.
- **The clean-exit marker is the shift's alone** — `SessionEnd` writes it only when the ending session matches the record, so closing an unrelated tab in the same project no longer stands the watchman down.

`start` and the hunt cut clear the record with the other stale markers; setup gitignores it in the receipts repo. The gate now reads its stdin payload (tty-guarded for manual runs).

Seven new tests (129 total): first-writer-wins recording in hardhat and the gate, no record without an active shift, recorded-transcript-beats-newest in both directions, resume-by-id with the layered fallback, and the SessionEnd id filter.

Local: 129/129 bats, shellcheck clean, `claude plugin validate . --strict` passes, `release-notes.sh 0.5.1` extracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)