### PR TITLE
v0.5.2 — strong evidence of death

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,36 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.5.2 — strong evidence of death
+
+The one truly harmful watchman failure is spawning a second agent beside a living one: a resumed
+id APPENDS to the same session, so two writers interleave into one conversation while sharing a
+working tree. v0.5.0 read liveness from project files alone — long reasoning, research, or a
+25-minute test run writes none and looked dead. Revival now requires strong positive evidence of
+death, never "looks stuck".
+
+- **Liveness is a ladder.** The shift's transcript is the primary pulse — a live session streams
+  every turn into it, project files or not. Project activity stays as the second rung. Then the
+  process witness: the hooks record the claude ancestor's pid and start time alongside the
+  session id, and the watchman checks that exact process — `kill -0` plus the start time, a pair
+  no pid reuse can counterfeit. Alive with a quiet, unerrored transcript is long silent work:
+  stand by. Dead is dead even while other tabs live in the project: revive. No pid recorded
+  degrades to the conservative reading — any claude process working in the project stands the
+  watchman by.
+- **The 500 wedge is recognized, not guessed.** Claude Code writes API failures verbatim into
+  the transcript ("API Error: 500 …", "529 Overloaded"). A live shift process whose quiet
+  transcript ends in one is a session sitting at an errored prompt with nobody there to press
+  retry — the night the watchman exists for. That combination revives; prose merely mentioning
+  API errors does not match.
+- **Every retry re-checks the whole ladder first.** A site that comes back to life mid-wake — or
+  an owner who acts — cancels the remaining attempts. Each failed attempt re-baselines the
+  sentinel, so the watchman's own error events in the transcript never read as site life.
+- **The revival chain is real and logged per rung**: the recorded conversation first, `claude
+  --continue` next, a fresh `claude -p` last — the morning log says exactly which recovery level
+  carried the night.
+- **The identity claim is atomic.** `.shift-session` is taken with an exclusive create — two
+  racing first sessions cannot interleave; one record lands whole.
+
 ## v0.5.1 — the shift knows its own session
 
 Live dogfooding with two tabs in one project exposed the guess in v0.5.0: the watchman read "the
@@ -15,9 +45,9 @@ the project both could point at the wrong conversation.
 - **The Esc tell reads the shift's own transcript** — a helper tab's interrupt proves nothing and
   is ignored. No record yet falls back to the newest transcript in the project.
 - **The revival is `claude --resume <that id> -p`** — the shift's exact conversation, with
-  everything it knew before the crash: hours of context, decisions, where it stood mid-item. A
-  vanished session degrades to `--continue`, and the last retry of a wake still falls back to a
-  fresh session.
+  everything it knew before the crash: hours of context, decisions, where it stood mid-item. No
+  record yet means `--continue`, and the last retry of a wake still falls back to a fresh
+  session.
 - **The clean-exit marker is the shift's alone** — `SessionEnd` writes it only when the ending
   session matches the record, so closing an unrelated tab in the same project no longer stands
   the watchman down.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ death, never "looks stuck".
   carried the night.
 - **The identity claim is atomic.** `.shift-session` is taken with an exclusive create — two
   racing first sessions cannot interleave; one record lands whole.
+- **A revival's own exit is not the owner's hand on the door.** Spawned sessions carry a mark,
+  and the `SessionEnd` hook stays inert for them — without it, the worker finishing (or dying on
+  the API again) would write the clean-end marker under the recorded id and stand the watchman
+  down mid-outage after the first revival.
 
 ## v0.5.1 — the shift knows its own session
 

--- a/README.md
+++ b/README.md
@@ -65,14 +65,19 @@ at a serious product — not a half-done prototype full of shortcuts.
 - **A dead session is revived, not mourned.** No hook can fire in a session that no longer
   exists — that's the 500 night. You're supposed to be asleep; instead you're refreshing
   status.claude.com so you can relaunch the moment it recovers. Don't — the **night watchman**
-  works that shift: it wakes every 20 minutes, and when boxes are open but the site has gone dead
-  quiet, it sends the conversation itself back to work — `claude --continue` — so the morning
-  transcript is one unbroken thread: the 500, the revival, and everything after, in the terminal
-  or your IDE's extension alike. (The punch list on disk is the safety net: even a fresh session
-  carries on from it, which is also the built-in fallback if the transcript itself broke.) It
-  stands down at every honest ending — done, stop-work order, quitting time, a clean exit —
-  gives an outage 2–3 tries then backs off instead of hammering, and **Esc still means stop**:
-  your interrupt is in the transcript, and the watchman reads it before touching anything.
+  works that shift: it wakes every 20 minutes, and when the site is quiet it resumes **the
+  shift's own conversation by id** — hours of context, decisions, where it stood mid-item — so
+  the morning transcript is one unbroken thread: the 500, the revival, and everything after, in
+  the terminal or your IDE's extension alike. (The chain degrades honestly: the recorded
+  conversation first, `claude --continue` next, a fresh session last — the punch list on disk is
+  enough for any of them.) Reviving needs strong positive evidence of death, never "looks
+  stuck": the shift records its own session id, transcript, and process at first work, and the
+  watchman checks all three — a transcript still streaming, a live shift process on silent work,
+  or any claude session in the project stands it by; a dead process, or one alive at an errored
+  prompt with an `API Error` in the transcript tail, is what gets revived. It stands down at
+  every honest ending — done, stop-work order, quitting time, a clean exit — gives an outage
+  2–3 tries then backs off instead of hammering, and **Esc still means stop**: your interrupt is
+  in the transcript, and the watchman reads it before touching anything.
 - **You're never trapped.** Escape and Ctrl+C still work — it's your keyboard, the plugin can't
   override it. But a pause isn't an ending: the next session resumes the shift, and a headless
   run or the foreman loop has no Escape at all. `touch .nightshift/STOP` from any terminal is the
