### PR TITLE
Release v0.6.0 — the 500 night, start to finish

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.5.2",
+  "version": "0.6.0",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,78 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.6.0 — the 500 night, start to finish
+
+Start a shift, watch the very first call come back `API Error: 500`, and go to sleep anyway:
+the watchman now carries that night from the first error to the morning receipts, and the
+whole story — the 500, the revival, the finished work — is one conversation you open with
+one click.
+
+- **The wedge is the transcript's last word, read structurally.** Claude Code records an API
+  failure as its own synthetic event, flagged `isApiErrorMessage:true`; the watchman requires
+  that flag on the last conversation event before calling a live-but-quiet session wedged. An
+  owner pasting an error report as a prompt, or an error the session already retried past, no
+  longer reads as a wedge — if anything followed the error, somebody was there, and that
+  session is not the watchman's to touch. The owner's Esc is read by the same rule: an
+  interrupt is a pause only as the last conversation event — one the owner already resumed
+  past is history, and a real death after that resume reads as death.
+- **A 500 before first work is still the wedge.** The shift records its identity at the first
+  tool call — but an outage can land before any tool runs, leaving no record. A project whose
+  newest conversation ends in the host's error event now revives via `--continue`, which
+  resumes that very conversation, instead of standing by all night behind "a live claude
+  session in the project".
+- **Session-first, and only the session.** The verdict reads the session's own signals in
+  order — the owner's Esc above all, the shift's transcript, the recorded process, then the
+  host's registry: `claude agents --json` listing the recorded id is the host saying alive
+  (it even rescues a stale pid), and a clean roster without it is death evidence no folder
+  churn can drown out. Project files never vote — a detached loop, a build, or a sync can
+  neither mute the owner's Esc nor mask a dead session as alive.
+- **Revival orders match what the session knows.** A resumed conversation carries its own
+  context, so its order is one line: cut off, continue — the contract already lives in the
+  thread, and the gate enforces the ending. The fresh-session fallback starts empty and gets
+  the full pointer at the punch list. Both texts are the owner's (`revivalPrompt`,
+  `freshRevivalPrompt`).
+- **The morning is one click away.** A successful revival leaves a notice in
+  `parking-lot.md` — the file the owner reads — with the thread's handles: `claude --resume
+  <id>` for the terminal, the `cursor://` and `vscode://` deep links for the IDE panel. The
+  first thing you open is the exact conversation: the error, the revival, and everything it
+  finished. The one night event that needs the owner — a dead session no attempt could bring
+  back — rings the morning whistle instead, once per outage.
+- **Tighter cadence.** The watch interval defaults to 10 minutes (`NIGHTSHIFT_WATCH=N` still
+  sets it), and a dead API never stretches the rhythm: three tries per wake, every wake,
+  until the API answers.
+- **The night cannot click Allow.** Setup now asks to enable `bypassPermissions` in the
+  project's settings (recommended; written to `.claude/settings.local.json` so revivals
+  inherit it), start warns once when no frictionless grant exists, and the README says the
+  trade plainly. nightshift's guards are hooks and stay armed in every permission mode.
+- **One rules file, every decision the owner's.** Setup copies a ready template to
+  `.claude/nightshift-rules.json` and syncs it into the env block — clean JSON to edit, the
+  ugly escaping machine-written. It carries the per-tool denial map (`toolDeny`: your message
+  per tool, an empty message lifts a rule, absent keys keep the defaults), every guard
+  pattern, the stall cap and warning cadence, the watch cadence, the morning whistle, the
+  watchman's revival orders, and the gate's clock-out reinjection. The env stays the enforcement surface, fixed at session start — the file is the
+  owner's editor, never the agent's lever — and start warns when the file drifts from the
+  running session's rules. Re-running setup after an update offers what the new template added
+  — missing keys, a changed contract — and never touches the owner's words.
+- **The receipts repo is opt-in.** A git repo living inside the project is not everyone's
+  taste: setup now asks before `git init`-ing `.nightshift/`, and the default is no — the
+  receipts remain as plain files, and the gate's snapshot commit is a no-op without the repo.
+- **`/nightshift:archive` — the finished part becomes a dated record.** Ticked items move into
+  `archive/<date>/shipped.md`, the journal rotates whole, snags and parked questions move only
+  once they carry the owner's answer. The live files stay lean; what shipped stays on disk as
+  plain dated facts. Start auto-rotates a journal past ~500 KB into the same archive.
+- **The shift binds one session.** The gate holds, and the site rules govern, the recorded
+  shift session alone — a second conversation in the same project chats, stops, and asks
+  freely; the night is not its business unless the owner brings it. A watchman revival stays
+  bound under whatever id the fallback chain gave it and re-claims the record, so the watchman
+  follows the living thread. Start refuses to start a second agent beside a living one — it
+  hands the owner the running thread's `claude --resume` and IDE deep link instead.
+- **One writer per site.** Two sessions stopping at once could tear the stall counter, double
+  the morning whistle, or collide in the receipts repo. The gate's decision tail now runs
+  under a per-site lock (mkdir-based — every platform has it; a dead holder's lock is broken
+  on sight, a live one is waited on, bounded), and the whistle marker is claimed with an
+  exclusive create. The wait can never hang a session: an unlockable site is decided unlocked.
+
 ## v0.5.2 — strong evidence of death
 
 The one truly harmful watchman failure is spawning a second agent beside a living one: a resumed

--- a/README.md
+++ b/README.md
@@ -53,8 +53,13 @@ at a serious product — not a half-done prototype full of shortcuts.
 - **Your rules are laws, not suggestions.** Nothing is blocked out of the box; whatever *you*
   forbid, hooks deny mechanically for the length of the shift: `git push` for the night, `rm -rf`,
   commits that touch a protected folder, diffs that smell like secrets, commits under the wrong
-  identity. The agent *can't*, not *shouldn't*. They are shift rules, not a background scanner —
-  outside a shift your session is your own.
+  identity. The agent *can't*, not *shouldn't*. And because they are hooks, not permission rules,
+  they hold in **every** permission mode — run the night on `bypassPermissions` and your denylist
+  still stands. Allow everything, deny your list: a combination Claude Code has no native spelling
+  for. They are shift rules, not a background scanner — outside a shift your session is your own.
+  And the shift binds **one** session — the one working it: a second conversation opened beside a
+  running shift chats, stops, and asks freely, and `/nightshift:start` refuses to start a second
+  agent beside a living one — it hands you the running thread instead.
 - **Questions get parked, not asked.** Mid-shift the ask-the-user tool is denied; the question
   lands in `parking-lot.md` with a sensible default chosen, and work continues. Watching live?
   Type your answer any time and it's applied. Asleep? Review the parked calls over coffee.
@@ -65,18 +70,21 @@ at a serious product — not a half-done prototype full of shortcuts.
 - **A dead session is revived, not mourned.** No hook can fire in a session that no longer
   exists — that's the 500 night. You're supposed to be asleep; instead you're refreshing
   status.claude.com so you can relaunch the moment it recovers. Don't — the **night watchman**
-  works that shift: it wakes every 20 minutes, and when the site is quiet it resumes **the
+  works that shift: it wakes every 10 minutes, and when the site is quiet it resumes **the
   shift's own conversation by id** — hours of context, decisions, where it stood mid-item — so
   the morning transcript is one unbroken thread: the 500, the revival, and everything after, in
   the terminal or your IDE's extension alike. (The chain degrades honestly: the recorded
   conversation first, `claude --continue` next, a fresh session last — the punch list on disk is
   enough for any of them.) Reviving needs strong positive evidence of death, never "looks
   stuck": the shift records its own session id, transcript, and process at first work, and the
-  watchman checks all three — a transcript still streaming, a live shift process on silent work,
-  or any claude session in the project stands it by; a dead process, or one alive at an errored
-  prompt with an `API Error` in the transcript tail, is what gets revived. It stands down at
+  watchman reads only the session's own signals — your Esc first, then a transcript still
+  streaming, a live shift process on silent work, the host's own session roster
+  (`claude agents --json`), or any claude session in the project stands it by. Project files
+  never vote: a churning build, a sync, or a stray log writer can neither mute your Esc nor
+  mask a death. A dead process, a roster without the shift, or a session alive at an errored
+  prompt — the transcript's last word is the API error itself — is what gets revived. It stands down at
   every honest ending — done, stop-work order, quitting time, a clean exit — gives an outage
-  2–3 tries then backs off instead of hammering, and **Esc still means stop**: your interrupt is
+  three tries every wake, all night, until the API answers, and **Esc still means stop**: your interrupt is
   in the transcript, and the watchman reads it before touching anything.
 - **You're never trapped.** Escape and Ctrl+C still work — it's your keyboard, the plugin can't
   override it. But a pause isn't an ending: the next session resumes the shift, and a headless
@@ -85,9 +93,11 @@ at a serious product — not a half-done prototype full of shortcuts.
   written. It lands at the next stop attempt rather than mid-keystroke, and the site rules stay
   armed until then, so an order given in alarm never strips the guards off a still-working agent.
   Open boxes stay open — a true snapshot of where it stopped.
-- **Receipts, not vibes.** Timestamps, per-item commits, cycle logs — versioned in a local
-  receipts repo inside `.nightshift/` that never touches your project's history (ignored by
-  default; no remote, never pushed).
+- **Receipts, not vibes.** Timestamps, per-item commits, cycle logs — plain files under
+  `.nightshift/`, kept out of your project's history. When they grow, `/nightshift:archive`
+  files the finished part into `.nightshift/archive/<date>/` — shipped items, the journal,
+  handled snags — dated, readable facts about what landed. Want git history of the run state
+  too? Setup offers a local-only receipts repo (opt-in; no remote, never pushed).
 
 ## When to call in the night shift
 
@@ -127,12 +137,21 @@ Then:
 /nightshift:start      # hours asked only for open-ended work; then go to sleep
 /nightshift:status     # morning: what got done, what got parked, what got stuck
 /nightshift:stop       # end the shift now; open boxes stay open, honestly