@@ -199,7 +204,7 @@ Everything is named from a real construction site — learn one term, guess the 
 | **stop-work order** | `.nightshift/STOP` | `/nightshift:stop` — or `touch .nightshift/STOP` from any terminal — ends the shift at the agent's next stop attempt; the site rules stay armed until it actually stops |
 | **morning whistle** | `NIGHTSHIFT_NOTIFY_CMD` | optional shift-end ping (ntfy / Pushover / `say`) |
 | **foreman** | `adapters/foreman.sh` | outer loop for ANY agent CLI — keeps sending the worker back in until the list is clear |
-| **night watchman** | `adapters/watchman.sh` | revives a session that DIED mid-shift (crash, API outage) from the punch list; stands down at every honest ending |
+| **night watchman** | `adapters/watchman.sh` | revives a session that DIED mid-shift (crash, API outage) by resuming its own conversation; stands down at every honest ending |
 
 ## Owner knobs
 
@@ -211,7 +216,7 @@ Zero-config by default; every knob below is off until you set it (unset ⇒ the 
 | `NIGHTSHIFT_EXPECTED_EMAIL` | during a shift, deny commits authored under any other identity |
 | `NIGHTSHIFT_PROTECTED_DIRS` | during a shift, space/pipe-separated dir names never to `git add/commit/tag/remote` |
 | `NIGHTSHIFT_NEVER_COMMIT_PATTERNS` | during a shift, deny a commit whose diff matches this `grep -E` pattern — the index, widened to the working tree when the command stages implicitly (`git commit -a`) |
-| `NIGHTSHIFT_WATCH` | minutes between night-watchman wakes; `0` disarms it (unset ⇒ 20). The revival runs `claude --continue -p` — the **same conversation**, so the morning transcript is one unbroken thread in the terminal and the IDE extension alike, with a fresh-session fallback on the last retry in case the transcript itself is what broke. `NIGHTSHIFT_WATCH_AGENT="claude -p"` makes every revival a fresh session instead |
+| `NIGHTSHIFT_WATCH` | minutes between night-watchman wakes; `0` disarms it (unset ⇒ 20). The revival resumes **the shift's own conversation by id** (`claude --resume <recorded session> -p`) — one unbroken thread in the terminal and the IDE extension alike — degrading per attempt to `claude --continue -p` and last to a fresh `claude -p` in case the conversation itself is what broke. `NIGHTSHIFT_WATCH_AGENT="claude -p"` makes every revival a fresh session instead |
 | `NIGHTSHIFT_STALL_MAX` | by default a stuck agent is held and red-flagged in the shift log, never clocked out; set `=N` to clock the shift out after N stuck attempts. The foreman honors the same knob for its loop (`--stall N` is the CLI form) |
 | `NIGHTSHIFT_NOTIFY_CMD` | shift-end ping; runs with `$NIGHTSHIFT_SUMMARY` set (e.g. `say "$NIGHTSHIFT_SUMMARY"`) |
 

--- a/adapters/watchman.sh
+++ b/adapters/watchman.sh
@@ -15,11 +15,11 @@
 #   --agent     the resume command. Default: the SHIFT'S OWN conversation, by id — the hooks
 #               record the first working session into .nightshift/.shift-session, and the
 #               revival is "claude --resume <that id> -p", one unbroken thread in the terminal
-#               and the IDE extension alike. No record (or a vanished session) degrades to
-#               "claude --continue -p". On the default agent only, the last retry of a wake
-#               falls back to a fresh "claude -p": if the conversation itself is what broke,
-#               resuming it would fail every wake forever, and the punch list on disk is enough
-#               for a fresh session to carry on.
+#               and the IDE extension alike. On the default agent the attempts of a wake walk a
+#               chain, each rung logged: the recorded conversation first, "claude --continue -p"
+#               next (no record starts here), and a fresh "claude -p" last — if the conversation
+#               itself is what broke, resuming it would fail every wake forever, and the punch
+#               list on disk is enough for a fresh session to carry on.
 #   --max-wakes bound the number of wakes (0 = unbounded; tests use this)
 #
 # Stand-down order, checked at every wake — the watchman never overrides an honest ending:
@@ -31,18 +31,28 @@
 #   4. quitting time passed                          -> one clock-out spawn, then down
 #   5. clean session end (.nightshift/.session-end)  -> down; the owner closed it on purpose
 #
-# Liveness: a working agent touches files constantly, so "alive" = anything in the project newer
-# than the last wake's sentinel.
+# Liveness is a ladder, not a guess — revival needs strong positive evidence of death, because
+# the one truly harmful failure is spawning a second agent beside a living one (a resumed id
+# APPENDS to the same session; two writers interleave):
+#   1. the shift's transcript moved since last wake  -> alive (a session streams every turn)
+#   2. any project file moved                        -> alive (work that writes files)
+#   3. interrupt marker in the transcript tail       -> owner pressed Esc; stand by
+#   4. recorded pid alive (start time verified)      -> tail shows "API Error"? the 500 wedge:
+#                                                       alive but errored, nobody home — revive.
+#                                                       No error -> long silent work; stand by
+#   5. no pid recorded, a claude process in project  -> uncertain; stand by (conservative)
+#   6. none of the above                             -> dead; revive
+# Every retry attempt re-runs the whole ladder first — a site that comes back to life mid-wake
+# is left alone — and each failed attempt re-baselines the sentinel so its own transcript writes
+# never read as site life.
 #
 # Esc still means stop. Claude Code records a user interrupt in the session transcript
-# ("Request interrupted by user"), and a 500 or a crash never writes one — that is the tell. At a
-# quiet wake the watchman reads the tail of THE SHIFT'S OWN transcript (recorded in
-# .shift-session by the hooks): interrupt there -> the owner paused it, stand by and keep
-# watching; no interrupt -> it died or errored with nobody there, revive it. A second tab's Esc
-# proves nothing and is ignored. With no record yet, the newest transcript in the project is the
-# fallback tell. Unreadable defaults to reviving: waking a paused session costs an apology, a
-# lost night costs the night. $NIGHTSHIFT_WATCH_TRANSCRIPTS overrides the transcript directory
-# (tests use it).
+# ("Request interrupted by user"), and a 500 or a crash never writes one — that is the tell, read
+# from the tail of THE SHIFT'S OWN transcript (recorded in .shift-session by the hooks). A second
+# tab's Esc proves nothing and is ignored. With no record yet, the newest transcript in the
+# project is the fallback tell. Unreadable defaults to reviving: waking a paused session costs an
+# apology, a lost night costs the night. $NIGHTSHIFT_WATCH_TRANSCRIPTS overrides the transcript
+# directory (tests use it).
 #
 # API outages: per wake, up to 3 spawn attempts spaced by $NIGHTSHIFT_WATCH_RETRY (default
 # "30 120" seconds). Wakes that fail entirely back the interval off — double per consecutive
@@ -115,22 +125,31 @@ deadline_passed() {
   [ "$(date +%s)" -ge "$dl" ]
 }
 
-# The hooks write the shift's identity (session id, transcript path) at first work. Read fresh
-# each use — the record appears after the watchman was armed.
+# The hooks write the shift's identity at first work: session id, transcript path, and the
+# claude ancestor's pid + start time. Read fresh each use — the record appears after the
+# watchman was armed.
 shift_session_id() { sed -n 1p "$NS/.shift-session" 2>/dev/null; }
 shift_transcript() { sed -n 2p "$NS/.shift-session" 2>/dev/null; }
+shift_pid() { sed -n 3p "$NS/.shift-session" 2>/dev/null; }
+shift_pid_start() { sed -n 4p "$NS/.shift-session" 2>/dev/null; }
 
-# The default agent resumes the shift's own conversation by id; no record degrades to --continue.
-# An owner-supplied agent is used verbatim.
-resolve_agent() {
+# Attempts of a wake walk a chain of rungs on the default agent: the recorded conversation
+# first, --continue next (and first when nothing was recorded), a fresh session last — each a
+# weaker but sturdier claim on the night. An owner-supplied agent is used verbatim on every rung.
+rung_agent() { # $1 attempt, $2 total attempts this wake
   local sid
-  if [ "$AGENT_IS_DEFAULT" -eq 1 ]; then
-    sid="$(shift_session_id)"
-    if [ -n "$sid" ]; then printf 'claude --resume %s -p' "$sid"; else printf 'claude --continue -p'; fi
-  else
-    printf '%s' "$AGENT"
-  fi
+  if [ "$AGENT_IS_DEFAULT" -ne 1 ]; then printf '%s' "$AGENT"; return; fi
+  if [ "$1" -ge "$2" ] && [ "$2" -gt 1 ]; then printf 'claude -p'; return; fi
+  sid="$(shift_session_id)"
+  if [ "$1" -eq 1 ] && [ -n "$sid" ]; then printf 'claude --resume %s -p' "$sid"; else printf 'claude --continue -p'; fi
 }
+rung_label() { # morning-readable name for the rung, mirrors rung_agent
+  if [ "$AGENT_IS_DEFAULT" -ne 1 ]; then printf 'owner agent'; return; fi
+  if [ "$1" -ge "$2" ] && [ "$2" -gt 1 ]; then printf 'fresh-session fallback'; return; fi
+  if [ "$1" -eq 1 ] && [ -n "$(shift_session_id)" ]; then printf 'resuming the recorded conversation'; else printf -- '--continue fallback'; fi
+}
+# Clock-out spawns take the strongest single rung: the recorded conversation, else --continue.
+resolve_agent() { rung_agent 1 2; }
 
 PROMPT="Resume the nightshift. Read .nightshift/punch-list.md and work its open items per the contract, one at a time; run the item gate before each commit; tick what you finish. Leave pushing to the owner unless the punch list says otherwise. Park owner decisions in parking-lot.md. Stop only when every box is ticked or a stop-work order exists."
 
@@ -142,34 +161,113 @@ spawn() { # $1 optionally overrides the agent for this one attempt
   $a "$PROMPT" >/dev/null 2>&1
 }
 
-# The Esc tell: an interrupt marker in the tail of the newest transcript means the owner paused
-# the session on purpose. Only the tail — an interrupt mid-history with work after it is a
-# session that already moved on.
-owner_paused() {
+# The transcript the tells read: the shift's own, recorded by the hooks; the newest in the
+# project's transcript directory is the fallback before the record exists.
+resolve_transcript() {
   local f latest=""
   latest="$(shift_transcript)"
-  if [ -z "$latest" ] || [ ! -f "$latest" ]; then
-    latest=""
-    for f in "$TRANSCRIPTS"/*.jsonl; do
-      [ -f "$f" ] || continue
-      if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then latest="$f"; fi
-    done
-  fi
-  [ -n "$latest" ] || return 1
-  tail -n 25 "$latest" 2>/dev/null | grep -q "Request interrupted by user"
+  if [ -n "$latest" ] && [ -f "$latest" ]; then printf '%s' "$latest"; return; fi
+  latest=""
+  for f in "$TRANSCRIPTS"/*.jsonl; do
+    [ -f "$f" ] || continue
+    if [ -z "$latest" ] || [ "$f" -nt "$latest" ]; then latest="$f"; fi
+  done
+  printf '%s' "$latest"
 }
 
-alive_since_last_wake() {
+# The Esc tell: an interrupt marker in the transcript tail means the owner paused the session on
+# purpose. Only the tail — an interrupt mid-history with work after it is a session that already
+# moved on.
+owner_paused() {
+  local t
+  t="$(resolve_transcript)"
+  [ -n "$t" ] || return 1
+  tail -n 25 "$t" 2>/dev/null | grep -q "Request interrupted by user"
+}
+
+# The wedge tell: Claude Code writes API failures verbatim into the transcript ("API Error: 500
+# Internal server error", "529 Overloaded", "Connection closed mid-response"). An error at the
+# tail of a quiet transcript whose process still lives is a session sitting at an errored prompt
+# with nobody there to press retry. The [^\\] guard skips the escaped quote of a session merely
+# TALKING about API errors — only the host's own event starts the JSON string with the phrase.
+errored_tail() {
+  local t
+  t="$(resolve_transcript)"
+  [ -n "$t" ] || return 1
+  tail -n 25 "$t" 2>/dev/null | grep -q '[^\\]"API Error:'
+}
+
+# Primary pulse: a live session streams every turn into its transcript, even when the work
+# writes no project files — long reasoning, research, a wall of tool output.
+transcript_pulse() {
+  local t
+  t="$(resolve_transcript)"
+  [ -n "$t" ] && [ "$t" -nt "$SENTINEL" ]
+}
+
+site_moved() {
   # -type f: a directory's mtime moves whenever anything inside it is created or removed — the
   # watchman's own bookkeeping would read as site life. Files are the signal, directories noise.
   find "$PROJECT" -path "$NS/.watchman*" -prune -o -type f -newer "$SENTINEL" -print 2>/dev/null |
     grep -q .
 }
 
+# The process witness. 0: the recorded process is alive — pid checked with kill -0 and the start
+# time re-read, because a reused pid wears the number but not the birthday. 1: provably dead.
+# 2: nothing recorded to check.
+shift_process_alive() {
+  local pid start now
+  pid="$(shift_pid)"
+  case "$pid" in '' | *[!0-9]*) return 2 ;; esac
+  kill -0 "$pid" 2>/dev/null || return 1
+  start="$(shift_pid_start)"
+  if [ -n "$start" ]; then
+    now="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    [ "$now" = "$start" ] || return 1
+  fi
+  return 0
+}
+
+# Fallback witness when no pid was recorded: any claude process whose working directory is this
+# project. Not the shift's identity — just reason enough not to spawn beside it.
+project_has_claude() {
+  local p comm cwd
+  for p in $(pgrep -f claude 2>/dev/null); do
+    comm="$(ps -o comm= -p "$p" 2>/dev/null)"
+    case "${comm##*/}" in claude) ;; *) continue ;; esac
+    if [ -r "/proc/$p/cwd" ]; then
+      cwd="$(readlink "/proc/$p/cwd" 2>/dev/null)"
+    else
+      cwd="$(lsof -a -p "$p" -d cwd -Fn 2>/dev/null | sed -n 's/^n//p')"
+    fi
+    case "$cwd" in "$PROJECT" | "$PROJECT"/*) return 0 ;; esac
+  done
+  return 1
+}
+
+# Re-evaluated before every retry attempt: an honest ending arriving, the site coming back to
+# life, or the owner acting mid-wake cancels the remaining attempts. Empty means revival is
+# still warranted.
+hold_reason() {
+  if [ -f "$NS/STOP" ]; then printf 'stop-work order'; return; fi
+  if [ -f "$NS/.ended" ] || [ ! -f "$PUNCH" ]; then printf 'shift ended'; return; fi
+  if [ "$(open_boxes)" -eq 0 ]; then printf 'all boxes ticked'; return; fi
+  if deadline_passed; then printf 'deadline passed'; return; fi
+  if [ -f "$NS/.session-end" ]; then printf 'clean session end'; return; fi
+  if transcript_pulse || site_moved; then printf 'site activity'; return; fi
+  if owner_paused; then printf 'owner Esc'; return; fi
+  shift_process_alive
+  case $? in
+    0) errored_tail || printf 'live shift process' ;;
+    2) if project_has_claude; then printf 'a live claude session in the project'; fi ;;
+  esac
+}
+
 log_line "watchman armed · every ${INTERVAL_MIN}m"
 : >"$SENTINEL"
 wake=0
 misses=0
+standby_prev=""
 
 # NIGHTSHIFT_WATCH_SLEEP overrides the base sleep in seconds — the test suite's speed lever.
 BASE_SLEEP="${NIGHTSHIFT_WATCH_SLEEP:-$((INTERVAL_MIN * 60))}"
@@ -195,43 +293,82 @@ while :; do
     exit 0
   fi
 
-  if alive_since_last_wake; then
+  # The liveness ladder. Revival needs strong positive evidence of death — the one truly harmful
+  # failure is a second agent beside a living one, so every uncertain reading stands by.
+  if transcript_pulse || site_moved; then
     misses=0
-    esc_prev=0
-  elif owner_paused; then
-    # Esc means stop. Stand by rather than down: if the owner resumes and a 500 kills it later,
-    # the next quiet wake will find an errored tail, not an interrupt, and revive as usual.
-    if [ "${esc_prev:-0}" -eq 0 ]; then
-      log_line "watchman: owner pressed Esc — standing by, not resuming (STOP ends the shift; resuming re-arms)"
-    fi
-    esc_prev=1
-    misses=0
+    standby_prev=""
   else
-    esc_prev=0
-    attempt=0
-    revived=1
-    # shellcheck disable=SC2086  # RETRY_SPACING is a space-separated list; splitting is the point
-    for spacing in $RETRY_SPACING ""; do
-      attempt=$((attempt + 1))
-      if [ -z "$spacing" ] && [ "$AGENT_IS_DEFAULT" -eq 1 ]; then
-        # Last try of the wake: if the conversation itself is what broke, --continue can never
-        # succeed — a fresh session reads the punch list and carries on regardless.
-        log_line "watchman: resume attempt $attempt (fresh-session fallback)"
-        if spawn "claude -p"; then revived=0; fi
-        break
-      fi
-      log_line "watchman: site quiet ${INTERVAL_MIN}m+ with open boxes — resume attempt $attempt"
-      if spawn "$(resolve_agent)"; then revived=0; break; fi
-      [ -n "$spacing" ] || break
-      sleep "$spacing"
-    done
-    if [ "$revived" -eq 0 ]; then
-      misses=0
-      log_line "watchman: resumed session returned — re-checking next wake"
+    verdict=""
+    if owner_paused; then
+      # Esc means stop. Stand by rather than down: if the owner resumes and a 500 kills it
+      # later, the next quiet wake will find an errored tail, not an interrupt, and revive.
+      verdict="esc"
     else
-      misses=$((misses + 1))
-      log_line "watchman: all $attempt attempts failed (api down?) — backing off"
+      shift_process_alive
+      case $? in
+        0) if errored_tail; then verdict="wedge"; else verdict="silent"; fi ;;
+        2) if project_has_claude; then verdict="tabs"; fi ;;
+      esac
     fi
+    case "$verdict" in
+      esc)
+        [ "$standby_prev" = "esc" ] || log_line "watchman: owner pressed Esc — standing by, not resuming (STOP ends the shift; resuming re-arms)"
+        standby_prev="esc"
+        misses=0
+        ;;
+      silent)
+        [ "$standby_prev" = "silent" ] || log_line "watchman: shift process alive with a quiet transcript — long silent work; standing by"
+        standby_prev="silent"
+        misses=0
+        ;;
+      tabs)
+        [ "$standby_prev" = "tabs" ] || log_line "watchman: a claude session is live in this project — standing by"
+        standby_prev="tabs"
+        misses=0
+        ;;
+      *)
+        standby_prev=""
+        [ "$verdict" != "wedge" ] || log_line "watchman: probable wedge — shift process alive at an errored prompt; reviving its conversation"
+        attempt=0
+        revived=1
+        aborted=""
+        # shellcheck disable=SC2086  # RETRY_SPACING is a space-separated list; splitting is the point
+        set -- $RETRY_SPACING ""
+        total=$#
+        for spacing in "$@"; do
+          attempt=$((attempt + 1))
+          if [ "$attempt" -gt 1 ]; then
+            # Re-check the whole ladder: a site that came back to life mid-wake — or an owner
+            # who acted — cancels the remaining attempts.
+            aborted="$(hold_reason)"
+            if [ -n "$aborted" ]; then
+              log_line "watchman: $aborted during retries — holding the remaining attempts"
+              break
+            fi
+          fi
+          log_line "watchman: site quiet ${INTERVAL_MIN}m+ with open boxes — resume attempt $attempt ($(rung_label "$attempt" "$total"))"
+          if spawn "$(rung_agent "$attempt" "$total")"; then
+            revived=0
+            break
+          fi
+          # Re-baseline: the failed attempt may have appended its own error to the transcript.
+          # Only what moves AFTER this line is site life.
+          : >"$SENTINEL"
+          [ -n "$spacing" ] || break
+          sleep "$spacing"
+        done
+        if [ "$revived" -eq 0 ]; then
+          misses=0
+          log_line "watchman: resumed session returned — re-checking next wake"
+        elif [ -n "$aborted" ]; then
+          misses=0
+        else
+          misses=$((misses + 1))
+          log_line "watchman: all $attempt attempts failed (api down?) — backing off"
+        fi
+        ;;
+    esac
   fi
 
   : >"$SENTINEL" # after all actions, so the watchman's own writes never read as site life

--- a/adapters/watchman.sh
+++ b/adapters/watchman.sh
@@ -157,8 +157,11 @@ PROMPT="Resume the nightshift. Read .nightshift/punch-list.md and work its open 
 # $AGENT is an owner-provided command line; word-splitting is intended, as in foreman.
 spawn() { # $1 optionally overrides the agent for this one attempt
   local a="${1:-$AGENT}"
+  # NIGHTSHIFT_REVIVAL marks the child for the hooks: a revival session ending is never the
+  # owner's hand on the door — without the mark, the worker's own exit would write .session-end
+  # under the recorded id and stand the watchman down mid-outage.
   # shellcheck disable=SC2086
-  $a "$PROMPT" >/dev/null 2>&1
+  NIGHTSHIFT_REVIVAL=1 $a "$PROMPT" >/dev/null 2>&1
 }
 
 # The transcript the tells read: the shift's own, recorded by the hooks; the newest in the

--- a/hooks/clock-out-gate.sh
+++ b/hooks/clock-out-gate.sh
@@ -131,10 +131,24 @@ end_shift() {
 if [ -f "$PUNCH" ]; then OPEN="$(open_boxes)"; TICKED="$(ticked_boxes)"; else OPEN=0; TICKED=0; fi
 TOTAL=$((OPEN + TICKED))
 
-# Record the shift's own session, once — same contract as hardhat's record.
+# Record the shift's own session, once — same contract as hardhat's record: id, transcript, and
+# the claude ancestor's pid + start time, claimed with an exclusive create so two racing first
+# sessions cannot interleave. Losing the race is the design.
+record_shift_session() {
+  local p="$$" _ comm pid="" start=""
+  for _ in 1 2 3 4 5 6; do
+    case "$p" in '' | *[!0-9]*) break ;; esac
+    [ "$p" -gt 1 ] || break
+    comm="$(ps -o comm= -p "$p" 2>/dev/null)" || break
+    case "${comm##*/}" in claude) pid="$p"; break ;; esac
+    p="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d '[:space:]')"
+  done
+  [ -z "$pid" ] || start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  (set -C; printf '%s\n%s\n%s\n%s\n' "$SID" "${TPATH:-}" "$pid" "$start" >"$NS/.shift-session") 2>/dev/null || true
+}
 if [ -f "$PUNCH" ] && [ "$OPEN" -gt 0 ] && [ ! -f "$ENDED" ] \
   && [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
-  printf '%s\n%s\n' "$SID" "${TPATH:-}" >"$NS/.shift-session"
+  record_shift_session
 fi
 
 # 1. Stop-work order — honor at once; open boxes are left open on purpose (an honest snapshot).

--- a/hooks/hardhat.sh
+++ b/hooks/hardhat.sh
@@ -84,11 +84,25 @@ if [ ! -f "$PUNCH" ] || [ -f "$ENDED" ] \
 fi
 
 # The shift records its own identity: the first session to work under an active shift writes its
-# session id and transcript path, once. The watchman reads THIS session's transcript for the Esc
-# tell and revives THIS conversation by id — never a guess at "the newest". Any later session in
-# the same project (a second tab, a helper) never overwrites the record.
+# session id, transcript path, and best-effort process identity — the claude ancestor's pid and
+# start time, a pair no pid reuse can counterfeit. The watchman reads THIS session's transcript
+# for the Esc tell, checks THIS process for life, and revives THIS conversation by id — never a
+# guess at "the newest". The exclusive create makes first-writer-wins mechanical: two racing
+# first sessions cannot interleave, one claim lands whole. Losing that race is the design.
+record_shift_session() {
+  local p="$$" _ comm pid="" start=""
+  for _ in 1 2 3 4 5 6; do
+    case "$p" in '' | *[!0-9]*) break ;; esac
+    [ "$p" -gt 1 ] || break
+    comm="$(ps -o comm= -p "$p" 2>/dev/null)" || break
+    case "${comm##*/}" in claude) pid="$p"; break ;; esac
+    p="$(ps -o ppid= -p "$p" 2>/dev/null | tr -d '[:space:]')"
+  done
+  [ -z "$pid" ] || start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  (set -C; printf '%s\n%s\n%s\n%s\n' "$SID" "${TPATH:-}" "$pid" "$start" >"$NS/.shift-session") 2>/dev/null || true
+}
 if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
-  printf '%s\n%s\n' "$SID" "${TPATH:-}" >"$NS/.shift-session"
+  record_shift_session
 fi
 
 # An unparseable owner pattern makes grep exit 2, which a plain `if` reads as "no match" — the

--- a/hooks/session-end.sh
+++ b/hooks/session-end.sh
@@ -11,6 +11,11 @@
 # nothing, so ordinary sessions leave no residue.
 set -u
 
+# A watchman-spawned revival carries this mark. Its exit — finished, or dead on the API again —
+# is never the owner's hand on the door; writing the marker for it would stand the watchman down
+# mid-outage after the first revival.
+[ "${NIGHTSHIFT_REVIVAL:-}" != "1" ] || exit 0
+
 INPUT="$(cat)"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
 NS="$PROJECT_DIR/.nightshift"

--- a/tests/clock-out-gate.bats
+++ b/tests/clock-out-gate.bats
@@ -262,4 +262,5 @@ load helpers
   run gate "$p"
   is_block "$output"
   [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "test-shift-session" ]
+  [ "$(wc -l <"$p/.nightshift/.shift-session")" -eq 4 ] # id, transcript, pid, start time
 }

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -335,3 +335,60 @@ load helpers
     CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
   [ ! -f "$p/.nightshift/.shift-session" ]
 }