+/nightshift:archive    # file finished work into .nightshift/archive/<date>/ — shipped items, logs, handled snags
 # you review the local commits and push — or forbid pushing outright (one env line below)
 ```
 
 Stop-work order, any time, from any terminal: `touch .nightshift/STOP`. In an interactive session
 Escape is the immediate halt; STOP is what reaches a headless run or the foreman loop, and it ends
 the shift at the agent's next stop attempt.
+
+**Permissions: the night cannot click Allow.** An unattended shift freezes on a permission prompt,
+and a watchman revival runs headless — a denied tool stays denied. For long runs,
+`bypassPermissions` is the recommended mode, set in the project's `.claude/settings.local.json` so
+revived sessions inherit it (`/nightshift:setup` offers this and writes it on a yes); the narrower
+alternative is pre-allowing the punch list's own tools. nightshift's guards are hooks — they stay
+armed in every permission mode, bypass included. Decline both and a mid-shift prompt costs the
+night; that trade is the owner's.
 
 One more appears in your slash menu: `/nightshift:nightshift` is the method itself — how to work an
 item, park a decision, keep a snag log. Claude loads it on its own whenever a shift is running, so
@@ -153,8 +172,8 @@ v1.2.0 on npm the same day. Public links:
 [`examples/adapttable-overnight.md`](examples/adapttable-overnight.md).
 
 The live `.nightshift/` state stays out of this repo — the same default nightshift sets for your
-projects: your run history is yours, ignored by your repo, versioned in its own local receipts
-repo.
+projects: your run history is yours, ignored by your repo, and versioned in its own local
+receipts repo if you opt in at setup.
 
 ## The three famous shifts
 
@@ -208,17 +227,29 @@ Everything is named from a real construction site — learn one term, guess the 
 
 ## Owner knobs
 
-Zero-config by default; every knob below is off until you set it (unset ⇒ the default described):
+Zero-config by default; every knob below is off until you set it (unset ⇒ the default described).
+
+**One file drives them all:** setup copies a ready template to `.claude/nightshift-rules.json` —
+edit it in clean JSON (the tool-deny map, the guard patterns, the cadence, even the watchman's
+revival prompt and the gate's clock-out text), re-run `/nightshift:setup`, start a fresh session.
+Setup machine-writes your file into the env block below; the env is what enforces, fixed at
+session start — so only you can set or lift a rule, never the agent mid-run. Start warns when
+the file has drifted from the running session's rules.
 
 | Env var | Effect |
 |---|---|
+| `NIGHTSHIFT_TOOL_RULES` | JSON map of tool name → denial message (rules file: `toolDeny`). A key denies that tool with your wording; an empty message lifts the rule; absent keys mean the default — AskUserQuestion parked, everything else allowed |
+| `NIGHTSHIFT_REVIVAL_PROMPT` | your wording for the order a **resumed** conversation gets — default is one line ("you were cut off, continue"), because the thread carries its own context (rules file: `revivalPrompt`) |
+| `NIGHTSHIFT_FRESH_PROMPT` | your wording for the **fresh-session** fallback's order — the only rung that starts with no context, so its default points at the punch list (rules file: `freshRevivalPrompt`) |
+| `NIGHTSHIFT_GATE_MESSAGE` | your wording for the clock-out gate's DO-NOT-STOP reinjection (rules file: `clockOutMessage`) |
+| `NIGHTSHIFT_STALL_WARN` | hold-mode stall warning cadence — warn every N stuck stop attempts (rules file: `stallWarnEvery`; default 3) |
 | `NIGHTSHIFT_FORBIDDEN_COMMANDS` | deny any Bash command matching this `grep -E` pattern during a shift — your own site rules. `git .*push` keeps pushing yours for the night (the `.*` also catches `git -c k=v push`); `rm -rf\|docker\|terraform` fences the rest. Env vars are fixed at session start, so only you can set or lift a rule — never the agent mid-run |
 | `NIGHTSHIFT_EXPECTED_EMAIL` | during a shift, deny commits authored under any other identity |
 | `NIGHTSHIFT_PROTECTED_DIRS` | during a shift, space/pipe-separated dir names never to `git add/commit/tag/remote` |
 | `NIGHTSHIFT_NEVER_COMMIT_PATTERNS` | during a shift, deny a commit whose diff matches this `grep -E` pattern — the index, widened to the working tree when the command stages implicitly (`git commit -a`) |
 | `NIGHTSHIFT_WATCH` | minutes between night-watchman wakes; `0` disarms it (unset ⇒ 20). The revival resumes **the shift's own conversation by id** (`claude --resume <recorded session> -p`) — one unbroken thread in the terminal and the IDE extension alike — degrading per attempt to `claude --continue -p` and last to a fresh `claude -p` in case the conversation itself is what broke. `NIGHTSHIFT_WATCH_AGENT="claude -p"` makes every revival a fresh session instead |
 | `NIGHTSHIFT_STALL_MAX` | by default a stuck agent is held and red-flagged in the shift log, never clocked out; set `=N` to clock the shift out after N stuck attempts. The foreman honors the same knob for its loop (`--stall N` is the CLI form) |
-| `NIGHTSHIFT_NOTIFY_CMD` | shift-end ping; runs with `$NIGHTSHIFT_SUMMARY` set (e.g. `say "$NIGHTSHIFT_SUMMARY"`) |
+| `NIGHTSHIFT_NOTIFY_CMD` | shift-end ping; runs with `$NIGHTSHIFT_SUMMARY` set (e.g. `say "$NIGHTSHIFT_SUMMARY"`). The watchman rings it too — once per outage — when a dead session could not be revived: the one night event that needs you. A successful revival never pages; it lands as a notice in `parking-lot.md` with the thread's resume command and deep links |
 
 Every rule above is **shift-scoped**: it applies while `.nightshift/punch-list.md` has an open
 `- [ ]` and the gate has not yet ended the shift. With no punch list, or once the last box is
@@ -239,9 +270,9 @@ auto-clock-out after N stuck attempts.
 
 ## Recommended layout
 
-nightshift works in-place on any repo — state is gitignored and versioned in its own local
-receipts repo, so your project history stays clean either way. For hard separation, run it from a
-plain workspace folder that contains your repo:
+nightshift works in-place on any repo — state is gitignored, and can be versioned in its own
+local receipts repo if you opt in at setup, so your project history stays clean either way. For
+hard separation, run it from a plain workspace folder that contains your repo:
 
 ```text
 my-project/            ← plain folder, not a repo — open Claude Code here

--- a/adapters/watchman.sh
+++ b/adapters/watchman.sh
@@ -10,7 +10,7 @@
 #
 #   watchman.sh [--project DIR] [--interval MIN] [--agent CMD] [--max-wakes N]
 #
-#   --interval  minutes between wakes (default $NIGHTSHIFT_WATCH, else 20; 0 exits immediately —
+#   --interval  minutes between wakes (default $NIGHTSHIFT_WATCH, else 10; 0 exits immediately —
 #               the "disabled" spelling)
 #   --agent     the resume command. Default: the SHIFT'S OWN conversation, by id — the hooks
 #               record the first working session into .nightshift/.shift-session, and the
@@ -31,17 +31,29 @@
 #   4. quitting time passed                          -> one clock-out spawn, then down
 #   5. clean session end (.nightshift/.session-end)  -> down; the owner closed it on purpose
 #
-# Liveness is a ladder, not a guess — revival needs strong positive evidence of death, because
-# the one truly harmful failure is spawning a second agent beside a living one (a resumed id
-# APPENDS to the same session; two writers interleave):
-#   1. the shift's transcript moved since last wake  -> alive (a session streams every turn)
-#   2. any project file moved                        -> alive (work that writes files)
-#   3. interrupt marker in the transcript tail       -> owner pressed Esc; stand by
-#   4. recorded pid alive (start time verified)      -> tail shows "API Error"? the 500 wedge:
-#                                                       alive but errored, nobody home — revive.
-#                                                       No error -> long silent work; stand by
-#   5. no pid recorded, a claude process in project  -> uncertain; stand by (conservative)
-#   6. none of the above                             -> dead; revive
+# Liveness is a ladder, session-first — revival needs strong positive evidence of death,
+# because the one truly harmful failure is spawning a second agent beside a living one (a
+# resumed id APPENDS to the same session; two writers interleave). Only the session's own
+# signals testify; project files never vote — a detached loop, a build, or a sync writing
+# files can neither mute the owner's Esc nor mask a dead session as alive:
+#   1. interrupt marker in the transcript tail       -> owner pressed Esc; stand by
+#   2. the shift's transcript moved since last wake  -> alive (a session streams every turn)
+#   3. recorded pid alive (start time verified)      -> transcript's last word is the host's own
+#                                                       API-error event? the 500 wedge: alive but
+#                                                       errored, nobody home — revive.
+#                                                       Otherwise -> long silent work; stand by
+#   4. `claude agents --json` (the host's roster)    -> id present: alive, wedge rule as above —
+#                                                       it even rescues a stale recorded pid;
+#                                                       a clean roster without it: dead; revive
+#   5. pid provably dead, or roster without the id   -> dead; revive
+#   6. neither oracle answered                       -> a claude process working in the project
+#                                                       stands it by; else dead; revive
+#   7. no identity recorded at all                   -> transcript ends in the error -> the
+#                                                       wedge again (a 500 can land before the
+#                                                       first tool call records identity;
+#                                                       --continue resumes that conversation);
+#                                                       a claude process in the project stands
+#                                                       it by; else dead; revive
 # Every retry attempt re-runs the whole ladder first — a site that comes back to life mid-wake
 # is left alone — and each failed attempt re-baselines the sentinel so its own transcript writes
 # never read as site life.
@@ -55,18 +67,19 @@
 # directory (tests use it).
 #
 # API outages: per wake, up to 3 spawn attempts spaced by $NIGHTSHIFT_WATCH_RETRY (default
-# "30 120" seconds). Wakes that fail entirely back the interval off — double per consecutive
-# failure, capped at 8x — so a dead API costs a handful of logged attempts, not one every tick.
+# "30 120" seconds). A wake that fails entirely just waits for the next one — the watchman
+# knocks every interval, all night, until the API answers.
 # Exit: 0 stood down honestly · 1 usage/lock · 7 wake cap (tests).
 set -u
 
 PROJECT="$PWD"
-INTERVAL_MIN="${NIGHTSHIFT_WATCH:-20}"
+INTERVAL_MIN="${NIGHTSHIFT_WATCH:-10}"
 AGENT="${NIGHTSHIFT_WATCH_AGENT:-claude --continue -p}"
 AGENT_IS_DEFAULT=1
 [ -z "${NIGHTSHIFT_WATCH_AGENT:-}" ] || AGENT_IS_DEFAULT=0
 MAX_WAKES=0
 RETRY_SPACING="${NIGHTSHIFT_WATCH_RETRY:-30 120}"