+
+# v0.5.2: the record carries process identity — the claude ancestor's pid and start time, found
+# by walking the hook's own ancestry. A stubbed ps makes the walk deterministic here.
+@test "the record claims the claude ancestor's pid and start time" {
+  p="$(new_project)"
+  punch_open "$p"
+  stub="$BATS_TEST_TMPDIR/pidbin"
+  mkdir -p "$stub"
+  cat >"$stub/ps" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *lstart*) echo "  Mon Jan  1 00:00:00 2026  " ;;
+  *comm*) echo "claude" ;;
+  *) echo 1 ;;
+esac
+STUB
+  chmod +x "$stub/ps"
+  jq -nc '{tool_name:"Bash",session_id:"pid-tab",transcript_path:"/tmp/t.jsonl",tool_input:{command:"echo hi"}}' |
+    PATH="$stub:$PATH" CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "pid-tab" ]
+  sed -n 3p "$p/.nightshift/.shift-session" | grep -qE '^[0-9]+$'
+  [ "$(sed -n 4p "$p/.nightshift/.shift-session")" = "Mon Jan  1 00:00:00 2026" ]
+}
+
+@test "no claude ancestor leaves the pid lines empty, never breaks the record" {
+  p="$(new_project)"
+  punch_open "$p"
+  jq -nc '{tool_name:"Bash",session_id:"bare-tab",transcript_path:"",tool_input:{command:"echo hi"}}' |
+    CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "bare-tab" ]
+  [ "$(wc -l <"$p/.nightshift/.shift-session")" -eq 4 ]
+  [ -z "$(sed -n 3p "$p/.nightshift/.shift-session")" ]
+}
+
+# The claim is an exclusive create: two racing first sessions cannot interleave — one record
+# lands whole, id and transcript from the same writer.
+@test "two racing identity claims land exactly one whole record" {
+  for round in 1 2 3; do
+    p="$(new_project "race$round")"
+    punch_open "$p"
+    jq -nc '{tool_name:"Bash",session_id:"race-a",transcript_path:"/tmp/a.jsonl",tool_input:{command:"echo hi"}}' |
+      CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh" &
+    one=$!
+    jq -nc '{tool_name:"Bash",session_id:"race-b",transcript_path:"/tmp/b.jsonl",tool_input:{command:"echo hi"}}' |
+      CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh" &
+    two=$!
+    wait "$one" "$two"
+    [ "$(wc -l <"$p/.nightshift/.shift-session")" -eq 4 ]
+    sid="$(sed -n 1p "$p/.nightshift/.shift-session")"
+    tpath="$(sed -n 2p "$p/.nightshift/.shift-session")"
+    case "$sid" in
+      race-a) [ "$tpath" = "/tmp/a.jsonl" ] ;;
+      race-b) [ "$tpath" = "/tmp/b.jsonl" ] ;;
+      *) false ;;
+    esac
+  done
+}

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -448,3 +448,13 @@ STUB
   ! grep -q fresh "$P/.nightshift/agent-calls"
   [ "$(grep -c resume "$P/.nightshift/agent-calls")" -eq 2 ] # the revival and the clock-out
 }