+NOTIFY="${NIGHTSHIFT_NOTIFY_CMD:-}" # the same bell the morning whistle rings; unset = silent
 
 usage() {
   awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
@@ -151,17 +164,27 @@ rung_label() { # morning-readable name for the rung, mirrors rung_agent
 # Clock-out spawns take the strongest single rung: the recorded conversation, else --continue.
 resolve_agent() { rung_agent 1 2; }
 
-PROMPT="Resume the nightshift. Read .nightshift/punch-list.md and work its open items per the contract, one at a time; run the item gate before each commit; tick what you finish. Leave pushing to the owner unless the punch list says otherwise. Park owner decisions in parking-lot.md. Stop only when every box is ticked or a stop-work order exists."
+# A resumed conversation carries its own context — the thread IS the instruction, and the gate
+# does the enforcing. Its order is one line: you were cut off, keep going. Only the
+# fresh-session fallback, which starts empty, gets the full pointer at the punch list. Both are
+# the owner's to word (rules file keys: revivalPrompt, freshRevivalPrompt).
+PROMPT_RESUME="${NIGHTSHIFT_REVIVAL_PROMPT:-You were cut off mid-work by an outage or a crash — not by the owner. Pick up exactly where you left off and continue.}"
+PROMPT_FRESH="${NIGHTSHIFT_FRESH_PROMPT:-Resume the nightshift. Read .nightshift/punch-list.md and work its open items per the contract, one at a time; run the item gate before each commit; tick what you finish. Leave pushing to the owner unless the punch list says otherwise. Park owner decisions in parking-lot.md. Stop only when every box is ticked or a stop-work order exists.}"
+
+# Resumed rungs get the short order; the fresh rung gets the map. Attempts mirror rung_agent.
+rung_prompt() { # $1 attempt, $2 total attempts this wake
+  if [ "$1" -ge "$2" ] && [ "$2" -gt 1 ]; then printf '%s' "$PROMPT_FRESH"; else printf '%s' "$PROMPT_RESUME"; fi
+}
 
 # One spawn attempt; the resumed session may legitimately run for hours. shellcheck disable:
 # $AGENT is an owner-provided command line; word-splitting is intended, as in foreman.
-spawn() { # $1 optionally overrides the agent for this one attempt
-  local a="${1:-$AGENT}"
+spawn() { # $1 optionally overrides the agent for this one attempt; $2 the order for its rung
+  local a="${1:-$AGENT}" p="${2:-$PROMPT_RESUME}"
   # NIGHTSHIFT_REVIVAL marks the child for the hooks: a revival session ending is never the
   # owner's hand on the door — without the mark, the worker's own exit would write .session-end
   # under the recorded id and stand the watchman down mid-outage.
   # shellcheck disable=SC2086
-  NIGHTSHIFT_REVIVAL=1 $a "$PROMPT" >/dev/null 2>&1
+  NIGHTSHIFT_REVIVAL=1 $a "$p" >/dev/null 2>&1
 }
 
 # The transcript the tells read: the shift's own, recorded by the hooks; the newest in the
@@ -178,26 +201,38 @@ resolve_transcript() {
   printf '%s' "$latest"
 }
 
-# The Esc tell: an interrupt marker in the transcript tail means the owner paused the session on
-# purpose. Only the tail — an interrupt mid-history with work after it is a session that already
-# moved on.
+# The Esc tell: the owner's interrupt matters only as the transcript's LAST WORD — the same
+# rule as the wedge. An interrupt the owner already resumed past has newer conversation events
+# after it and is history, not a pause; a real death right after such a resume must read as
+# death. Trailing bookkeeping lines are not conversation and cannot mask the marker.
 owner_paused() {
   local t
   t="$(resolve_transcript)"
   [ -n "$t" ] || return 1
-  tail -n 25 "$t" 2>/dev/null | grep -q "Request interrupted by user"
+  tail -n 25 "$t" 2>/dev/null | awk '
+    /[^\\]"type"[[:space:]]*:[[:space:]]*"(user|assistant)"/ {
+      esc = /Request interrupted by user/
+    }
+    END { exit esc ? 0 : 1 }'
 }
 
-# The wedge tell: Claude Code writes API failures verbatim into the transcript ("API Error: 500
-# Internal server error", "529 Overloaded", "Connection closed mid-response"). An error at the
-# tail of a quiet transcript whose process still lives is a session sitting at an errored prompt
-# with nobody there to press retry. The [^\\] guard skips the escaped quote of a session merely
-# TALKING about API errors — only the host's own event starts the JSON string with the phrase.
+# The wedge tell: Claude Code records an API failure as its own synthetic assistant event,
+# flagged "isApiErrorMessage":true at the top level — an owner pasting "API Error: 500" into a
+# prompt carries no such field, and prose quoting the field arrives with its quotes escaped,
+# which the [^\\] guard skips. The wedge is the session sitting at that errored prompt NOW, so
+# the flag must be on the LAST conversation event (user or assistant): anything after it —
+# a retry, an answer, the owner's next prompt — means somebody already acted, and a session
+# whose owner is awake at the keyboard is not the watchman's to touch. Trailing bookkeeping
+# lines (summaries, snapshots) are not conversation and cannot mask the wedge.
 errored_tail() {
   local t
   t="$(resolve_transcript)"
   [ -n "$t" ] || return 1
-  tail -n 25 "$t" 2>/dev/null | grep -q '[^\\]"API Error:'
+  tail -n 25 "$t" 2>/dev/null | awk '
+    /[^\\]"type"[[:space:]]*:[[:space:]]*"(user|assistant)"/ {
+      wedge = /[^\\]"isApiErrorMessage"[[:space:]]*:[[:space:]]*true/
+    }
+    END { exit wedge ? 0 : 1 }'
 }
 
 # Primary pulse: a live session streams every turn into its transcript, even when the work
@@ -206,13 +241,6 @@ transcript_pulse() {
   local t
   t="$(resolve_transcript)"
   [ -n "$t" ] && [ "$t" -nt "$SENTINEL" ]
-}
-
-site_moved() {
-  # -type f: a directory's mtime moves whenever anything inside it is created or removed — the
-  # watchman's own bookkeeping would read as site life. Files are the signal, directories noise.
-  find "$PROJECT" -path "$NS/.watchman*" -prune -o -type f -newer "$SENTINEL" -print 2>/dev/null |
-    grep -q .
 }
 
 # The process witness. 0: the recorded process is alive — pid checked with kill -0 and the start
@@ -248,8 +276,58 @@ project_has_claude() {
   return 1
 }
 
-# Re-evaluated before every retry attempt: an honest ending arriving, the site coming back to
-# life, or the owner acting mid-wake cancels the remaining attempts. Empty means revival is
+# The registry witness: `claude agents --json` is the host's own roster of every live session,
+# interactive and background. The recorded id present is the host saying the shift is alive; a
+# clean roster without it is the host saying it is gone. 0 present · 1 absent · 2 no record, or
+# a CLI without the command — which proves nothing.
+registry_state() {
+  local sid out
+  sid="$(shift_session_id)"
+  [ -n "$sid" ] || return 2
+  out="$(claude agents --json 2>/dev/null)" || return 2
+  case "$out" in \[*) ;; *) return 2 ;; esac
+  printf '%s' "$out" | grep -qF "\"$sid\"" && return 0
+  return 1
+}
+
+# The verdict, session-first. The session's own signals decide — the owner's Esc above all,
+# then the shift's transcript, then its process, then the host's registry. Project files never
+# vote: folder noise (a detached loop, a build, a sync) must never mute the owner's Esc, and
+# must never mask a dead session as alive.
+site_verdict() { # prints: esc | alive | silent | wedge | tabs | dead
+  local sid ps rg
+  if owner_paused; then printf 'esc'; return; fi
+  if transcript_pulse; then printf 'alive'; return; fi
+  sid="$(shift_session_id)"
+  if [ -n "$sid" ]; then
+    shift_process_alive
+    ps=$?
+    if [ "$ps" -eq 0 ]; then
+      if errored_tail; then printf 'wedge'; else printf 'silent'; fi
+      return
+    fi
+    registry_state
+    rg=$?
+    if [ "$rg" -eq 0 ]; then
+      # The pid may be stale or unrecorded, but the host lists the session — alive.
+      if errored_tail; then printf 'wedge'; else printf 'silent'; fi
+      return
+    fi
+    if [ "$ps" -eq 1 ] || [ "$rg" -eq 1 ]; then printf 'dead'; return; fi
+    # Identity recorded but no oracle answered: the conservative reading.
+    if project_has_claude; then printf 'tabs'; return; fi
+    printf 'dead'
+    return
+  fi
+  # No identity recorded — a 500 can land before the first tool call writes one. The newest
+  # conversation ending in the host's error event is the wedge; --continue resumes it.
+  if errored_tail; then printf 'wedge'; return; fi
+  if project_has_claude; then printf 'tabs'; return; fi
+  printf 'dead'
+}
+
+# Re-evaluated before every retry attempt: an honest ending arriving, the session coming back
+# to life, or the owner acting mid-wake cancels the remaining attempts. Empty means revival is
 # still warranted.
 hold_reason() {
   if [ -f "$NS/STOP" ]; then printf 'stop-work order'; return; fi
@@ -257,38 +335,37 @@ hold_reason() {
   if [ "$(open_boxes)" -eq 0 ]; then printf 'all boxes ticked'; return; fi
   if deadline_passed; then printf 'deadline passed'; return; fi
   if [ -f "$NS/.session-end" ]; then printf 'clean session end'; return; fi
-  if transcript_pulse || site_moved; then printf 'site activity'; return; fi
-  if owner_paused; then printf 'owner Esc'; return; fi
-  shift_process_alive
-  case $? in
-    0) errored_tail || printf 'live shift process' ;;
-    2) if project_has_claude; then printf 'a live claude session in the project'; fi ;;
+  case "$(site_verdict)" in
+    alive) printf 'session activity' ;;
+    esc) printf 'owner Esc' ;;
+    silent) printf 'live shift session' ;;
+    tabs) printf 'a live claude session in the project' ;;
   esac
 }
 
 log_line "watchman armed · every ${INTERVAL_MIN}m"
 : >"$SENTINEL"
 wake=0
-misses=0
 standby_prev=""
+down_notified=0
 
 # NIGHTSHIFT_WATCH_SLEEP overrides the base sleep in seconds — the test suite's speed lever.
 BASE_SLEEP="${NIGHTSHIFT_WATCH_SLEEP:-$((INTERVAL_MIN * 60))}"
 
 while :; do
-  sleep $((BASE_SLEEP * (misses < 3 ? 1 << misses : 8)))
+  sleep "$BASE_SLEEP"
   wake=$((wake + 1))
 
   if [ -f "$NS/STOP" ]; then log_line "watchman: stop-work order — standing down"; exit 0; fi
   if [ -f "$NS/.ended" ] || [ ! -f "$PUNCH" ]; then exit 0; fi
   if [ "$(open_boxes)" -eq 0 ]; then
     log_line "watchman: every box ticked but the shift never clocked out — spawning the clock-out"
-    spawn "$(resolve_agent)" || true
+    spawn "$(resolve_agent)" "$(rung_prompt 1 2)" || true
     exit 0
   fi
   if deadline_passed; then
     log_line "watchman: quitting time passed with the site dead — spawning the clock-out"
-    spawn "$(resolve_agent)" || true
+    spawn "$(resolve_agent)" "$(rung_prompt 1 2)" || true
     exit 0
   fi
   if [ -f "$NS/.session-end" ]; then
@@ -296,43 +373,35 @@ while :; do
     exit 0
   fi
 
-  # The liveness ladder. Revival needs strong positive evidence of death — the one truly harmful
-  # failure is a second agent beside a living one, so every uncertain reading stands by.
-  if transcript_pulse || site_moved; then
-    misses=0
-    standby_prev=""
-  else
-    verdict=""
-    if owner_paused; then
-      # Esc means stop. Stand by rather than down: if the owner resumes and a 500 kills it
-      # later, the next quiet wake will find an errored tail, not an interrupt, and revive.
-      verdict="esc"
-    else
-      shift_process_alive
-      case $? in
-        0) if errored_tail; then verdict="wedge"; else verdict="silent"; fi ;;
-        2) if project_has_claude; then verdict="tabs"; fi ;;
-      esac
-    fi
-    case "$verdict" in
+  # The liveness ladder, session-first (site_verdict). Revival needs strong positive evidence
+  # of death — the one truly harmful failure is a second agent beside a living one, so every
+  # uncertain reading stands by. Esc is read before everything else: if the owner resumes and a
+  # 500 kills it later, the next wake finds an errored tail, not an interrupt, and revives.
+  verdict="$(site_verdict)"
+  case "$verdict" in
+      alive)
+        standby_prev=""
+        down_notified=0
+        ;;
       esc)
         [ "$standby_prev" = "esc" ] || log_line "watchman: owner pressed Esc — standing by, not resuming (STOP ends the shift; resuming re-arms)"
         standby_prev="esc"
-        misses=0
+        down_notified=0
         ;;
       silent)