+
+# A watchman-spawned revival is marked; its own exit is never the owner's hand on the door.
+@test "a marked revival session's exit never writes the clean-end marker" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'right-id\n\n\n\n' >"$p/.nightshift/.shift-session"
+  printf '{"reason":"exit","session_id":"right-id"}' |
+    NIGHTSHIFT_REVIVAL=1 CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
+  [ ! -f "$p/.nightshift/.session-end" ]
+}

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -245,3 +245,206 @@ STUB
   printf '{"reason":"exit","session_id":"right-id"}' | CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
   grep -q 'clean session end (exit)' "$p/.nightshift/.session-end"
 }
+
+# ---- v0.5.2: the liveness ladder — strong positive evidence of death, or stand by ----
+
+# Primary pulse: a session streams every turn into its transcript even when the work writes no
+# project files. Transcript movement alone means alive.
+@test "transcript activity alone keeps the watchman standing by" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
+  printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
+  ( while :; do printf '{"type":"message","content":"x"}\n' >>"$T/shift.jsonl"; sleep 0.15; done ) &
+  toucher=$!
+  run env NIGHTSHIFT_WATCH_SLEEP=1 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+  kill "$toucher" 2>/dev/null || true
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+}
+
+@test "a helper transcript's activity is not the shift's pulse" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
+  printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
+  ( while :; do printf '{"type":"message","content":"other"}\n' >>"$T/other.jsonl"; sleep 0.15; done ) &
+  toucher=$!
+  run env NIGHTSHIFT_WATCH_SLEEP=1 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  kill "$toucher" 2>/dev/null || true
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ] # revived despite the helper's noise, then clocked out
+}
+
+# The process witness: the recorded pid alive with a quiet, unerrored transcript is long silent
+# work — a 25-minute test run writes nothing anywhere. Never spawn beside it.
+@test "the shift's own live process holds the watchman through a silent stretch" {
+  start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf 'sid-shift\n\n%s\n%s\n' "$$" "$start" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 3
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'long silent work; standing by' "$P/.nightshift/shift-log.md"
+  [ "$(grep -c 'standing by' "$P/.nightshift/shift-log.md")" -eq 1 ] # logged once, not every wake
+}
+
+# The wedge: process alive, transcript quiet, and the host's own API-error event at the tail —
+# a session sitting at an errored prompt with nobody there. This one is revived.
+@test "a live shift process at an errored prompt is the wedge — revived" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n{"type":"error","content":"API Error: 500 Internal server error"}\n' >"$T/shift.jsonl"
+  start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ]
+  grep -q 'probable wedge' "$P/.nightshift/shift-log.md"
+}
+
+# A session merely TALKING about API errors is not the wedge — the escaped quote of prose
+# never matches the host's own event string.
+@test "prose mentioning API errors does not read as the wedge" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"we should handle the \\"API Error: 500\\" case"}\n' >"$T/shift.jsonl"
+  start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'long silent work; standing by' "$P/.nightshift/shift-log.md"
+}
+
+@test "a dead recorded pid is strong evidence — revived" {
+  bash -c ':' &
+  deadpid=$!
+  wait "$deadpid" 2>/dev/null || true
+  printf 'sid-shift\n\n%s\n\n' "$deadpid" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ]
+}
+
+# A pid wears the number but not the birthday: a mismatched start time means the shift's
+# process is gone and something else inherited its pid.
+@test "a reused pid is not the shift's process — revived" {
+  printf 'sid-shift\n\n%s\n%s\n' "$$" "Thu Jan  1 00:00:00 1970" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ]
+}
+
+# No pid recorded: any claude process working in this project is reason enough not to spawn.
+# Not identity — just the conservative reading of an uncertain site.
+@test "with no recorded pid, a claude process in the project stands the watchman by" {
+  cat >"$BIN/pgrep" <<'STUB'
+#!/usr/bin/env bash
+echo 999999
+STUB
+  cat >"$BIN/ps" <<'STUB'
+#!/usr/bin/env bash
+echo "/fake/bin/claude"
+STUB
+  cat >"$BIN/lsof" <<STUB
+#!/usr/bin/env bash
+echo "p999999"
+echo "n$P"
+STUB
+  chmod +x "$BIN/pgrep" "$BIN/ps" "$BIN/lsof"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 3
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'a claude session is live in this project — standing by' "$P/.nightshift/shift-log.md"
+}
+
+# ---- v0.5.2: pre-spawn re-checks and the honest retry baseline ----
+
+@test "site activity during the retry sleep cancels the remaining attempts" {
+  ( sleep 1; touch "$P/came-back" ) &
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="2" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/fail.sh" --max-wakes 1
+  wait 2>/dev/null || true
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 1 ]
+  grep -q 'site activity during retries — holding the remaining attempts' "$P/.nightshift/shift-log.md"
+}
+
+# A failed resume may append its own API-error event to the shift transcript. Re-baselining
+# after each attempt keeps the watchman from mistaking its own noise for site life.
+@test "the watchman's own failed attempt cannot fool the retry check" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
+  printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
+  cat >"$BIN/fail-noisy.sh" <<STUB
+#!/usr/bin/env bash
+echo called >>.nightshift/agent-calls
+printf '{"type":"error","content":"API Error: 500"}\n' >>"$T/shift.jsonl"
+exit 1
+STUB
+  chmod +x "$BIN/fail-noisy.sh"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/fail-noisy.sh" --max-wakes 1
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 3 ] # all three attempts ran; none was fooled by the previous one's writes
+  ! grep -q 'during retries' "$P/.nightshift/shift-log.md"
+}
+
+# ---- v0.5.2: the revival chain — recorded conversation, --continue, fresh session ----
+
+@test "a failed resume degrades to --continue before the fresh session" {
+  printf 'abc-123\n\n\n\n' >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *--resume*) echo resume >>.nightshift/agent-calls; exit 1 ;;
+  *--continue*) echo continue >>.nightshift/agent-calls; exit 1 ;;
+  *) echo fresh >>.nightshift/agent-calls
+     awk 'BEGIN{d=0} !d && /^- \[ \]/{sub(/\[ \]/,"[x]");d=1} {print}' .nightshift/punch-list.md >.nightshift/pl.tmp
+     mv .nightshift/pl.tmp .nightshift/punch-list.md ;;
+esac
+STUB
+  chmod +x "$BIN/claude"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --max-wakes 4
+  [ "$status" -eq 0 ]
+  [ "$(sed -n 1p "$P/.nightshift/agent-calls")" = "resume" ]
+  [ "$(sed -n 2p "$P/.nightshift/agent-calls")" = "continue" ]
+  [ "$(sed -n 3p "$P/.nightshift/agent-calls")" = "fresh" ]
+  grep -q 'resuming the recorded conversation' "$P/.nightshift/shift-log.md"
+  grep -q -- '--continue fallback' "$P/.nightshift/shift-log.md"
+  grep -q 'fresh-session fallback' "$P/.nightshift/shift-log.md"
+}
+
+@test "a successful resume never falls to --continue or a fresh session" {
+  printf 'abc-123\n\n\n\n' >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  *--resume*) echo resume >>.nightshift/agent-calls
+     awk 'BEGIN{d=0} !d && /^- \[ \]/{sub(/\[ \]/,"[x]");d=1} {print}' .nightshift/punch-list.md >.nightshift/pl.tmp
+     mv .nightshift/pl.tmp .nightshift/punch-list.md ;;
+  *--continue*) echo continue >>.nightshift/agent-calls ;;
+  *) echo fresh >>.nightshift/agent-calls ;;
+esac
+STUB
+  chmod +x "$BIN/claude"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --max-wakes 4
+  [ "$status" -eq 0 ]
+  ! grep -q continue "$P/.nightshift/agent-calls"
+  ! grep -q fresh "$P/.nightshift/agent-calls"
+  [ "$(grep -c resume "$P/.nightshift/agent-calls")" -eq 2 ] # the revival and the clock-out
+}