-        [ "$standby_prev" = "silent" ] || log_line "watchman: shift process alive with a quiet transcript — long silent work; standing by"
+        [ "$standby_prev" = "silent" ] || log_line "watchman: the shift session is alive with a quiet transcript — long silent work; standing by"
         standby_prev="silent"
-        misses=0
+        down_notified=0
         ;;
       tabs)
         [ "$standby_prev" = "tabs" ] || log_line "watchman: a claude session is live in this project — standing by"
         standby_prev="tabs"
-        misses=0
+        down_notified=0
         ;;
-      *)
+      wedge | dead)
         standby_prev=""
-        [ "$verdict" != "wedge" ] || log_line "watchman: probable wedge — shift process alive at an errored prompt; reviving its conversation"
+        sid="$(shift_session_id)"
+        [ "$verdict" != "wedge" ] || log_line "watchman: probable wedge — a session sits at an errored prompt with nobody there; reviving its conversation"
         attempt=0
         revived=1
         aborted=""
@@ -351,7 +420,7 @@ while :; do
             fi
           fi
           log_line "watchman: site quiet ${INTERVAL_MIN}m+ with open boxes — resume attempt $attempt ($(rung_label "$attempt" "$total"))"
-          if spawn "$(rung_agent "$attempt" "$total")"; then
+          if spawn "$(rung_agent "$attempt" "$total")" "$(rung_prompt "$attempt" "$total")"; then
             revived=0
             break
           fi
@@ -361,18 +430,30 @@ while :; do
           [ -n "$spacing" ] || break
           sleep "$spacing"
         done
+        # A successful revival is morning news, not a page: it lands in the parking lot — the
+        # file the owner reads — with the thread's handles. The page is reserved for the one
+        # night event that needs the owner: a dead session no attempt could bring back, rung
+        # once per outage, not once per wake.
         if [ "$revived" -eq 0 ]; then
-          misses=0
-          log_line "watchman: resumed session returned — re-checking next wake"
-        elif [ -n "$aborted" ]; then
-          misses=0
-        else
-          misses=$((misses + 1))
-          log_line "watchman: all $attempt attempts failed (api down?) — backing off"
+          down_notified=0
+          if [ -n "$sid" ]; then
+            log_line "watchman: resumed session returned — the night is one thread: claude --resume $sid · vscode://anthropic.claude-code/open?session=$sid"
+            printf -- '- [notice] %s — the shift session died and the watchman revived it. One thread: claude --resume %s · cursor://anthropic.claude-code/open?session=%s · vscode://anthropic.claude-code/open?session=%s\n' \
+              "$(ts)" "$sid" "$sid" "$sid" >>"$NS/parking-lot.md"
+          else
+            log_line "watchman: resumed session returned — re-checking next wake"
+            printf -- '- [notice] %s — the shift session died and the watchman revived it (details in shift-log.md).\n' "$(ts)" >>"$NS/parking-lot.md"
+          fi
+        elif [ -z "$aborted" ]; then
+          log_line "watchman: all $attempt attempts failed (api down?) — knocking again in ${INTERVAL_MIN}m"
+          if [ -n "$NOTIFY" ] && [ "$down_notified" -eq 0 ]; then
+            down_notified=1
+            summary="nightshift: the shift session is down and revival failed — it needs you${sid:+: claude --resume $sid}"
+            NIGHTSHIFT_SUMMARY="$summary" sh -c "$NOTIFY" nightshift "$summary" >/dev/null 2>&1 || true
+          fi
         fi
         ;;
-    esac
-  fi
+  esac
 
   : >"$SENTINEL" # after all actions, so the watchman's own writes never read as site life
   if [ "$MAX_WAKES" -gt 0 ] && [ "$wake" -ge "$MAX_WAKES" ]; then exit 7; fi

--- a/hooks/clock-out-gate.sh
+++ b/hooks/clock-out-gate.sh
@@ -47,7 +47,8 @@ NOTIFIED="$NS/.notified"
 ENDED="$NS/.ended" # written when the shift actually ends; hardhat keeps the site rules armed until then
 LOG="$NS/shift-log.md"
 STALL_MAX="${NIGHTSHIFT_STALL_MAX:-0}" # 0 = hold a stalled shift, never auto-end
-STALL_WARN=3
+STALL_WARN="${NIGHTSHIFT_STALL_WARN:-3}" # rules file: stallWarnEvery
+case "$STALL_WARN" in '' | *[!0-9]*) STALL_WARN=3 ;; esac
 NOTIFY="${NIGHTSHIFT_NOTIFY_CMD:-}"
 
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
@@ -98,8 +99,8 @@ deadline_passed() {
 # Morning whistle — fires at most once per shift; $1 is the summary line.
 whistle() {
   [ -n "$NOTIFY" ] || return 0
-  [ -f "$NOTIFIED" ] && return 0
-  : >"$NOTIFIED"
+  # Exclusive create: of two sessions releasing at once, exactly one owns the whistle.
+  (set -C; : >"$NOTIFIED") 2>/dev/null || return 0
   NIGHTSHIFT_SUMMARY="$1" sh -c "$NOTIFY" nightshift "$1" >/dev/null 2>&1 || true
 }
 
@@ -149,6 +150,28 @@ record_shift_session() {
 if [ -f "$PUNCH" ] && [ "$OPEN" -gt 0 ] && [ ! -f "$ENDED" ] \
   && [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
   record_shift_session
+fi
+
+# The shift binds ONE session — the recorded one. Any other conversation in this project stops
+# freely: the night is not its business unless the owner brings it. A watchman revival carries
+# NIGHTSHIFT_REVIVAL=1 and inherits the binding even when the fresh-session fallback gave it a
+# new id — it re-claims the record so the watchman and the clean-end tell follow the living
+# thread. No parseable id keeps the conservative reading: held.
+REC="$(sed -n 1p "$NS/.shift-session" 2>/dev/null)"
+if [ -n "$REC" ] && [ -n "${SID:-}" ] && [ "$SID" != "$REC" ]; then
+  if [ "${NIGHTSHIFT_REVIVAL:-}" = "1" ]; then
+    rm -f "$NS/.shift-session"
+    record_shift_session
+  else
+    exit 0
+  fi
+fi
+
+# One writer per site from here down: the stall fingerprint, the stop/ended markers, and the
+# receipts commit are read-modify-write against shared files, and two sessions can attempt to
+# stop at once. An unlockable site is decided unlocked — the gate must answer, never queue.
+if [ -d "$NS" ] && ns_lock "$NS"; then
+  trap 'ns_unlock "$NS"' EXIT
 fi
 
 # 1. Stop-work order — honor at once; open boxes are left open on purpose (an honest snapshot).
@@ -206,7 +229,13 @@ elif [ "$attempts" -ge "$STALL_WARN" ]; then
 fi
 printf '%s\n%s\n' "$FP" "$attempts" >"$STALL"
 
-# 4. Block, and re-inject the contract so the next turn resumes the shift.
+# 4. Block, and re-inject the contract so the next turn resumes the shift. The owner may word
+# the reinjection (rules file key: clockOutMessage) — jq builds the JSON so their text cannot
+# break it; without jq the custom text is skipped, never a malformed decision.
+if [ -n "${NIGHTSHIFT_GATE_MESSAGE:-}" ] && command -v jq >/dev/null 2>&1; then
+  jq -nc --arg r "$NIGHTSHIFT_GATE_MESSAGE" '{decision:"block",reason:$r}'
+  exit 0
+fi
 cat <<'JSON'
 {"decision":"block","reason":"DO NOT STOP — the punch list (.nightshift/punch-list.md) still has open items. Work them top to bottom, ONE at a time, each to its own Verify. Per item: implement fully — no stubs, no deferrals, no 'documented for later'; effort is never a reason to defer, and this IS the focused session; run the item gate right before its commit and require it GREEN; make ONE commit; then tick the box to '- [x]'. Never fake a tick. Deletion is not completion — never remove an item or edit the contract above '## Items'. Park any decision that is genuinely the owner's in .nightshift/parking-lot.md with a sensible default chosen, and KEEP WORKING — never ask, never wait. A walkthrough cycle that finds nothing new is SUCCESS, not idleness. You may stop only when zero '- [ ]' remain, or the owner issues a stop-work order (.nightshift/STOP)."}
 JSON

--- a/hooks/hardhat.sh
+++ b/hooks/hardhat.sh
@@ -58,17 +58,6 @@ else
 fi
 [ -n "$CMD" ] || CMD="$INPUT"
 
-# Park, don't ask — during an active shift, deny AskUserQuestion so a 2:40am question
-# cannot kill the run. No active shift -> questions flow normally. (Raw grep backs up the
-# jq path so the rule holds even without jq.)
-if [ "$TOOL" = "AskUserQuestion" ] || printf '%s' "$INPUT" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"AskUserQuestion"'; then
-  if [ -f "$PUNCH" ] && [ ! -f "$ENDED" ] \
-     && grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]' "$PUNCH" 2>/dev/null; then
-    deny "BLOCKED (park, don't ask): a shift is active and the owner is asleep. Choose the most sensible production-grade default yourself, record the decision and your reasoning in .nightshift/parking-lot.md, and KEEP WORKING. The owner reviews it in the morning."
-  fi
-  exit 0
-fi
-
 # A commit message must not read as the command it mentions, so blank the message argument
 # before matching. Only that argument: scrubbing every quoted span would also hide a genuinely
 # forbidden command that happens to be quoted, such as sh -c "git push".
@@ -103,6 +92,56 @@ record_shift_session() {
 }
 if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
   record_shift_session
+fi
+
+# The site rules govern the shift's own session; another conversation in the same project works
+# untouched — its questions, commits, and commands are the owner's business, not the night's. A
+# marked revival stays bound whatever id the fallback chain gave it.
+REC="$(sed -n 1p "$NS/.shift-session" 2>/dev/null)"
+if [ -n "$REC" ] && [ -n "${SID:-}" ] && [ "$SID" != "$REC" ] \
+  && [ "${NIGHTSHIFT_REVIVAL:-}" != "1" ]; then
+  exit 0
+fi
+
+# Tool rules — one knob: NIGHTSHIFT_TOOL_RULES, a JSON map of tool name -> denial message,
+# loaded by setup from .claude/nightshift-rules.json (the file the owner edits; the env is
+# what enforces, fixed at session start — only the owner sets or lifts a rule, never the
+# agent mid-run). A key's message is the denial Claude reads; an empty message lifts the
+# rule; an absent key means the default — AskUserQuestion denied so a 2:40am question cannot
+# kill the run, every other tool allowed. (sed backs up the jq path; the default holds even
+# without jq.)
+TOOL_RULES="${NIGHTSHIFT_TOOL_RULES:-}"
+rules_has() {
+  [ -n "$TOOL_RULES" ] || return 1
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$TOOL_RULES" | jq -e --arg t "$1" 'has($t)' >/dev/null 2>&1
+  else
+    printf '%s' "$TOOL_RULES" | grep -q "\"$1\"[[:space:]]*:"
+  fi
+}
+rules_msg() {
+  if command -v jq >/dev/null 2>&1; then
+    printf '%s' "$TOOL_RULES" | jq -r --arg t "$1" '.[$t] // empty' 2>/dev/null
+  else
+    printf '%s' "$TOOL_RULES" | sed -n 's/.*"'"$1"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p'
+  fi
+}
+if [ -n "$TOOL_RULES" ] && command -v jq >/dev/null 2>&1 \
+  && ! printf '%s' "$TOOL_RULES" | jq -e 'type == "object"' >/dev/null 2>&1; then
+  deny "BLOCKED: NIGHTSHIFT_TOOL_RULES is not a JSON object, so the tool rules cannot run. Re-run /nightshift:setup to rewrite it from .claude/nightshift-rules.json."
+fi
+if [ "$TOOL" = "AskUserQuestion" ] || printf '%s' "$INPUT" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"AskUserQuestion"'; then
+  if rules_has "AskUserQuestion"; then
+    m="$(rules_msg AskUserQuestion)"
+    [ -z "$m" ] || deny "$m"
+  else
+    deny "BLOCKED (park, don't ask): a shift is active and the owner is asleep. Choose the most sensible production-grade default yourself, record the decision and your reasoning in .nightshift/parking-lot.md, and KEEP WORKING. The owner reviews it in the morning."
+  fi
+  exit 0 # a permitted question is not a command; the command guards have no business with it
+fi
+if [ -n "$TOOL" ] && [ "$TOOL" != "Bash" ] && rules_has "$TOOL"; then
+  m="$(rules_msg "$TOOL")"
+  [ -z "$m" ] || deny "$m"
 fi
 
 # An unparseable owner pattern makes grep exit 2, which a plain `if` reads as "no match" — the

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -92,3 +92,27 @@ valid_ere() {
   printf '' | grep -qE "$1" 2>/dev/null
   [ "$?" -le 1 ]
 }
+
+# Cross-session mutex over one .nightshift/ — mkdir is the one atomic primitive every platform
+# here ships (macOS has no flock). The holder writes its pid inside; a lock whose holder is
+# provably dead is broken on sight, a mid-claim lock (no pid yet) is waited on, never stolen.
+# The wait is bounded because a Stop hook must never hang a session over bookkeeping: on
+# timeout the caller proceeds without the lock, and the race window is merely what it was
+# before locks existed.
+ns_lock() { # $1 = the .nightshift dir; bounded ~2s wait
+  local dir="$1/.lock.d" holder _
+  for _ in 1 2 3 4 5 6 7 8 9 10; do
+    if mkdir "$dir" 2>/dev/null; then
+      printf '%s' "$$" >"$dir/pid" 2>/dev/null || true
+      return 0
+    fi
+    holder="$(cat "$dir/pid" 2>/dev/null)"
+    case "$holder" in
+      '' | *[!0-9]*) ;;
+      *) kill -0 "$holder" 2>/dev/null || { rm -rf "$dir" 2>/dev/null; continue; } ;;
+    esac
+    sleep 0.2
+  done
+  return 1
+}
+ns_unlock() { rm -rf "$1/.lock.d" 2>/dev/null; }

--- a/skills/archive/SKILL.md
+++ b/skills/archive/SKILL.md
@@ -1,0 +1,39 @@
+---
+name: archive
+description: File the finished part of the run state into a dated archive — shipped items, the rotated journal, handled snags. The live files stay lean; the facts stay on disk.
+---
+
+Archive the finished paperwork. Work in `$CLAUDE_PROJECT_DIR`. This files records — it never
+does shift work, never ticks a box, never touches the contract.
+
+## Where it goes
+
+Everything lands in `.nightshift/archive/<YYYY-MM-DD>/` — today's date, one folder per archive
+run (create parents; re-running on the same day appends to that day's files).
+
+## What moves, what stays
+
+- **Punch list → `shipped.md`.** Move every ticked `- [x]` line under `## Items` into the
+  archive's `shipped.md` under a `## Shipped <date>` heading — that file reads as the plain
+  record of what actually landed. Open `- [ ]` items and everything above `## Items` (the
+  contract, the gates) stay exactly where they are.
+- **Shift log → the archive, whole.** Move `shift-log.md` into the folder and start a fresh one
+  with the same one-line header. The journal is mechanical; its lines belong to the dates they
+  happened.
+- **Snag log — only what's handled.** Move entries that carry a disposition (fixed, ignored,
+  answered) into the archive's `snag-log.md`. Entries still awaiting the owner stay live: an
+  open question is not history yet.
+- **Parking lot — only what's answered.** Same rule: answered entries move, unanswered stay.
+- **Work orders — only what's spent.** Orders already cut into a punch list or marked done
+  move; pending orders stay.
+
+## Timing
+
+Best between shifts. During an active shift with open boxes, say so and ask before moving
+anything — the ticked lines are the night's scoreboard, and the owner may want the morning
+review to see them in place. If the receipts repo exists (`.nightshift/.git`), commit after
+archiving so the move itself has history.
+
+## Summarize
+
+Print the archive path and one line per file moved or trimmed — and what stayed live and why.

--- a/skills/nightshift/references/nightshift-rules-template.json
+++ b/skills/nightshift/references/nightshift-rules-template.json
@@ -1,0 +1,17 @@
+{
+  "toolDeny": {
+    "AskUserQuestion": "BLOCKED (park, don't ask): a shift is active and the owner is asleep. Choose the most sensible production-grade default yourself, record the decision and your reasoning in .nightshift/parking-lot.md, and KEEP WORKING. The owner reviews it in the morning."
+  },
+  "forbiddenCommands": "",
+  "neverCommitPatterns": "",
+  "expectedEmail": "",
+  "protectedDirs": "",
+  "stallMax": 0,
+  "stallWarnEvery": 3,
+  "watchMinutes": 10,
+  "watchRetrySeconds": "30 120",
+  "notifyCommand": "",
+  "revivalPrompt": "",
+  "freshRevivalPrompt": "",
+  "clockOutMessage": ""
+}

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -25,11 +25,15 @@ they do not exist.
   is not one — the recommended layout, where the code repo sits a level below — `.nightshift/` is
   already outside every repo, so write no `.gitignore` there. Run history is the owner's; it never
   enters the project repo.