### PR DESCRIPTION
The one truly harmful watchman failure is spawning a second agent beside a living session: a resumed id **appends to the same conversation**, so two writers interleave while sharing one working tree. v0.5.0 read liveness from project files alone — long reasoning or a 25-minute test run writes none and looked dead. This release makes revival require strong positive evidence of death.

## The liveness ladder

| Evidence | Verdict | Action |
|---|---|---|
| Interrupt marker in the recorded transcript tail | owner pressed Esc | stand by |
| Recorded transcript mtime moved | alive — a session streams every turn | stand by |
| Project files moved | alive | stand by |
| Recorded pid alive (start time verified), no error tail | long silent work | stand by |
| Recorded pid alive + `API Error` at the tail | **the 500 wedge** — errored, nobody home | revive |
| Recorded pid dead — even with other tabs open | dead | revive |
| No pid recorded, a claude process in the project | uncertain | stand by (conservative) |
| None of the above | dead | revive |

## Changes

- **Process identity**: the hooks record the claude ancestor's pid + start time into `.shift-session` (best-effort, fail-open), found by walking the hook's own ancestry — verified working inside the IDE extension. `kill -0` plus the start time defeats pid reuse.
- **Atomic identity claim**: `.shift-session` is taken with an exclusive create — two racing first sessions cannot interleave.
- **Wedge signature**: Claude Code writes API failures verbatim into the transcript; the matcher skips escaped quotes so prose about API errors never counts.
- **Pre-spawn re-checks**: every retry re-runs the whole ladder — a site that comes back to life mid-wake cancels the remaining attempts — and each failed attempt re-baselines the sentinel so the watchman's own error events never read as site life.
- **The revival chain is real and logged per rung**: recorded conversation → `claude --continue` → fresh `claude -p`. Previously the middle rung was documentation only.
- **A revival's own exit is not the owner's hand on the door**: spawned workers carry `NIGHTSHIFT_REVIVAL=1` and the `SessionEnd` hook stays inert for them. Without the mark, the first worker finishing — or dying on the API again — would write the clean-end marker under the recorded id and stand the watchman down mid-outage, ending exactly the multi-hour-outage night the watchman exists for.
- README and changelog synchronized with the recorded-id revival.

## Verification

- 145/145 bats (17 new: one per ladder rung, chain order, successful-resume short-circuit, retry cancellation, re-baseline honesty, racing claims, pid recording, revival-mark inertness)
- shellcheck clean, `claude plugin validate . --strict` passed
- CI green: bats, shellcheck, validate

🤖 Generated with [Claude Code](https://claude.com/claude-code)