-- Give `.nightshift/` its own local-only receipts repo so state stays versioned without touching the
-  project history: if `.nightshift/.git` does not exist, `git init` inside `.nightshift/`, add a
-  `.nightshift/.gitignore` that ignores the transient markers `STOP`, `.stall`, `.notified`,
-  `deadline`, `.session-end`, `.shift-session`, `.watchman`, and `.watchman-tick`, and make one
-  initial commit. **Never add a remote to it, never push it.**
+- **Receipts repo — ask, default no.** The run state can be versioned in its own local-only git
+  repo inside `.nightshift/`, so every punch-list change and log line has history. Most people
+  don't want a git repo living inside their project, so ask — *"version the run state in a local
+  receipts repo? (never pushed, never touches your project's history)"* — and on anything but a
+  clear yes, skip it: the receipts still exist as plain files. On yes: if `.nightshift/.git` does
+  not exist, `git init` inside `.nightshift/`, add a `.nightshift/.gitignore` that ignores the
+  transient markers `STOP`, `.stall`, `.notified`, `deadline`, `.session-end`, `.shift-session`,
+  `.watchman`, `.watchman-tick`, and `.lock.d/`, and make one initial commit. **Never add a
+  remote to it, never push it.**
 
 ## 3. Gates — ask, never impose
 
@@ -47,7 +51,59 @@ placeholder. If the answer was none, leave the placeholder as-is.
 The `## Gates` block is plain markdown the owner may edit anytime — re-run `/nightshift:setup` to
 re-detect after a stack change. The contract's immutability binds the agent, not the owner.
 
-## 4. Summarize
+## 4. Permissions — the night cannot click Allow
+
+An unattended shift stalls forever on a permission prompt, and a watchman revival runs headless —
+denied means denied. Ask one question:
+
+> Overnight runs can't answer permission prompts. Enable `bypassPermissions` for this project?
+> (recommended — nightshift's guards are hooks and stay armed in every permission mode)
+
+- **Yes** → merge `{"permissions": {"defaultMode": "bypassPermissions"}}` into
+  `.claude/settings.local.json` in the project (create the file if absent; never clobber keys the
+  owner already has). Settings on disk are what revivals inherit — a mode picked at launch dies
+  with the process.
+- **No** → respect it and say the cost plainly: *"a permission prompt mid-shift freezes the night
+  until morning — if the shift stalls on one, that was tonight's trade."* Suggest the narrower
+  alternative: pre-allow just the punch list's tools (test runner, linter, git) in the same file.
+
+## 5. The rules file — every knob in one place
+
+Copy `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/nightshift-rules-template.json` to
+`.claude/nightshift-rules.json` if it does not already exist — the owner's one config file,
+defaults inline, survives plugin updates. Then load it: validate with `jq -e 'type == "object"'`
+(an invalid file is reported, never half-applied) and sync each key into the `env` block of
+`.claude/settings.local.json`, machine-escaped, never clobbering env keys that are not
+nightshift's:
+
+- `toolDeny` (object) → `NIGHTSHIFT_TOOL_RULES` (compact, via `jq -c`)
+- `forbiddenCommands` → `NIGHTSHIFT_FORBIDDEN_COMMANDS`
+- `neverCommitPatterns` → `NIGHTSHIFT_NEVER_COMMIT_PATTERNS`
+- `expectedEmail` → `NIGHTSHIFT_EXPECTED_EMAIL`
+- `protectedDirs` → `NIGHTSHIFT_PROTECTED_DIRS`
+- `stallMax` → `NIGHTSHIFT_STALL_MAX`
+- `stallWarnEvery` → `NIGHTSHIFT_STALL_WARN`
+- `watchMinutes` → `NIGHTSHIFT_WATCH`
+- `watchRetrySeconds` → `NIGHTSHIFT_WATCH_RETRY`
+- `notifyCommand` → `NIGHTSHIFT_NOTIFY_CMD`
+- `revivalPrompt` → `NIGHTSHIFT_REVIVAL_PROMPT`
+- `freshRevivalPrompt` → `NIGHTSHIFT_FRESH_PROMPT`
+- `clockOutMessage` → `NIGHTSHIFT_GATE_MESSAGE`
+
+An empty string, empty object, or `0` means "use the default": remove that env key rather than
+writing it. The env is what enforces, fixed at session start — the file is the owner's editor,
+not the agent's lever. Editing the file changes nothing by itself; the summary must say so:
+**"rules changed → re-run `/nightshift:setup`, then start a fresh session."**
+
+**Template evolution — offer, never impose.** On a re-run with the file already present,
+compare the shipped template's keys to the owner's file (`jq -r 'keys[]'` on each): offer any
+missing key with its default — "this version added `stallWarnEvery`; add it?" — and never
+touch a value the owner already has. Same posture for the contract: if the shipped punch-list
+template's contract (the text above `## Items`) has changed since the owner's copy was
+scaffolded, show the diff and offer a merge — the owner's wording wins every conflict, and a
+punch list with open boxes is never touched at all.
+
+## 6. Summarize
 
 Print what was scaffolded, whether a receipts repo was created, and the gates that were written (or
 that none were). Tell the user to draft items in `.nightshift/drafting-table.md`, promote them into

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -7,11 +7,19 @@ Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 
 ## 1. Preflight
 
+- **One shift, one agent — check before touching anything.** Read `.nightshift/.shift-session`.
+  If it records a session that is still alive — line 3's pid exists and `ps -o lstart= -p <pid>`
+  matches line 4, or the id on line 1 appears in `claude agents --json` — an agent is ALREADY
+  working this punch list. Do not start a second one beside it. Tell the owner and hand them the
+  running thread: `claude --resume <id>` for a terminal,
+  `vscode://anthropic.claude-code/open?session=<id>` for the IDE — and stop here;
+  `touch .nightshift/STOP` is the lever if they want that shift ended first. A record whose
+  process is dead is last night's leftover: fall through and clear it below.
 - **Clear every stale run-control marker first**, before anything writes a new one — last night's
   leftovers would otherwise end tonight's shift at its first stop attempt. Remove them all if
   present: `.nightshift/STOP`, `.nightshift/.stall`, `.nightshift/.notified`, `.nightshift/.ended`,
-  `.nightshift/deadline`, `.nightshift/.session-end`, `.nightshift/.shift-session`, and
-  `.nightshift/.watchman-tick`. If
+  `.nightshift/deadline`, `.nightshift/.session-end`, `.nightshift/.shift-session`,
+  `.nightshift/.watchman-tick`, and the `.nightshift/.lock.d/` directory. If
   `.nightshift/.watchman` holds a live pid, kill it — last night's watchman must not double-arm
   tonight's. A shift that reached the whistle leaves the deadline behind; keeping it means the
   gate clocks the next one out immediately, zero items done.
@@ -22,6 +30,24 @@ Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 - `.nightshift/punch-list.md` exists and has at least one open `- [ ]` under `## Items`. If not, stop
   and tell the user to run `/nightshift:setup` and add items first.
 - The working tree is clean enough to commit per item (warn if not).
+- **Rotate the journal before it becomes one.** If `.nightshift/shift-log.md` is larger than
+  ~500 KB, move it to `.nightshift/archive/<YYYY-MM-DD>/shift-log.md` and start a fresh one
+  with the same one-line header. Only the mechanical journal auto-rotates — `snag-log.md` and
+  `parking-lot.md` are the owner's review material; `/nightshift:archive` files those on the
+  owner's order.
+- **Rules drift:** if `.claude/nightshift-rules.json` exists, compare it to what this session
+  actually runs under — `jq -c '.toolDeny'` of the file against `$NIGHTSHIFT_TOOL_RULES`, and
+  each other mapped key against its env var. On any mismatch, warn once: the file changed after
+  this session's env was fixed — re-run `/nightshift:setup`, then start a fresh session, or
+  tonight runs on the old rules. Also compare the shipped template's keys against the file's
+  (`jq -r 'keys[]'` on each): keys the template has that the file lacks mean a plugin update
+  brought new knobs — say so once and point at `/nightshift:setup` to review them; never add
+  them yourself here.
+- The night cannot click Allow: if neither `.claude/settings.local.json` nor
+  `.claude/settings.json` grants frictionless permissions (`bypassPermissions` default mode or an
+  allowlist covering the gates' commands), warn once — a permission prompt mid-shift freezes the
+  night, and a headless revival is denied outright. `/nightshift:setup` offers the fix. Warn and
+  proceed; the choice stays the owner's.
 
 ## 2. Deadline — asked only when it means something
 
@@ -45,7 +71,7 @@ Unless `NIGHTSHIFT_WATCH=0`, arm it in the background:
 
 ```bash
 nohup "${CLAUDE_PLUGIN_ROOT}/adapters/watchman.sh" --project "$CLAUDE_PROJECT_DIR" \
-  --interval "${NIGHTSHIFT_WATCH:-20}" >/dev/null 2>&1 &
+  --interval "${NIGHTSHIFT_WATCH:-10}" >/dev/null 2>&1 &
 ```
 
 It revives a session that DIES mid-shift — an API outage, a crash, a killed terminal — by

--- a/tests/clock-out-gate.bats
+++ b/tests/clock-out-gate.bats
@@ -264,3 +264,98 @@ load helpers
   [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "test-shift-session" ]
   [ "$(wc -l <"$p/.nightshift/.shift-session")" -eq 4 ] # id, transcript, pid, start time
 }
+
+# ---- the shift binds one session: everyone else stops freely ----
+
+@test "another conversation's stop is not the shift's business — released" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'the-shift\n\n\n\n' >"$p/.nightshift/.shift-session"
+  run gate "$p" # this stop arrives as test-shift-session, not the-shift
+  is_release
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "the-shift" ] # record untouched
+  [ ! -f "$p/.nightshift/.ended" ] # and nothing was ended on the stranger's way out
+}
+
+@test "the recorded shift session itself is still held" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'test-shift-session\n\n\n\n' >"$p/.nightshift/.shift-session"
+  run gate "$p"
+  is_block "$output"
+}
+
+# The fresh-session fallback gives a revival a NEW id; the mark keeps it bound, and it
+# re-claims the record so the watchman follows the living thread.
+@test "a marked revival inherits the binding under a new id and re-claims the record" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'dead-old-id\n\n\n\n' >"$p/.nightshift/.shift-session"
+  run gate "$p" NIGHTSHIFT_REVIVAL=1
+  is_block "$output"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "test-shift-session" ]
+}
+
+# ---- the site lock: two sessions may stop at once; the bookkeeping must not tear ----
+
+@test "a stale lock from a dead process never blocks the gate" {
+  p="$(new_project)"
+  punch_open "$p"
+  bash -c ':' &
+  deadpid=$!
+  wait "$deadpid" 2>/dev/null || true
+  mkdir "$p/.nightshift/.lock.d"
+  printf '%s' "$deadpid" >"$p/.nightshift/.lock.d/pid"
+  run gate "$p"
+  is_block "$output"
+  [ ! -d "$p/.nightshift/.lock.d" ] # broken, taken, released
+}
+
+@test "a live foreign lock delays but never hangs the gate — and is never stolen" {
+  p="$(new_project)"
+  punch_open "$p"
+  mkdir "$p/.nightshift/.lock.d"
+  printf '%s' "$$" >"$p/.nightshift/.lock.d/pid"
+  run gate "$p"
+  is_block "$output"
+  [ "$(cat "$p/.nightshift/.lock.d/pid")" = "$$" ] # still the foreign holder's
+}
+
+# The torn read this lock exists for: both racers read the same counter, both warn, both write
+# zero. Serialized, exactly one warns and the counter lands where a sequence of two honest stop
+# attempts leaves it.
+@test "two racing stop attempts warn the stall exactly once" {
+  p="$(new_project)"
+  punch_open "$p"
+  run gate "$p" # let the gate write the real fingerprint
+  fp="$(sed -n 1p "$p/.nightshift/.stall")"
+  printf '%s\n2\n' "$fp" >"$p/.nightshift/.stall"
+  jq -nc '{hook_event_name:"Stop",session_id:"test-shift-session",transcript_path:""}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/clock-out-gate.sh" >/dev/null &
+  g1=$!
+  jq -nc '{hook_event_name:"Stop",session_id:"test-shift-session",transcript_path:""}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/clock-out-gate.sh" >/dev/null &
+  g2=$!
+  wait "$g1" "$g2" 2>/dev/null || true
+  [ "$(grep -c 'stall warning' "$p/.nightshift/shift-log.md")" -eq 1 ]
+  [ "$(sed -n 2p "$p/.nightshift/.stall")" = "1" ]
+}
+
+# The reinjected contract is the owner's to word — jq builds the JSON so their text cannot
+# break the decision.
+@test "the clock-out reinjection is the owner's to word" {
+  p="$(new_project)"
+  punch_open "$p"
+  run gate "$p" NIGHTSHIFT_GATE_MESSAGE="back to the bench — boxes are open"
+  is_block "$output"
+  printf '%s' "$output" | grep -q "back to the bench"
+}
+
+@test "the stall warning cadence is the owner's (rules file: stallWarnEvery)" {
+  p="$(new_project)"
+  punch_open "$p"
+  run gate "$p" NIGHTSHIFT_STALL_WARN=2
+  run gate "$p" NIGHTSHIFT_STALL_WARN=2
+  is_block "$output"
+  grep -q 'stall warning — 2 attempts' "$p/.nightshift/shift-log.md"
+}

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -392,3 +392,86 @@ STUB
     esac
   done
 }
+
+# ---- the site rules bind the shift's session; other conversations keep their tools ----
+
+@test "another conversation is untouched by the site rules" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'the-shift\n\n\n\n' >"$p/.nightshift/.shift-session"
+  out="$(jq -nc '{tool_name:"AskUserQuestion",tool_input:{},session_id:"helper-tab"}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ] # the question is the helper's to ask
+  out="$(jq -nc '{tool_name:"Bash",tool_input:{command:"git push origin main"},session_id:"helper-tab"}' |
+    env NIGHTSHIFT_FORBIDDEN_COMMANDS='git .*push' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ] # the owner's other tab pushes if the owner pleases
+}
+
+@test "the shift session itself still answers to the site rules" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'the-shift\n\n\n\n' >"$p/.nightshift/.shift-session"
+  out="$(jq -nc '{tool_name:"Bash",tool_input:{command:"git push origin main"},session_id:"the-shift"}' |
+    env NIGHTSHIFT_FORBIDDEN_COMMANDS='git .*push' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  is_deny "$out"
+}
+
+@test "a tool call without a session id keeps the conservative reading — rules apply" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'the-shift\n\n\n\n' >"$p/.nightshift/.shift-session"
+  run hardhat_bash "$p" "git push origin main" NIGHTSHIFT_FORBIDDEN_COMMANDS='git .*push'
+  is_deny "$output"
+}
+
+# ---- the tool rules map: one knob, per-tool messages, owner-only (env, fixed at start) ----
+
+@test "the map words the park denial per tool" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_ask "$p" NIGHTSHIFT_TOOL_RULES='{"AskUserQuestion":"park it and keep welding"}'
+  is_deny "$output"
+  printf '%s' "$output" | grep -q "park it and keep welding"
+}
+
+@test "an empty message in the map lifts the question rule" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_ask "$p" NIGHTSHIFT_TOOL_RULES='{"AskUserQuestion":""}'
+  is_allow
+}
+
+@test "a listed tool is denied with its own message; an unlisted one passes" {
+  p="$(new_project)"
+  punch_open "$p"
+  out="$(jq -nc '{tool_name:"WebSearch",tool_input:{}}' |
+    env NIGHTSHIFT_TOOL_RULES='{"WebSearch":"no browsing tonight"}' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  is_deny "$out"
+  printf '%s' "$out" | grep -q "no browsing tonight"
+  out="$(jq -nc '{tool_name:"WebFetch",tool_input:{}}' |
+    env NIGHTSHIFT_TOOL_RULES='{"WebSearch":"no browsing tonight"}' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ]
+}
+
+@test "a map that is not a JSON object denies loudly instead of waving through" {
+  p="$(new_project)"
+  punch_open "$p"
+  out="$(jq -nc '{tool_name:"WebSearch",tool_input:{}}' |
+    env NIGHTSHIFT_TOOL_RULES='not json' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  is_deny "$out"
+  printf '%s' "$out" | grep -q "NIGHTSHIFT_TOOL_RULES"
+}
+
+@test "the map's default Ask rule holds even without jq" {
+  p="$(new_project)"
+  punch_open "$p"
+  nojq="$BATS_TEST_TMPDIR/nojq-rules"
+  mkdir -p "$nojq"
+  for t in bash grep sed cat printf env sh ps dirname head tail tr awk date mkdir rm cut wc sleep kill git; do
+    command -v "$t" >/dev/null && ln -sf "$(command -v "$t")" "$nojq/$t"
+  done
+  out="$(jq -nc '{tool_name:"AskUserQuestion",tool_input:{}}' |
+    env PATH="$nojq" NIGHTSHIFT_TOOL_RULES='{"AskUserQuestion":"welded shut"}' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  is_deny "$out"
+  printf '%s' "$out" | grep -q "welded shut"
+}

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -40,3 +40,22 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
       || { echo "setup does not scaffold $t-template.md"; return 1; }
   done
 }
+
+# The rules template is the owner's whole config surface — every synced key ships in it.
+@test "the rules template is valid JSON and carries every synced key" {
+  t="$BATS_TEST_DIRNAME/../skills/nightshift/references/nightshift-rules-template.json"
+  jq -e 'type == "object"' "$t" >/dev/null
+  for k in toolDeny forbiddenCommands neverCommitPatterns expectedEmail protectedDirs \
+    stallMax stallWarnEvery watchMinutes watchRetrySeconds notifyCommand revivalPrompt freshRevivalPrompt clockOutMessage; do
+    jq -e --arg k "$k" 'has($k)' "$t" >/dev/null || { echo "template missing $k"; return 1; }
+  done
+}
+
+# Updates offer their improvements; they never overwrite the owner's words.
+@test "setup's template evolution offers, never imposes" {
+  s="$BATS_TEST_DIRNAME/../skills/setup/SKILL.md"
+  grep -qF 'offer, never impose' "$s"
+  grep -qF 'touch a value the owner already has' "$s"
+  grep -qF "wording wins every conflict" "$s"
+  grep -qF 'open boxes is never touched' "$s"
+}

--- a/tests/walkthroughs.bats
+++ b/tests/walkthroughs.bats
@@ -58,3 +58,13 @@ HUNT="$BATS_TEST_DIRNAME/../skills/hunt/SKILL.md"
   grep -q 'work-orders.md' "$BATS_TEST_DIRNAME/../skills/start/SKILL.md"
   grep -q 'work-orders.md' "$BATS_TEST_DIRNAME/../skills/setup/SKILL.md"
 }
+
+# The archive files finished paperwork only — the contract and open work are untouchable.
+@test "the archive skill moves only finished records, never the contract or open items" {
+  s="$BATS_TEST_DIRNAME/../skills/archive/SKILL.md"
+  [ -f "$s" ]
+  grep -qF 'stay exactly where they are' "$s"      # open items + contract stay
+  grep -qF 'never ticks a box' "$s"                # files paperwork, does no work
+  grep -qF 'archive/<YYYY-MM-DD>/' "$s"            # dated folders are the shape
+  grep -qF 'unanswered stay' "$s"                  # open questions are not history
+}

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -81,17 +81,17 @@ calls() { grep -c called "$P/.nightshift/agent-calls" 2>/dev/null || echo 0; }
   grep -q 'never clocked out — spawning the clock-out' "$P/.nightshift/shift-log.md"
 }
 
-@test "a live site is never resumed" {
+@test "project-file churn alone is not life — a dead site is revived through it" {
   ( while :; do touch "$P/beat"; sleep 0.15; done ) &
   toucher=$!
   run env NIGHTSHIFT_WATCH_SLEEP=1 NIGHTSHIFT_WATCH_RETRY="0 0" \
-    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
   kill "$toucher" 2>/dev/null || true
-  [ "$status" -eq 7 ]
-  [ "$(calls)" -eq 0 ]
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ] # revived through the churn, then clocked out
 }
 
-@test "an API-down agent gets exactly 3 tries per wake, then backs off" {
+@test "an API-down agent gets exactly 3 tries per wake, every wake" {
   run watch --agent "bash $BIN/fail.sh" --max-wakes 2
   [ "$status" -eq 7 ]
   [ "$(calls)" -eq 6 ]
@@ -141,6 +141,7 @@ calls() { grep -c called "$P/.nightshift/agent-calls" 2>/dev/null || echo 0; }
   # and ticks the box — proving the last retry saves the night when the transcript cannot.
   cat >"$BIN/claude" <<'STUB'
 #!/usr/bin/env bash
+if printf '%s' "$*" | grep -q '^agents'; then echo "[]"; exit 0; fi
 if printf '%s' "$*" | grep -q -- '--continue'; then
   echo continue >>.nightshift/agent-calls
   exit 1
@@ -165,7 +166,7 @@ STUB
 @test "an Esc-paused session is stood by, never resumed" {
   T="$BATS_TEST_TMPDIR/transcripts"
   mkdir -p "$T"
-  printf '{"type":"message","content":"working"}\n{"type":"message","content":"[Request interrupted by user]"}\n' >"$T/session.jsonl"
+  printf '{"type":"message","content":"working"}\n{"type":"user","content":"[Request interrupted by user]"}\n' >"$T/session.jsonl"
   run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
     "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 3
   [ "$status" -eq 7 ]
@@ -177,8 +178,8 @@ STUB
 @test "a transcript without an interrupt in its tail is revived" {
   T="$BATS_TEST_TMPDIR/transcripts"
   mkdir -p "$T"
-  printf '{"type":"message","content":"[Request interrupted by user]"}\n' >"$T/session.jsonl"
-  for i in $(seq 1 30); do printf '{"type":"message","content":"work %s"}\n' "$i" >>"$T/session.jsonl"; done
+  printf '{"type":"user","content":"[Request interrupted by user]"}\n' >"$T/session.jsonl"
+  for i in $(seq 1 30); do printf '{"type":"assistant","content":"work %s"}\n' "$i" >>"$T/session.jsonl"; done
   run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
     "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 5
   [ "$status" -eq 0 ]
@@ -190,7 +191,7 @@ STUB
 @test "the shift's own transcript decides Esc, not the newest in the project" {
   T="$BATS_TEST_TMPDIR/transcripts"
   mkdir -p "$T"
-  printf '{"type":"message","content":"[Request interrupted by user]"}\n' >"$T/shift.jsonl"
+  printf '{"type":"user","content":"[Request interrupted by user]"}\n' >"$T/shift.jsonl"
   sleep 0.01
   printf '{"type":"message","content":"other tab, still working"}\n' >"$T/other.jsonl" # newer, clean
   printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
@@ -206,7 +207,7 @@ STUB
   mkdir -p "$T"
   printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
   sleep 0.01
-  printf '{"type":"message","content":"[Request interrupted by user]"}\n' >"$T/other.jsonl" # newer!
+  printf '{"type":"user","content":"[Request interrupted by user]"}\n' >"$T/other.jsonl" # newer!
   printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
   run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
     "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 5
@@ -220,6 +221,7 @@ STUB
   cat >"$BIN/claude" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
+  agents*) echo "[]" ;;
   *--resume*) echo "resume:$1 $2" >>.nightshift/agent-calls; exit 1 ;;
   *--continue*) echo "continue" >>.nightshift/agent-calls; exit 1 ;;
   *) echo fresh >>.nightshift/agent-calls
@@ -291,12 +293,16 @@ STUB
   [ "$(grep -c 'standing by' "$P/.nightshift/shift-log.md")" -eq 1 ] # logged once, not every wake
 }
 
-# The wedge: process alive, transcript quiet, and the host's own API-error event at the tail —
-# a session sitting at an errored prompt with nobody there. This one is revived.
+# The wedge: process alive, transcript quiet, and the host's own API-error event — flagged
+# "isApiErrorMessage":true, as Claude Code writes it — as the transcript's last word. A session
+# sitting at an errored prompt with nobody there. This one is revived.
 @test "a live shift process at an errored prompt is the wedge — revived" {
   T="$BATS_TEST_TMPDIR/transcripts"
   mkdir -p "$T"
-  printf '{"type":"message","content":"working"}\n{"type":"error","content":"API Error: 500 Internal server error"}\n' >"$T/shift.jsonl"
+  printf '%s\n%s\n' \
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"working"}]}}' \
+    '{"type":"assistant","message":{"model":"<synthetic>","content":[{"type":"text","text":"API Error: 500 Internal server error"}]},"error":"server_error","isApiErrorMessage":true,"apiErrorStatus":500}' \
+    >"$T/shift.jsonl"
   start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
   printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
   run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
@@ -304,14 +310,80 @@ STUB
   [ "$status" -eq 0 ]
   [ "$(calls)" -eq 2 ]
   grep -q 'probable wedge' "$P/.nightshift/shift-log.md"
+  grep -q 'claude --resume sid-shift' "$P/.nightshift/shift-log.md" # the morning deep link
 }
 
-# A session merely TALKING about API errors is not the wedge — the escaped quote of prose
-# never matches the host's own event string.
+# A 500 can land before the first tool call records the shift's identity: no pid on file, the
+# wedged claude process alive in the project, and the newest conversation ending in the host's
+# own error event. Still the wedge — --continue resumes that very conversation. Without the
+# tell, this session would out-wait the night as "a live claude session in the project".
+@test "a 500 before any recorded identity is still the wedge — revived" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"assistant","message":{"model":"<synthetic>","content":[{"type":"text","text":"API Error: 500 Internal server error"}]},"error":"server_error","isApiErrorMessage":true,"apiErrorStatus":500}\n' >"$T/shift.jsonl"
+  cat >"$BIN/pgrep" <<'STUB'
+#!/usr/bin/env bash
+echo 999999
+STUB
+  cat >"$BIN/ps" <<'STUB'
+#!/usr/bin/env bash
+echo "/fake/bin/claude"
+STUB
+  cat >"$BIN/lsof" <<STUB
+#!/usr/bin/env bash
+echo "p999999"
+echo "n$P"
+STUB
+  chmod +x "$BIN/pgrep" "$BIN/ps" "$BIN/lsof"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ]
+  grep -q 'probable wedge' "$P/.nightshift/shift-log.md"
+}
+
+# A session merely TALKING about API errors is not the wedge — prose quoting the flag arrives
+# with its quotes escaped, and a user message carries no isApiErrorMessage field at all.
 @test "prose mentioning API errors does not read as the wedge" {
   T="$BATS_TEST_TMPDIR/transcripts"
   mkdir -p "$T"
-  printf '{"type":"message","content":"we should handle the \\"API Error: 500\\" case"}\n' >"$T/shift.jsonl"
+  printf '{"type":"user","message":{"role":"user","content":"the host flags failures with \\"isApiErrorMessage\\":true — handle the \\"API Error: 500\\" case"}}\n' >"$T/shift.jsonl"
+  start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'long silent work; standing by' "$P/.nightshift/shift-log.md"
+}
+
+# An owner pasting last night's error report as a prompt is a session with its owner AT the
+# keyboard — the pasted text is a user message, not the host's flagged event. Never the wedge.
+@test "an owner-pasted error report is not the wedge" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"user","message":{"role":"user","content":"API Error: 500 Internal server error — this killed the run last night, investigate"}}\n' >"$T/shift.jsonl"
+  start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'long silent work; standing by' "$P/.nightshift/shift-log.md"
+}
+
+# A recovered error is history, not a wedge: retry succeeded, work continued, then a long
+# silent stretch — the error is still inside the tail window but no longer the last word.
+# Spawning here would put a second writer beside a living session, the exact failure the
+# ladder exists to prevent.
+@test "an error the session already recovered from is not the wedge" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '%s\n%s\n' \
+    '{"type":"assistant","message":{"model":"<synthetic>","content":[{"type":"text","text":"API Error: 500 Internal server error"}]},"error":"server_error","isApiErrorMessage":true,"apiErrorStatus":500}' \
+    '{"type":"assistant","message":{"content":[{"type":"text","text":"back on it — running the suite"}]}}' \
+    >"$T/shift.jsonl"
   start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
   printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
   run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
@@ -369,14 +441,25 @@ STUB
 
 # ---- v0.5.2: pre-spawn re-checks and the honest retry baseline ----
 
-@test "site activity during the retry sleep cancels the remaining attempts" {
-  ( sleep 1; touch "$P/came-back" ) &
-  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="2" \
+@test "session activity during the retry sleep cancels the remaining attempts" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
+  printf 'sid-shift\n%s\n' "$T/shift.jsonl" >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in agents*) echo "[]" ;; esac
+STUB
+  chmod +x "$BIN/claude"
+  # Quiet for the first wake, then the session streams again — like a real session coming back.
+  ( sleep 1; while :; do printf '{"type":"message","content":"back"}\n' >>"$T/shift.jsonl"; sleep 0.3; done ) &
+  appender=$!
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="2" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
     "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/fail.sh" --max-wakes 1
-  wait 2>/dev/null || true
+  kill "$appender" 2>/dev/null || true
   [ "$status" -eq 7 ]
   [ "$(calls)" -eq 1 ]
-  grep -q 'site activity during retries — holding the remaining attempts' "$P/.nightshift/shift-log.md"
+  grep -q 'session activity during retries — holding the remaining attempts' "$P/.nightshift/shift-log.md"
 }
 
 # A failed resume may append its own API-error event to the shift transcript. Re-baselining
@@ -389,7 +472,7 @@ STUB
   cat >"$BIN/fail-noisy.sh" <<STUB
 #!/usr/bin/env bash
 echo called >>.nightshift/agent-calls
-printf '{"type":"error","content":"API Error: 500"}\n' >>"$T/shift.jsonl"
+printf '{"type":"assistant","message":{"model":"<synthetic>","content":[{"type":"text","text":"API Error: 500"}]},"error":"server_error","isApiErrorMessage":true,"apiErrorStatus":500}\n' >>"$T/shift.jsonl"
 exit 1
 STUB
   chmod +x "$BIN/fail-noisy.sh"
@@ -407,6 +490,7 @@ STUB
   cat >"$BIN/claude" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
+  agents*) echo "[]" ;;
   *--resume*) echo resume >>.nightshift/agent-calls; exit 1 ;;
   *--continue*) echo continue >>.nightshift/agent-calls; exit 1 ;;
   *) echo fresh >>.nightshift/agent-calls
@@ -432,6 +516,7 @@ STUB
   cat >"$BIN/claude" <<'STUB'
 #!/usr/bin/env bash
 case "$*" in
+  agents*) echo "[]" ;;
   *--resume*) echo resume >>.nightshift/agent-calls
      awk 'BEGIN{d=0} !d && /^- \[ \]/{sub(/\[ \]/,"[x]");d=1} {print}' .nightshift/punch-list.md >.nightshift/pl.tmp
      mv .nightshift/pl.tmp .nightshift/punch-list.md ;;
@@ -457,4 +542,138 @@ STUB
   printf '{"reason":"exit","session_id":"right-id"}' |
     NIGHTSHIFT_REVIVAL=1 CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
   [ ! -f "$p/.nightshift/.session-end" ]
+}
+
+# ---- session-first: folder noise never mutes the owner or masks a death ----
+
+# The bug the dogfood caught: a detached loop writing project files muted the Esc
+# acknowledgment forever. The owner's signal is read FIRST now.
+@test "Esc is acknowledged even while project files churn" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n{"type":"user","content":"[Request interrupted by user]"}\n' >"$T/shift.jsonl"
+  start="$(ps -o lstart= -p $$ | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+  printf 'sid-shift\n%s\n%s\n%s\n' "$T/shift.jsonl" "$$" "$start" >"$P/.nightshift/.shift-session"
+  ( while :; do touch "$P/detached-writer"; sleep 0.15; done ) &
+  toucher=$!
+  run env NIGHTSHIFT_WATCH_SLEEP=1 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+  kill "$toucher" 2>/dev/null || true
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'owner pressed Esc — standing by' "$P/.nightshift/shift-log.md"
+}
+
+@test "a dead shift is revived even while a detached writer churns the project" {
+  T="$BATS_TEST_TMPDIR/transcripts"
+  mkdir -p "$T"
+  printf '{"type":"message","content":"working"}\n' >"$T/shift.jsonl"
+  bash -c ':' &
+  deadpid=$!
+  wait "$deadpid" 2>/dev/null || true
+  printf 'sid-shift\n%s\n%s\n\n' "$T/shift.jsonl" "$deadpid" >"$P/.nightshift/.shift-session"
+  ( while :; do touch "$P/detached-writer"; sleep 0.15; done ) &
+  toucher=$!
+  run env NIGHTSHIFT_WATCH_SLEEP=1 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS="$T" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  kill "$toucher" 2>/dev/null || true
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ] # revived despite the churn, then clocked out
+}
+
+# The registry witness: `claude agents --json` is the host's own roster.
+@test "the registry listing the recorded session stands the watchman by" {
+  printf 'sid-shift\n\n\n\n' >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  agents*) printf '[{"sessionId":"sid-shift","kind":"interactive"}]\n' ;;
+esac
+STUB
+  chmod +x "$BIN/claude"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 3
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'long silent work; standing by' "$P/.nightshift/shift-log.md"
+}
+
+@test "a clean roster without the recorded session is death — revived" {
+  printf 'sid-shift\n\n\n\n' >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  agents*) printf '[{"sessionId":"someone-else"}]\n' ;;
+esac
+STUB
+  chmod +x "$BIN/claude"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 2 ]
+}
+
+# A stale recorded pid must not read as death while the host still lists the session.
+@test "the registry rescues a stale pid — listed session is alive, not revived over" {
+  bash -c ':' &
+  deadpid=$!
+  wait "$deadpid" 2>/dev/null || true
+  printf 'sid-shift\n\n%s\n\n' "$deadpid" >"$P/.nightshift/.shift-session"
+  cat >"$BIN/claude" <<'STUB'
+#!/usr/bin/env bash
+case "$*" in
+  agents*) printf '[{"sessionId":"sid-shift","kind":"interactive"}]\n' ;;
+esac
+STUB
+  chmod +x "$BIN/claude"
+  run env PATH="$BIN:$PATH" NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 3
+  [ "$status" -eq 7 ]
+  [ "$(calls)" -eq 0 ]
+}
+
+# The revival order is the owner's to word; the default carries the contract.
+@test "the revival order is the owner's to word" {
+  cat >"$BIN/hear.sh" <<'STUB'
+#!/usr/bin/env bash
+echo called >>.nightshift/agent-calls
+printf '%s\n' "$1" >.nightshift/heard
+awk 'BEGIN{d=0} !d && /^- \[ \]/{sub(/\[ \]/,"[x]");d=1} {print}' .nightshift/punch-list.md >.nightshift/pl.tmp
+mv .nightshift/pl.tmp .nightshift/punch-list.md
+STUB
+  chmod +x "$BIN/hear.sh"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    NIGHTSHIFT_REVIVAL_PROMPT="wake up and weld" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/hear.sh" --max-wakes 5
+  [ "$status" -eq 0 ]
+  grep -q "wake up and weld" "$P/.nightshift/heard"
+}
+
+# A successful revival is morning news, not a page: it lands in the parking lot; the push is
+# reserved for the failure that needs the owner.
+@test "a revival writes a parking-lot notice and does not page the owner" {
+  wl="$BATS_TEST_TMPDIR/page.log"
+  printf 'sid-shift\n\n\n\n' >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    NIGHTSHIFT_NOTIFY_CMD="printf '%s\n' \"\$NIGHTSHIFT_SUMMARY\" >> $wl" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 4
+  [ "$status" -eq 0 ]
+  grep -q 'revived it' "$P/.nightshift/parking-lot.md"
+  grep -q 'claude --resume sid-shift' "$P/.nightshift/parking-lot.md"
+  [ ! -f "$wl" ] # no page for a night that fixed itself
+}
+
+@test "a dead session no attempt could revive pages the owner exactly once" {
+  wl="$BATS_TEST_TMPDIR/down.log"
+  printf 'sid-shift\n\n\n\n' >"$P/.nightshift/.shift-session"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" NIGHTSHIFT_WATCH_TRANSCRIPTS=/tmp/nowhere \
+    NIGHTSHIFT_NOTIFY_CMD="printf '%s\n' \"\$NIGHTSHIFT_SUMMARY\" >> $wl" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/fail.sh" --max-wakes 3
+  [ "$status" -eq 7 ]
+  [ "$(wc -l <"$wl" | tr -d ' ')" -eq 1 ] # once per outage, not once per wake
+  grep -q 'revival failed' "$wl"
+  grep -q 'claude --resume sid-shift' "$wl"
 }


### PR DESCRIPTION
Start a shift, watch the very first call come back `API Error: 500`, and go to sleep anyway: the watchman carries the night from the first error to the morning receipts, and the whole story — the error, the revival, the finished work — is one conversation opened with one click.

## What ships

- **Liveness is session-first, and only the session.** The verdict reads the owner's Esc, the shift's transcript, the recorded process, then the host's registry (`claude agents --json`). Project files never vote — a detached loop, a build, or a sync can neither mute an Esc nor mask a death.
- **Errors and interrupts count only as the transcript's last word**, read structurally from the host's own event records — a pasted error report, a retried-past 500, or an interrupt the owner already resumed past never misleads the verdict.
- **A 500 before first work still revives**, via `--continue`, even when the outage lands before the shift records its identity.
- **Revival orders match what the session knows**: a resumed conversation gets one line — cut off, continue — and only the context-free fresh-session fallback gets the full punch-list pointer. Both texts are the owner's.
- **The shift binds one session.** Other conversations in the same project chat, stop, and ask freely; start refuses to arm a second agent beside a living one and hands over the running thread instead.
- **One writer per site.** A per-site lock keeps racing stop attempts from tearing the stall counter, double-firing the whistle, or colliding in the receipts repo.
- **The owner's rules file.** `.claude/nightshift-rules.json` — copied from a shipped template, synced into env by setup — carries the per-tool denial map, every guard pattern, the cadences, the whistle, both revival orders, and the clock-out text. Env stays the enforcement surface, fixed at session start; updates offer new keys and never touch the owner's words.
- **The morning is one click away.** A revival leaves a parking-lot notice with `claude --resume` and the IDE deep links; the one event that needs the owner — a death no attempt could revive — rings the whistle instead, once per outage.
- **Setup asks the permissions question** (`bypassPermissions` recommended, written to settings so revivals inherit it), the receipts repo is opt-in, and `/nightshift:archive` files finished work into dated records.

## Verification

- 175 bats tests green, shellcheck clean, `claude plugin validate --strict` passes
- Detection verified against real Claude Code transcripts: genuine `isApiErrorMessage` events from live 500/529 sessions, interrupt markers from real Esc and Ctrl+C
- End-to-end live runs: an Esc'd session correctly stood by; a Ctrl+C'd session refused; a `kill -9`'d session read as dead and revived by the default agent, continuing the same conversation; a real 500 from a mock API endpoint firing the wedge

🤖 Generated with [Claude Code](https://claude.com/claude-code)