### PR TITLE
Release v0.6.1 — one copy

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,32 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.6.1 — one copy
+
+The rules file is the config, and it lives with everything else nightshift owns:
+`.nightshift/rules.json`, copied as-is from the shipped template by setup, read by the hooks
+directly on every tool call — an owner's edit applies from the very next action, nothing is
+synced into settings, nothing needs a restart, and deleting `.nightshift/` removes all of
+nightshift, rules included. Env vars of the matching names remain session-start overrides —
+the test suite's lever and the one-off exception, never a copy to maintain.
+
+- **The night never touches its own leash.** During a shift, the working session is denied
+  the rules file — file tools and shell commands alike, the same pattern-match honesty as
+  every guard here. A rule that must change mid-shift changes by the owner's hand and reads
+  from the next tool call.
+- **Setup migrates and cleans.** A pre-0.6.1 `.claude/nightshift-rules.json` is moved into
+  `.nightshift/` (the hooks read the old home as a fallback until then), and setup offers to
+  strip the `NIGHTSHIFT_*` env keys an earlier version synced. The receipts-repo question is
+  asked neutrally: its default is no, and it is never presented as recommended.
+- **The watchman reads its own cadence** (`watchMinutes`, `watchRetrySeconds`,
+  `notifyCommand`, both revival orders) from the rules file at arm time; start no longer
+  passes an interval.
+- **No hidden defaults.** Every shipped value — both revival orders, the clock-out
+  reinjection, the park message, the cadences — lives visibly in the template setup copies;
+  the hooks carry no fallback copies. A missing or unreadable rules file fails loudly and
+  closed: the gate still blocks, questions stay parked, the watchman refuses to arm — each
+  naming the repair.
+
 ## v0.6.0 — the 500 night, start to finish
 
 Start a shift, watch the very first call come back `API Error: 500`, and go to sleep anyway:
@@ -49,7 +75,7 @@ one click.
   trade plainly. nightshift's guards are hooks and stay armed in every permission mode.
 - **One rules file, every decision the owner's.** Setup copies a ready template to
   `.claude/nightshift-rules.json` and syncs it into the env block — clean JSON to edit, the
-  ugly escaping machine-written. It carries the per-tool denial map (`toolDeny`: your message
+  escaping machine-written. It carries the per-tool denial map (`toolDeny`: your message
   per tool, an empty message lifts a rule, absent keys keep the defaults), every guard
   pattern, the stall cap and warning cadence, the watch cadence, the morning whistle, the
   watchman's revival orders, and the gate's clock-out reinjection. The env stays the enforcement surface, fixed at session start — the file is the

--- a/README.md
+++ b/README.md
@@ -73,7 +73,11 @@ at a serious product — not a half-done prototype full of shortcuts.
   works that shift: it wakes every 10 minutes, and when the site is quiet it resumes **the
   shift's own conversation by id** — hours of context, decisions, where it stood mid-item — so
   the morning transcript is one unbroken thread: the 500, the revival, and everything after, in
-  the terminal or your IDE's extension alike. (The chain degrades honestly: the recorded
+  the terminal or your IDE's extension alike. (One platform limitation: an already-open
+  conversation view cannot auto-update while a headless revival appends to it. nightshift hands
+  you the reopen instead — the revival leaves its resume command and deep links in the parking
+  lot, and any of them shows the full thread. An issue is open upstream to close the gap:
+  [anthropics/claude-code#82655](https://github.com/anthropics/claude-code/issues/82655).) (The chain degrades honestly: the recorded
   conversation first, `claude --continue` next, a fresh session last — the punch list on disk is
   enough for any of them.) Reviving needs strong positive evidence of death, never "looks
   stuck": the shift records its own session id, transcript, and process at first work, and the
@@ -229,12 +233,13 @@ Everything is named from a real construction site — learn one term, guess the 
 
 Zero-config by default; every knob below is off until you set it (unset ⇒ the default described).
 
-**One file drives them all:** setup copies a ready template to `.claude/nightshift-rules.json` —
-edit it in clean JSON (the tool-deny map, the guard patterns, the cadence, even the watchman's
-revival prompt and the gate's clock-out text), re-run `/nightshift:setup`, start a fresh session.
-Setup machine-writes your file into the env block below; the env is what enforces, fixed at
-session start — so only you can set or lift a rule, never the agent mid-run. Start warns when
-the file has drifted from the running session's rules.
+**One file drives them all:** setup copies a ready template to `.nightshift/rules.json` —
+clean JSON, yours to edit: the tool-deny map, the guard patterns, the cadences, the watchman's
+revival orders, the gate's clock-out text. The hooks read the file directly on every tool call,
+so an edit applies from your very next action — no sync, no restart, no second copy. During a
+shift the file itself is guarded: the session working the night is denied touching it, so only
+you set or lift a rule. The env vars below remain as session-start overrides for tests and
+one-off exceptions.
 
 | Env var | Effect |
 |---|---|
@@ -243,7 +248,7 @@ the file has drifted from the running session's rules.
 | `NIGHTSHIFT_FRESH_PROMPT` | your wording for the **fresh-session** fallback's order — the only rung that starts with no context, so its default points at the punch list (rules file: `freshRevivalPrompt`) |
 | `NIGHTSHIFT_GATE_MESSAGE` | your wording for the clock-out gate's DO-NOT-STOP reinjection (rules file: `clockOutMessage`) |
 | `NIGHTSHIFT_STALL_WARN` | hold-mode stall warning cadence — warn every N stuck stop attempts (rules file: `stallWarnEvery`; default 3) |
-| `NIGHTSHIFT_FORBIDDEN_COMMANDS` | deny any Bash command matching this `grep -E` pattern during a shift — your own site rules. `git .*push` keeps pushing yours for the night (the `.*` also catches `git -c k=v push`); `rm -rf\|docker\|terraform` fences the rest. Env vars are fixed at session start, so only you can set or lift a rule — never the agent mid-run |
+| `NIGHTSHIFT_FORBIDDEN_COMMANDS` | deny any Bash command matching this `grep -E` pattern during a shift — your own site rules. `git .*push` keeps pushing yours for the night (the `.*` also catches `git -c k=v push`); `rm -rf\|docker\|terraform` fences the rest. The rules file is guarded during a shift, so only you set or lift a rule — never the agent working the night |
 | `NIGHTSHIFT_EXPECTED_EMAIL` | during a shift, deny commits authored under any other identity |
 | `NIGHTSHIFT_PROTECTED_DIRS` | during a shift, space/pipe-separated dir names never to `git add/commit/tag/remote` |
 | `NIGHTSHIFT_NEVER_COMMIT_PATTERNS` | during a shift, deny a commit whose diff matches this `grep -E` pattern — the index, widened to the working tree when the command stages implicitly (`git commit -a`) |

--- a/adapters/watchman.sh
+++ b/adapters/watchman.sh
@@ -10,8 +10,8 @@
 #
 #   watchman.sh [--project DIR] [--interval MIN] [--agent CMD] [--max-wakes N]
 #
-#   --interval  minutes between wakes (default $NIGHTSHIFT_WATCH, else 10; 0 exits immediately —
-#               the "disabled" spelling)
+#   --interval  minutes between wakes (default: the rules file's watchMinutes, overridable by
+#               $NIGHTSHIFT_WATCH; 0 exits immediately — the "disabled" spelling)
 #   --agent     the resume command. Default: the SHIFT'S OWN conversation, by id — the hooks
 #               record the first working session into .nightshift/.shift-session, and the
 #               revival is "claude --resume <that id> -p", one unbroken thread in the terminal
@@ -66,20 +66,22 @@
 # apology, a lost night costs the night. $NIGHTSHIFT_WATCH_TRANSCRIPTS overrides the transcript
 # directory (tests use it).
 #
-# API outages: per wake, up to 3 spawn attempts spaced by $NIGHTSHIFT_WATCH_RETRY (default
-# "30 120" seconds). A wake that fails entirely just waits for the next one — the watchman
-# knocks every interval, all night, until the API answers.
+# API outages: per wake, up to 3 spawn attempts spaced by the rules file's watchRetrySeconds
+# (shipped "30 120"; $NIGHTSHIFT_WATCH_RETRY overrides). A wake that fails entirely just waits
+# for the next one — the watchman knocks every interval, all night, until the API answers.
 # Exit: 0 stood down honestly · 1 usage/lock · 7 wake cap (tests).
 set -u
 
+_here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
+# shellcheck source=hooks/lib.sh
+. "$_here/../hooks/lib.sh" # pure-bash path — no dirname dependency
+
 PROJECT="$PWD"
-INTERVAL_MIN="${NIGHTSHIFT_WATCH:-10}"
+INTERVAL_MIN="${NIGHTSHIFT_WATCH:-}" # resolved from the rules file once the project is known
 AGENT="${NIGHTSHIFT_WATCH_AGENT:-claude --continue -p}"
 AGENT_IS_DEFAULT=1
 [ -z "${NIGHTSHIFT_WATCH_AGENT:-}" ] || AGENT_IS_DEFAULT=0
 MAX_WAKES=0
-RETRY_SPACING="${NIGHTSHIFT_WATCH_RETRY:-30 120}"
-NOTIFY="${NIGHTSHIFT_NOTIFY_CMD:-}" # the same bell the morning whistle rings; unset = silent
 
 usage() {
   awk 'NR == 1 { next } !/^#/ { exit } { sub(/^# ?/, ""); print }' "$0"
@@ -98,11 +100,17 @@ while [ $# -gt 0 ]; do
   esac
 done
 
-case "$INTERVAL_MIN" in *[!0-9]*) printf 'watchman: --interval must be whole minutes\n' >&2; exit 1 ;; esac
-[ "$INTERVAL_MIN" -gt 0 ] || exit 0 # 0 = disabled, by design
-
 cd "$PROJECT" || { printf 'watchman: cannot cd to %s\n' "$PROJECT" >&2; exit 1; }
 PROJECT="$PWD"
+
+# One copy: the rules file is the config; a flag or env var is a session-start override. The
+# shipped values live visibly in the file setup copies — there are no fallbacks hiding here,
+# and a missing knob refuses to arm, loudly, naming the repair.
+[ -n "$INTERVAL_MIN" ] || INTERVAL_MIN="$(rule "$PROJECT" watchMinutes "")"
+case "$INTERVAL_MIN" in '' | *[!0-9]*) printf 'watchman: watchMinutes missing or not whole minutes — .nightshift/rules.json absent or incomplete; re-run /nightshift:setup\n' >&2; exit 1 ;; esac
+[ "$INTERVAL_MIN" -gt 0 ] || exit 0 # 0 = disabled, by design
+RETRY_SPACING="$(rule "$PROJECT" watchRetrySeconds "${NIGHTSHIFT_WATCH_RETRY:-}")"
+NOTIFY="$(rule "$PROJECT" notifyCommand "${NIGHTSHIFT_NOTIFY_CMD:-}")" # empty = silent, a real value
 NS="$PROJECT/.nightshift"
 PUNCH="$NS/punch-list.md"
 PIDFILE="$NS/.watchman"
@@ -168,8 +176,15 @@ resolve_agent() { rung_agent 1 2; }
 # does the enforcing. Its order is one line: you were cut off, keep going. Only the
 # fresh-session fallback, which starts empty, gets the full pointer at the punch list. Both are
 # the owner's to word (rules file keys: revivalPrompt, freshRevivalPrompt).
-PROMPT_RESUME="${NIGHTSHIFT_REVIVAL_PROMPT:-You were cut off mid-work by an outage or a crash — not by the owner. Pick up exactly where you left off and continue.}"
-PROMPT_FRESH="${NIGHTSHIFT_FRESH_PROMPT:-Resume the nightshift. Read .nightshift/punch-list.md and work its open items per the contract, one at a time; run the item gate before each commit; tick what you finish. Leave pushing to the owner unless the punch list says otherwise. Park owner decisions in parking-lot.md. Stop only when every box is ticked or a stop-work order exists.}"
+PROMPT_RESUME="$(rule "$PROJECT" revivalPrompt "${NIGHTSHIFT_REVIVAL_PROMPT:-}")"
+PROMPT_FRESH="$(rule "$PROJECT" freshRevivalPrompt "${NIGHTSHIFT_FRESH_PROMPT:-}")"
+for _req in "watchRetrySeconds:$RETRY_SPACING" "revivalPrompt:$PROMPT_RESUME" "freshRevivalPrompt:$PROMPT_FRESH"; do
+  if [ -z "${_req#*:}" ]; then
+    printf 'watchman: %s missing — .nightshift/rules.json absent or incomplete; re-run /nightshift:setup\n' "${_req%%:*}" >&2
+    log_line "watchman: rules.json is missing ${_req%%:*} — cannot arm; re-run /nightshift:setup"
+    exit 1
+  fi
+done
 
 # Resumed rungs get the short order; the fresh rung gets the map. Attempts mirror rung_agent.
 rung_prompt() { # $1 attempt, $2 total attempts this wake

--- a/hooks/clock-out-gate.sh
+++ b/hooks/clock-out-gate.sh
@@ -10,22 +10,23 @@
 # Stall guard: consecutive stop attempts with no progress are counted (progress = a tick or a
 # commit). By default a stalled shift is HELD — every 3 stuck attempts a stall warning lands
 # in the shift log and the gate keeps blocking; only STOP, done, or the deadline release.
-# Owner opt-in: NIGHTSHIFT_STALL_MAX=N auto-ends the shift (write STOP, log, release) after N
-# stuck attempts. Env is fixed at session start, so only a human can choose that.
+# Owner opt-in: stallMax N in the rules file auto-ends the shift (write STOP, log, release)
+# after N stuck attempts — the file is guarded during a shift, so only a human chooses that.
 #
 # Quitting time and the stall opt-in are a whistle, not an axe: a Stop hook can only run at
 # a stop attempt, so neither can ever interrupt work mid-item.
 #
-# Morning whistle: if NIGHTSHIFT_NOTIFY_CMD is set, any shift-ending release fires it exactly
-# once with a one-line summary (both $NIGHTSHIFT_SUMMARY and $1). Unset -> silent no-op.
+# Morning whistle: if the rules file sets notifyCommand, any shift-ending release fires it
+# exactly once with a one-line summary (both $NIGHTSHIFT_SUMMARY and $1). Empty -> silent.
 #
 # Receipts: any shift-ending release also snapshots .nightshift/ into its local receipts repo
 # (the one /nightshift:setup created). No receipts repo -> no-op; a failed commit never blocks
 # the release.
 set -u
 
+_here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
 # shellcheck source=hooks/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+. "$_here/lib.sh" # pure-bash path: no dirname, so a hostile PATH cannot unsource the helpers
 
 # The Stop payload carries the session's identity; a tty guard keeps manual runs from hanging.
 if [ -t 0 ]; then INPUT=""; else INPUT="$(cat)"; fi
@@ -46,10 +47,17 @@ STALL="$NS/.stall"
 NOTIFIED="$NS/.notified"
 ENDED="$NS/.ended" # written when the shift actually ends; hardhat keeps the site rules armed until then
 LOG="$NS/shift-log.md"
-STALL_MAX="${NIGHTSHIFT_STALL_MAX:-0}" # 0 = hold a stalled shift, never auto-end
-STALL_WARN="${NIGHTSHIFT_STALL_WARN:-3}" # rules file: stallWarnEvery
-case "$STALL_WARN" in '' | *[!0-9]*) STALL_WARN=3 ;; esac
-NOTIFY="${NIGHTSHIFT_NOTIFY_CMD:-}"
+# One copy: the rules file is the config; env vars are session-start overrides only. The
+# shipped values live visibly in the file setup copies — no fallbacks hide here. A gate whose
+# knobs are unreadable still gates (fail closed): the stall bookkeeping stands down loudly and
+# the block carries the repair.
+STALL_MAX="$(rule "$PROJECT_DIR" stallMax "${NIGHTSHIFT_STALL_MAX:-}")"
+STALL_WARN="$(rule "$PROJECT_DIR" stallWarnEvery "${NIGHTSHIFT_STALL_WARN:-}")"
+STALL_OK=1
+case "$STALL_MAX" in '' | *[!0-9]*) STALL_OK=0 ;; esac
+case "$STALL_WARN" in '' | *[!0-9]* | 0) STALL_OK=0 ;; esac
+NOTIFY="$(rule "$PROJECT_DIR" notifyCommand "${NIGHTSHIFT_NOTIFY_CMD:-}")"
+GATE_MESSAGE="$(rule "$PROJECT_DIR" clockOutMessage "${NIGHTSHIFT_GATE_MESSAGE:-}")"
 
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 log_line() { [ -d "$NS" ] && printf '%s · %s\n' "$(ts)" "$1" >>"$LOG"; }
@@ -203,40 +211,46 @@ fi
 # commit landed, captured in the fingerprint; either resets the counter. Held by default:
 # warn in the shift log every STALL_WARN stuck attempts and keep blocking. Auto-end only on
 # the owner's NIGHTSHIFT_STALL_MAX=N opt-in.
-FP="$TICKED:$(project_head)"
-prev_fp=""
-prev_n=0
-if [ -f "$STALL" ]; then
-  prev_fp="$(sed -n '1p' "$STALL")"
-  prev_n="$(sed -n '2p' "$STALL")"
-  prev_n="${prev_n:-0}"
-fi
-if [ "$prev_fp" = "$FP" ]; then
-  attempts=$((prev_n + 1))
-else
-  attempts=1
-fi
-if [ "$STALL_MAX" -gt 0 ] 2>/dev/null; then
-  if [ "$attempts" -ge "$STALL_MAX" ]; then
-    log_line "stalled — auto-ended, $attempts attempts no progress, $TICKED/$TOTAL done, items left open"
-    printf 'stalled\n' >"$STOP"
-    end_shift "stalled: $TICKED/$TOTAL done, $attempts attempts no progress"
-    exit 0
+if [ "$STALL_OK" -eq 1 ]; then
+  FP="$TICKED:$(project_head)"
+  prev_fp=""
+  prev_n=0
+  if [ -f "$STALL" ]; then
+    prev_fp="$(sed -n '1p' "$STALL")"
+    prev_n="$(sed -n '2p' "$STALL")"
+    prev_n="${prev_n:-0}"
   fi
-elif [ "$attempts" -ge "$STALL_WARN" ]; then
-  log_line "stall warning — $attempts attempts no progress, $TICKED/$TOTAL done; keeping shift open"
-  attempts=0
+  if [ "$prev_fp" = "$FP" ]; then
+    attempts=$((prev_n + 1))
+  else
+    attempts=1
+  fi
+  if [ "$STALL_MAX" -gt 0 ] 2>/dev/null; then
+    if [ "$attempts" -ge "$STALL_MAX" ]; then
+      log_line "stalled — auto-ended, $attempts attempts no progress, $TICKED/$TOTAL done, items left open"
+      printf 'stalled\n' >"$STOP"
+      end_shift "stalled: $TICKED/$TOTAL done, $attempts attempts no progress"
+      exit 0
+    fi
+  elif [ "$attempts" -ge "$STALL_WARN" ]; then
+    log_line "stall warning — $attempts attempts no progress, $TICKED/$TOTAL done; keeping shift open"
+    attempts=0
+  fi
+  printf '%s\n%s\n' "$FP" "$attempts" >"$STALL"
+else
+  log_line "stall guard down — stallMax/stallWarnEvery unreadable (.nightshift/rules.json absent or incomplete); re-run /nightshift:setup"
 fi
-printf '%s\n%s\n' "$FP" "$attempts" >"$STALL"
 
-# 4. Block, and re-inject the contract so the next turn resumes the shift. The owner may word
-# the reinjection (rules file key: clockOutMessage) — jq builds the JSON so their text cannot
-# break it; without jq the custom text is skipped, never a malformed decision.
-if [ -n "${NIGHTSHIFT_GATE_MESSAGE:-}" ] && command -v jq >/dev/null 2>&1; then
-  jq -nc --arg r "$NIGHTSHIFT_GATE_MESSAGE" '{decision:"block",reason:$r}'
+# 4. Block, and re-inject the contract so the next turn resumes the shift. The reinjection
+# text lives in the rules file (clockOutMessage) — the one copy, shipped in the template setup
+# copies; jq builds the JSON so the owner's text cannot break the decision. The block itself
+# never depends on config: an unreadable message (or no jq to embed it safely) still blocks,
+# fail closed, with the repair named.
+if [ -n "$GATE_MESSAGE" ] && command -v jq >/dev/null 2>&1; then
+  jq -nc --arg r "$GATE_MESSAGE" '{decision:"block",reason:$r}'
   exit 0
 fi
 cat <<'JSON'
-{"decision":"block","reason":"DO NOT STOP — the punch list (.nightshift/punch-list.md) still has open items. Work them top to bottom, ONE at a time, each to its own Verify. Per item: implement fully — no stubs, no deferrals, no 'documented for later'; effort is never a reason to defer, and this IS the focused session; run the item gate right before its commit and require it GREEN; make ONE commit; then tick the box to '- [x]'. Never fake a tick. Deletion is not completion — never remove an item or edit the contract above '## Items'. Park any decision that is genuinely the owner's in .nightshift/parking-lot.md with a sensible default chosen, and KEEP WORKING — never ask, never wait. A walkthrough cycle that finds nothing new is SUCCESS, not idleness. You may stop only when zero '- [ ]' remain, or the owner issues a stop-work order (.nightshift/STOP)."}
+{"decision":"block","reason":"DO NOT STOP — the punch list (.nightshift/punch-list.md) still has open items. Work them one at a time per its contract, run each item's gate, and tick honestly; park owner decisions in .nightshift/parking-lot.md and keep working. (nightshift: the full contract reinjection lives in .nightshift/rules.json clockOutMessage — unreadable here, or jq is absent; re-run /nightshift:setup.)"}
 JSON
 exit 0

--- a/hooks/hardhat.sh
+++ b/hooks/hardhat.sh
@@ -2,22 +2,24 @@
 # hardhat.sh — PreToolUse guard. Mechanical safety, zero-config core.
 #
 # One zero-config rule: AskUserQuestion is denied during an active shift — park, don't
-# ask. Every other rule is shift-scoped and opt-in — each empty by default, so an unset
-# one is skipped silently (a one-account developer configures nothing). Env vars are
-# fixed when the session starts, so only a human can set them — never the agent mid-run:
-#   NIGHTSHIFT_PROTECTED_DIRS        space/pipe-separated dir names never to git add/commit/tag/remote
-#   NIGHTSHIFT_EXPECTED_EMAIL        commits must be authored by this identity
-#   NIGHTSHIFT_NEVER_COMMIT_PATTERNS staged diff (git diff --cached) must not match this grep -E pattern
-#   NIGHTSHIFT_FORBIDDEN_COMMANDS    deny any command matching this grep -E pattern during a shift
-#                                    (the no-push recipe: set it to 'git .*push')
+# ask. Every other rule is shift-scoped and opt-in, read from the owner's rules file
+# (.nightshift/rules.json) — each empty by default, so an unset one is skipped silently:
+#   protectedDirs        space/pipe-separated dir names never to git add/commit/tag/remote
+#   expectedEmail        commits must be authored by this identity
+#   neverCommitPatterns  staged diff (git diff --cached) must not match this grep -E pattern
+#   forbiddenCommands    deny any command matching this grep -E pattern during a shift
+#                        (the no-push recipe: set it to 'git .*push')
+# An env var of the matching NIGHTSHIFT_ name overrides the file for the session; the file
+# itself is guarded during a shift, so only the owner sets or lifts a rule.
 #
 # The two commit guards read git, so they resolve the repository the commit lands in (see
 # repo_root in lib.sh) rather than assuming it is the project dir. When that repository cannot
 # be identified they deny: a guard that cannot look is never a guard that approves.
 set -u
 
+_here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
 # shellcheck source=hooks/lib.sh
-. "$(dirname "${BASH_SOURCE[0]}")/lib.sh"
+. "$_here/lib.sh" # pure-bash path: no dirname, so a hostile PATH cannot unsource the helpers
 
 INPUT="$(cat)"
 PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
@@ -25,10 +27,12 @@ NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 ENDED="$NS/.ended"
 
-PROTECTED_DIRS="${NIGHTSHIFT_PROTECTED_DIRS:-}"
-EXPECTED_EMAIL="${NIGHTSHIFT_EXPECTED_EMAIL:-}"
-NEVER_COMMIT_PATTERNS="${NIGHTSHIFT_NEVER_COMMIT_PATTERNS:-}"
-FORBIDDEN_COMMANDS="${NIGHTSHIFT_FORBIDDEN_COMMANDS:-}"
+# One copy: the rules file is the config; an env var of the matching name is a session-start
+# override (the test suite's lever), never a second copy.
+PROTECTED_DIRS="$(rule "$PROJECT_DIR" protectedDirs "${NIGHTSHIFT_PROTECTED_DIRS:-}")"
+EXPECTED_EMAIL="$(rule "$PROJECT_DIR" expectedEmail "${NIGHTSHIFT_EXPECTED_EMAIL:-}")"
+NEVER_COMMIT_PATTERNS="$(rule "$PROJECT_DIR" neverCommitPatterns "${NIGHTSHIFT_NEVER_COMMIT_PATTERNS:-}")"
+FORBIDDEN_COMMANDS="$(rule "$PROJECT_DIR" forbiddenCommands "${NIGHTSHIFT_FORBIDDEN_COMMANDS:-}")"
 
 # Reasons interpolate owner config and git output; escape them so a stray quote or
 # backslash can never break the JSON and void the deny.
@@ -103,14 +107,11 @@ if [ -n "$REC" ] && [ -n "${SID:-}" ] && [ "$SID" != "$REC" ] \
   exit 0
 fi
 
-# Tool rules — one knob: NIGHTSHIFT_TOOL_RULES, a JSON map of tool name -> denial message,
-# loaded by setup from .claude/nightshift-rules.json (the file the owner edits; the env is
-# what enforces, fixed at session start — only the owner sets or lifts a rule, never the
-# agent mid-run). A key's message is the denial Claude reads; an empty message lifts the
-# rule; an absent key means the default — AskUserQuestion denied so a 2:40am question cannot
-# kill the run, every other tool allowed. (sed backs up the jq path; the default holds even
-# without jq.)
-TOOL_RULES="${NIGHTSHIFT_TOOL_RULES:-}"
+# Tool rules — the rules file's toolDeny map: tool name -> denial message. A key's message
+# is the denial Claude reads; an empty message lifts the rule; an absent key means the
+# default — AskUserQuestion parked so a 2:40am question cannot kill the run, every other
+# tool allowed. (sed backs up the jq path; the park rule holds even without jq.)
+TOOL_RULES="$(rule "$PROJECT_DIR" toolDeny "${NIGHTSHIFT_TOOL_RULES:-}")"
 rules_has() {
   [ -n "$TOOL_RULES" ] || return 1
   if command -v jq >/dev/null 2>&1; then
@@ -128,20 +129,44 @@ rules_msg() {
 }
 if [ -n "$TOOL_RULES" ] && command -v jq >/dev/null 2>&1 \
   && ! printf '%s' "$TOOL_RULES" | jq -e 'type == "object"' >/dev/null 2>&1; then
-  deny "BLOCKED: NIGHTSHIFT_TOOL_RULES is not a JSON object, so the tool rules cannot run. Re-run /nightshift:setup to rewrite it from .claude/nightshift-rules.json."
+  deny "BLOCKED: the toolDeny rules are not a JSON object, so the tool rules cannot run. Fix .nightshift/rules.json or re-run /nightshift:setup."
 fi
 if [ "$TOOL" = "AskUserQuestion" ] || printf '%s' "$INPUT" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"AskUserQuestion"'; then
+  # The park message is the map's AskUserQuestion entry — the one copy, shipped in the
+  # template setup copies. No readable entry still parks the question (fail closed), with the
+  # repair named.
   if rules_has "AskUserQuestion"; then
     m="$(rules_msg AskUserQuestion)"
     [ -z "$m" ] || deny "$m"
   else
-    deny "BLOCKED (park, don't ask): a shift is active and the owner is asleep. Choose the most sensible production-grade default yourself, record the decision and your reasoning in .nightshift/parking-lot.md, and KEEP WORKING. The owner reviews it in the morning."
+    deny "BLOCKED (park, don't ask): a shift is active — record the decision and a sensible default in .nightshift/parking-lot.md and keep working. (nightshift: the owner's park message lives in .nightshift/rules.json toolDeny — unreadable here; re-run /nightshift:setup.)"
   fi
   exit 0 # a permitted question is not a command; the command guards have no business with it
 fi
 if [ -n "$TOOL" ] && [ "$TOOL" != "Bash" ] && rules_has "$TOOL"; then
   m="$(rules_msg "$TOOL")"
   [ -z "$m" ] || deny "$m"
+fi
+
+# The rules file is the owner's leash on the night, and the night never rewrites it: during a
+# shift, deny any file tool aimed at the rules file and any Bash command that names it. An
+# owner's mid-shift edit is the owner's hand — it reads from the very next tool call.
+# Pattern-match honesty, like every guard here.
+if command -v jq >/dev/null 2>&1; then
+  FILEPATH="$(printf '%s' "$INPUT" | jq -r '.tool_input.file_path // empty' 2>/dev/null || true)"
+else
+  FILEPATH="$(printf '%s' "$INPUT" | sed -n 's/.*"file_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+fi
+case "$TOOL" in
+  Edit | Write | MultiEdit | NotebookEdit)
+    case "$FILEPATH" in
+      */.nightshift/rules.json | *nightshift-rules.json) deny "BLOCKED: the rules file is the owner's — the night never rewrites its own rules. Park the need in .nightshift/parking-lot.md and keep working; the owner's edit applies from the next tool call." ;;
+    esac
+    exit 0 # a file tool is not a command; the command guards have no business with it
+    ;;
+esac
+if printf '%s' "$SCRUBBED" | grep -qE '\.nightshift/rules\.json|nightshift-rules\.json'; then
+  deny "BLOCKED: the rules file is the owner's — the night neither reads nor rewrites its own rules. Park the need in .nightshift/parking-lot.md and keep working."
 fi
 
 # An unparseable owner pattern makes grep exit 2, which a plain `if` reads as "no match" — the

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -18,6 +18,15 @@
             "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/hardhat.sh\""
           }
         ]
+      },
+      {
+        "matcher": "Edit|Write|MultiEdit|NotebookEdit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/hardhat.sh\""
+          }
+        ]
       }
     ],
     "SessionEnd": [

--- a/hooks/lib.sh
+++ b/hooks/lib.sh
@@ -93,6 +93,24 @@ valid_ere() {
   [ "$?" -le 1 ]
 }
 
+# The owner's rules file is the one copy of every knob: .nightshift/rules.json — nightshift's
+# whole life lives in nightshift's folder, and deleting the folder deletes all of it. Hooks
+# read the file directly — a change applies from the next tool call. An env var of the
+# matching name, when set, overrides the file for the session: the test suite's lever and the
+# power user's per-session exception, never a second copy the owner maintains.
+# rule <project-dir> <file-key> <env-value> — prints the effective value ('' = default).
+rule() {
+  if [ -n "$3" ]; then printf '%s' "$3"; return; fi
+  local f="$1/.nightshift/rules.json"
+  [ -f "$f" ] || f="$1/.claude/nightshift-rules.json" # pre-0.6.1 home; setup migrates it
+  [ -f "$f" ] || return 0
+  if command -v jq >/dev/null 2>&1; then
+    jq -r --arg k "$2" '.[$k] // empty | if type == "object" or type == "array" then tojson else tostring end' "$f" 2>/dev/null
+  else
+    sed -n 's/.*"'"$2"'"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$f" | sed -n 1p
+  fi
+}
+
 # Cross-session mutex over one .nightshift/ — mkdir is the one atomic primitive every platform
 # here ships (macOS has no flock). The holder writes its pid inside; a lock whose holder is
 # provably dead is broken on sight, a mid-claim lock (no pid yet) is waited on, never stolen.

--- a/skills/nightshift/references/nightshift-rules-template.json
+++ b/skills/nightshift/references/nightshift-rules-template.json
@@ -11,7 +11,7 @@
   "watchMinutes": 10,
   "watchRetrySeconds": "30 120",
   "notifyCommand": "",
-  "revivalPrompt": "",
-  "freshRevivalPrompt": "",
-  "clockOutMessage": ""
+  "revivalPrompt": "You were cut off mid-work by an outage or a crash — not by the owner. Pick up exactly where you left off and continue.",
+  "freshRevivalPrompt": "Resume the nightshift. Read .nightshift/punch-list.md and work its open items per the contract, one at a time; run the item gate before each commit; tick what you finish. Leave pushing to the owner unless the punch list says otherwise. Park owner decisions in parking-lot.md. Stop only when every box is ticked or a stop-work order exists.",
+  "clockOutMessage": "DO NOT STOP — the punch list (.nightshift/punch-list.md) still has open items. Work them top to bottom, ONE at a time, each to its own Verify. Per item: implement fully — no stubs, no deferrals, no 'documented for later'; effort is never a reason to defer, and this IS the focused session; run the item gate right before its commit and require it GREEN; make ONE commit; then tick the box to '- [x]'. Never fake a tick. Deletion is not completion — never remove an item or edit the contract above '## Items'. Park any decision that is genuinely the owner's in .nightshift/parking-lot.md with a sensible default chosen, and KEEP WORKING — never ask, never wait. A walkthrough cycle that finds nothing new is SUCCESS, not idleness. You may stop only when zero '- [ ]' remain, or the owner issues a stop-work order (.nightshift/STOP)."
 }

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -29,7 +29,8 @@ they do not exist.
   repo inside `.nightshift/`, so every punch-list change and log line has history. Most people
   don't want a git repo living inside their project, so ask — *"version the run state in a local
   receipts repo? (never pushed, never touches your project's history)"* — and on anything but a
-  clear yes, skip it: the receipts still exist as plain files. On yes: if `.nightshift/.git` does
+  clear yes, skip it: the receipts still exist as plain files. Present the question neutrally —
+  never describe the repo as recommended; the default is no. On yes: if `.nightshift/.git` does
   not exist, `git init` inside `.nightshift/`, add a `.nightshift/.gitignore` that ignores the
   transient markers `STOP`, `.stall`, `.notified`, `deadline`, `.session-end`, `.shift-session`,
   `.watchman`, `.watchman-tick`, and `.lock.d/`, and make one initial commit. **Never add a
@@ -70,30 +71,20 @@ denied means denied. Ask one question:
 ## 5. The rules file — every knob in one place
 
 Copy `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/nightshift-rules-template.json` to
-`.claude/nightshift-rules.json` if it does not already exist — the owner's one config file,
-defaults inline, survives plugin updates. Then load it: validate with `jq -e 'type == "object"'`
-(an invalid file is reported, never half-applied) and sync each key into the `env` block of
-`.claude/settings.local.json`, machine-escaped, never clobbering env keys that are not
-nightshift's:
+`.nightshift/rules.json` as-is, if it does not already exist — the owner's one config file,
+defaults inline. It lives in nightshift's own folder on purpose: everything nightshift is in
+one place, kept out of repo history by the same `.nightshift/` gitignore, versioned by the
+receipts repo when one exists — and deleting `.nightshift/` removes all of nightshift, rules
+included. If a pre-0.6.1 `.claude/nightshift-rules.json` exists, move it here — the owner's
+values, not the template. Then validate it with `jq -e 'type == "object"'` and report a
+broken file plainly — never half-apply it.
 
-- `toolDeny` (object) → `NIGHTSHIFT_TOOL_RULES` (compact, via `jq -c`)
-- `forbiddenCommands` → `NIGHTSHIFT_FORBIDDEN_COMMANDS`
-- `neverCommitPatterns` → `NIGHTSHIFT_NEVER_COMMIT_PATTERNS`
-- `expectedEmail` → `NIGHTSHIFT_EXPECTED_EMAIL`
-- `protectedDirs` → `NIGHTSHIFT_PROTECTED_DIRS`
-- `stallMax` → `NIGHTSHIFT_STALL_MAX`
-- `stallWarnEvery` → `NIGHTSHIFT_STALL_WARN`
-- `watchMinutes` → `NIGHTSHIFT_WATCH`
-- `watchRetrySeconds` → `NIGHTSHIFT_WATCH_RETRY`
-- `notifyCommand` → `NIGHTSHIFT_NOTIFY_CMD`
-- `revivalPrompt` → `NIGHTSHIFT_REVIVAL_PROMPT`
-- `freshRevivalPrompt` → `NIGHTSHIFT_FRESH_PROMPT`
-- `clockOutMessage` → `NIGHTSHIFT_GATE_MESSAGE`
-
-An empty string, empty object, or `0` means "use the default": remove that env key rather than
-writing it. The env is what enforces, fixed at session start — the file is the owner's editor,
-not the agent's lever. Editing the file changes nothing by itself; the summary must say so:
-**"rules changed → re-run `/nightshift:setup`, then start a fresh session."**
+The hooks read this file directly on every tool call: an owner's edit applies from their very
+next action. Nothing is synced anywhere, nothing needs a restart, and there is no second copy.
+Env vars of the matching names (`NIGHTSHIFT_FORBIDDEN_COMMANDS`, `NIGHTSHIFT_TOOL_RULES`, …)
+remain session-start overrides for tests and one-off exceptions — say so only if asked. If
+`.claude/settings.local.json` still carries `NIGHTSHIFT_*` env keys that an earlier version
+synced from this file, offer to remove them: the file is the one copy.
 
 **Template evolution — offer, never impose.** On a re-run with the file already present,
 compare the shipped template's keys to the owner's file (`jq -r 'keys[]'` on each): offer any

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -35,14 +35,11 @@ Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
   with the same one-line header. Only the mechanical journal auto-rotates — `snag-log.md` and
   `parking-lot.md` are the owner's review material; `/nightshift:archive` files those on the
   owner's order.
-- **Rules drift:** if `.claude/nightshift-rules.json` exists, compare it to what this session
-  actually runs under — `jq -c '.toolDeny'` of the file against `$NIGHTSHIFT_TOOL_RULES`, and
-  each other mapped key against its env var. On any mismatch, warn once: the file changed after
-  this session's env was fixed — re-run `/nightshift:setup`, then start a fresh session, or
-  tonight runs on the old rules. Also compare the shipped template's keys against the file's
-  (`jq -r 'keys[]'` on each): keys the template has that the file lacks mean a plugin update
-  brought new knobs — say so once and point at `/nightshift:setup` to review them; never add
-  them yourself here.
+- **New knobs check:** if `.nightshift/rules.json` exists, compare the shipped
+  template's keys against the file's (`jq -r 'keys[]'` on each): keys the template has that
+  the file lacks mean a plugin update brought new knobs — say so once and point at
+  `/nightshift:setup` to review them; never add them yourself here. (The hooks read the file
+  live — there is no drift to check and no restart to suggest.)
 - The night cannot click Allow: if neither `.claude/settings.local.json` nor
   `.claude/settings.json` grants frictionless permissions (`bypassPermissions` default mode or an
   allowlist covering the gates' commands), warn once — a permission prompt mid-shift freezes the
@@ -67,11 +64,11 @@ what the last shift parked. Append a `shift started` line to `.nightshift/shift-
 
 ## 4. Arm the night watchman
 
-Unless `NIGHTSHIFT_WATCH=0`, arm it in the background:
+Unless the rules file's `watchMinutes` is `0` (or `NIGHTSHIFT_WATCH=0` overrides), arm it in
+the background — it reads its cadence from the rules file itself:
 
 ```bash
-nohup "${CLAUDE_PLUGIN_ROOT}/adapters/watchman.sh" --project "$CLAUDE_PROJECT_DIR" \
-  --interval "${NIGHTSHIFT_WATCH:-10}" >/dev/null 2>&1 &
+nohup "${CLAUDE_PLUGIN_ROOT}/adapters/watchman.sh" --project "$CLAUDE_PROJECT_DIR" >/dev/null 2>&1 &
 ```
 
 It revives a session that DIES mid-shift — an API outage, a crash, a killed terminal — by

--- a/tests/clock-out-gate.bats
+++ b/tests/clock-out-gate.bats
@@ -359,3 +359,24 @@ load helpers
   is_block "$output"
   grep -q 'stall warning — 2 attempts' "$p/.nightshift/shift-log.md"
 }
+
+@test "the gate reads the stall cadence from the rules file" {
+  p="$(new_project)"
+  punch_open "$p"
+  jq '.stallWarnEvery = 2' "$RULES_TEMPLATE" >"$p/.nightshift/rules.json"
+  run gate "$p"
+  run gate "$p"
+  is_block "$output"
+  grep -q 'stall warning — 2 attempts' "$p/.nightshift/shift-log.md"
+}
+
+# The block never depends on config: unreadable knobs still gate, fail closed, repair named.
+@test "a missing rules file still blocks and names the repair" {
+  p="$(new_project)"
+  punch_open "$p"
+  rm "$p/.nightshift/rules.json"
+  run gate "$p"
+  is_block "$output"
+  printf '%s' "$output" | grep -q "re-run /nightshift:setup"
+  grep -q 'stall guard down' "$p/.nightshift/shift-log.md"
+}

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -459,7 +459,7 @@ STUB
   out="$(jq -nc '{tool_name:"WebSearch",tool_input:{}}' |
     env NIGHTSHIFT_TOOL_RULES='not json' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
   is_deny "$out"
-  printf '%s' "$out" | grep -q "NIGHTSHIFT_TOOL_RULES"
+  printf '%s' "$out" | grep -q "toolDeny"
 }
 
 @test "the map's default Ask rule holds even without jq" {
@@ -474,4 +474,68 @@ STUB
     env PATH="$nojq" NIGHTSHIFT_TOOL_RULES='{"AskUserQuestion":"welded shut"}' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
   is_deny "$out"
   printf '%s' "$out" | grep -q "welded shut"
+}
+
+# ---- one copy: the rules file IS the config; env is only a session-start override ----
+
+@test "the guards read the rules file directly — no env needed" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf '{"forbiddenCommands":"git .*push","toolDeny":{"AskUserQuestion":"file-map says park"}}\n' >"$p/.nightshift/rules.json"
+  run hardhat_bash "$p" "git push origin main"
+  is_deny "$output"
+  run hardhat_ask "$p"
+  is_deny "$output"
+  printf '%s' "$output" | grep -q "file-map says park"
+}
+
+@test "a pre-0.6.1 rules file in .claude still reads until setup migrates it" {
+  p="$(new_project)"
+  punch_open "$p"
+  rm "$p/.nightshift/rules.json" # a pre-0.6.1 site has no modern file
+  mkdir -p "$p/.claude"
+  printf '{"forbiddenCommands":"git .*push"}\n' >"$p/.claude/nightshift-rules.json"
+  run hardhat_bash "$p" "git push origin main"
+  is_deny "$output"
+}
+
+@test "an env var overrides the file for the session" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf '{"forbiddenCommands":"git .*push"}\n' >"$p/.nightshift/rules.json"
+  run hardhat_bash "$p" "git push origin main" NIGHTSHIFT_FORBIDDEN_COMMANDS="never-matches-anything"
+  is_allow
+}
+
+@test "the night never rewrites its own rules — file tools and commands alike" {
+  p="$(new_project)"
+  punch_open "$p"
+  out="$(jq -nc --arg fp "$p/.nightshift/rules.json" '{tool_name:"Write",tool_input:{file_path:$fp,content:"{}"}}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  is_deny "$out"
+  printf '%s' "$out" | grep -q "never rewrites its own rules"
+  run hardhat_bash "$p" "echo '{}' > .nightshift/rules.json"
+  is_deny "$output"
+}
+
+@test "file tools are free of the command guards — and free entirely outside a shift" {
+  p="$(new_project)"
+  punch_open "$p"
+  out="$(jq -nc '{tool_name:"Write",tool_input:{file_path:"/tmp/notes.md",content:"how to git push"}}' |
+    env NIGHTSHIFT_FORBIDDEN_COMMANDS='git .*push' CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ] # a file's content is not a command
+  q="$(new_project other)"
+  out="$(jq -nc --arg fp "$q/.nightshift/rules.json" '{tool_name:"Write",tool_input:{file_path:$fp,content:"{}"}}' |
+    env CLAUDE_PROJECT_DIR="$q" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ] # no shift, no rules — the owner edits freely
+}
+
+# No readable rules is a fault, never an opening: the question still parks, loudly.
+@test "a missing rules file still parks questions and names the repair" {
+  p="$(new_project)"
+  punch_open "$p"
+  rm "$p/.nightshift/rules.json"
+  run hardhat_ask "$p"
+  is_deny "$output"
+  printf '%s' "$output" | grep -q "re-run /nightshift:setup"
 }

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,10 +1,18 @@
 # Shared helpers for the nightshift hook tests.
 HOOKS="$BATS_TEST_DIRNAME/../hooks"
+RULES_TEMPLATE="$BATS_TEST_DIRNAME/../skills/nightshift/references/nightshift-rules-template.json"
 
 # Create an isolated project with its own git repo and a .nightshift dir. Echoes the path.
+# The suite must see only the env a test passes explicitly — a developer's own shell (or a
+# host that feeds settings env into commands) must never leak NIGHTSHIFT_* into fixtures.
+while IFS='=' read -r _v _; do
+  case "$_v" in NIGHTSHIFT_*) unset "$_v" ;; esac
+done < <(env)
+
 new_project() {
   local p="$BATS_TEST_TMPDIR/${1:-proj}"
   mkdir -p "$p/.nightshift"
+  cp "$RULES_TEMPLATE" "$p/.nightshift/rules.json" # as setup does — the one copy of every knob
   git -C "$p" init -q
   git -C "$p" config user.email dev@example.com
   git -C "$p" config user.name tester
@@ -17,6 +25,7 @@ new_project() {
 new_workspace() {
   local w="$BATS_TEST_TMPDIR/${1:-ws}"
   mkdir -p "$w/.nightshift"
+  cp "$RULES_TEMPLATE" "$w/.nightshift/rules.json"
   add_repo "$w" repo
   printf '%s' "$w"
 }

--- a/tests/hooks-json.bats
+++ b/tests/hooks-json.bats
@@ -3,9 +3,9 @@ load helpers
 # The plugin root can live at a path containing spaces (e.g. a local marketplace checkout);
 # an unquoted ${CLAUDE_PLUGIN_ROOT} makes the shell split the path and every hook fails.
 
-@test "hooks.json declares all four hook commands" {
+@test "hooks.json declares every hook command" {
   n="$(jq -r '[.. | .command? // empty] | length' "$BATS_TEST_DIRNAME/../hooks/hooks.json")"
-  [ "$n" -eq 4 ]
+  [ "$n" -eq 5 ]
 }
 
 @test "every hooks.json command quotes the plugin root (spaced-path safe)" {
@@ -43,12 +43,13 @@ load helpers
 
 @test "hooks.json registers the events and matchers the guards rely on" {
   f="$BATS_TEST_DIRNAME/../hooks/hooks.json"
-  [ "$(jq -r '[.hooks.PreToolUse[].matcher] | sort | join(",")' "$f")" = "AskUserQuestion,Bash" ]
+  [ "$(jq -r '[.hooks.PreToolUse[].matcher] | sort | join(",")' "$f")" = "AskUserQuestion,Bash,Edit|Write|MultiEdit|NotebookEdit" ]
   [ "$(jq -r '.hooks.Stop | length' "$f")" -eq 1 ]
   [ "$(jq -r '.hooks.SessionEnd | length' "$f")" -eq 1 ]
   jq -e '.hooks.SessionEnd[0].hooks[0].command | test("session-end")' "$f" >/dev/null
   jq -e '.hooks.PreToolUse[] | select(.matcher=="Bash")   | .hooks[0].command | test("hardhat")'       "$f" >/dev/null
   jq -e '.hooks.PreToolUse[] | select(.matcher=="AskUserQuestion") | .hooks[0].command | test("hardhat")' "$f" >/dev/null
+  jq -e '.hooks.PreToolUse[] | select(.matcher=="Edit|Write|MultiEdit|NotebookEdit") | .hooks[0].command | test("hardhat")' "$f" >/dev/null
   jq -e '.hooks.Stop[0].hooks[0].command | test("clock-out-gate")' "$f" >/dev/null
 }
 

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -49,6 +49,11 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
     stallMax stallWarnEvery watchMinutes watchRetrySeconds notifyCommand revivalPrompt freshRevivalPrompt clockOutMessage; do
     jq -e --arg k "$k" 'has($k)' "$t" >/dev/null || { echo "template missing $k"; return 1; }
   done
+  # the shipped texts are the ONLY copy — they must ship filled, not as empty placeholders
+  for k in revivalPrompt freshRevivalPrompt clockOutMessage watchRetrySeconds; do
+    jq -e --arg k "$k" '.[$k] | length > 0' "$t" >/dev/null || { echo "template ships empty $k"; return 1; }
+  done
+  jq -e '.toolDeny.AskUserQuestion | length > 0' "$t" >/dev/null
 }
 
 # Updates offer their improvements; they never overwrite the owner's words.
@@ -58,4 +63,15 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
   grep -qF 'touch a value the owner already has' "$s"
   grep -qF "wording wins every conflict" "$s"
   grep -qF 'open boxes is never touched' "$s"
+}
+
+# The contracts the setup conversation must not drift on: the receipts repo is never
+# "recommended", the rules live and die with nightshift's folder, and a pre-0.6.1 file is
+# moved, not retyped.
+@test "setup pins the neutral ask, the rules home, and the migration" {
+  s="$BATS_TEST_DIRNAME/../skills/setup/SKILL.md"
+  grep -qF 'never describe the repo as recommended; the default is no' "$s"
+  grep -qF '`.nightshift/rules.json` as-is' "$s"
+  grep -qF 'removes all of nightshift, rules' "$s"
+  grep -qF 'move it here' "$s"
 }

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -9,6 +9,7 @@ setup() {
   SESSION_END="$BATS_TEST_DIRNAME/../hooks/session-end.sh"
   P="$BATS_TEST_TMPDIR/proj"
   mkdir -p "$P/.nightshift"
+  cp "$BATS_TEST_DIRNAME/../skills/nightshift/references/nightshift-rules-template.json" "$P/.nightshift/rules.json"
   printf '## Items\n- [ ] **1.**\n' >"$P/.nightshift/punch-list.md"
 
   BIN="$BATS_TEST_TMPDIR/bin"
@@ -676,4 +677,32 @@ STUB
   [ "$(wc -l <"$wl" | tr -d ' ')" -eq 1 ] # once per outage, not once per wake
   grep -q 'revival failed' "$wl"
   grep -q 'claude --resume sid-shift' "$wl"
+}
+
+# One copy: the watchman reads its orders from the rules file; env stays the override.
+@test "the revival order is read from the rules file" {
+  jq '.revivalPrompt = "weld from the file"' \
+    "$BATS_TEST_DIRNAME/../skills/nightshift/references/nightshift-rules-template.json" >"$P/.nightshift/rules.json"
+  cat >"$BIN/hear2.sh" <<'STUB'
+#!/usr/bin/env bash
+echo called >>.nightshift/agent-calls
+printf '%s\n' "$1" >.nightshift/heard
+awk 'BEGIN{d=0} !d && /^- \[ \]/{sub(/\[ \]/,"[x]");d=1} {print}' .nightshift/punch-list.md >.nightshift/pl.tmp
+mv .nightshift/pl.tmp .nightshift/punch-list.md
+STUB
+  chmod +x "$BIN/hear2.sh"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 NIGHTSHIFT_WATCH_RETRY="0 0" \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/hear2.sh" --max-wakes 5
+  [ "$status" -eq 0 ]
+  grep -q "weld from the file" "$P/.nightshift/heard"
+}
+
+# The watchman refuses to arm without its orders — loudly, naming the repair.
+@test "a missing rules file refuses to arm the watchman" {
+  rm "$P/.nightshift/rules.json"
+  run env NIGHTSHIFT_WATCH_SLEEP=0 \
+    "$WATCHMAN" --project "$P" --interval 20 --agent "bash $BIN/tick.sh" --max-wakes 2
+  [ "$status" -eq 1 ]
+  printf '%s' "$output" | grep -q "re-run /nightshift:setup"
+  grep -q 'cannot arm' "$P/.nightshift/shift-log.md"
 }


### PR DESCRIPTION
The rules file is the config, and there is exactly one of it: `.nightshift/rules.json` — created as-is from the shipped template, edited by the owner, read by the hooks directly on every tool call. An edit applies from the owner's next action; nothing is synced into settings, nothing needs a restart, and deleting `.nightshift/` removes all of nightshift, rules included.

## What ships

- **One copy, read live.** Hooks read `.nightshift/rules.json` directly; env vars of the matching names remain session-start overrides for tests and one-off exceptions — never a second copy to maintain. A pre-0.6.1 `.claude/nightshift-rules.json` still reads as a fallback, and setup migrates it in.
- **No hidden defaults.** Every shipped value — both revival orders, the clock-out reinjection, the park message, the cadences — lives visibly in the template setup copies. The hooks carry no fallback copies: a missing or unreadable rules file fails loudly and closed — the gate still blocks, questions stay parked, the watchman refuses to arm, each naming the repair.
- **The night never touches its own leash.** During a shift the working session is denied the rules file — file tools and shell commands alike (new PreToolUse matcher for Edit/Write/MultiEdit/NotebookEdit) — so only the owner sets or lifts a rule, applying from the next tool call.
- **Setup migrates and cleans.** Moves the pre-0.6.1 file into `.nightshift/`, offers to strip `NIGHTSHIFT_*` env keys an earlier version synced, and asks the receipts-repo question neutrally — its default is no, and it is never presented as recommended.
- **The watchman reads its own cadence** (`watchMinutes`, `watchRetrySeconds`, `notifyCommand`, both revival orders) from the rules file at arm time; start no longer passes an interval.
- Hooks source their helpers via pure-bash paths (no `dirname` dependency), and the test suite scrubs ambient `NIGHTSHIFT_*` env so no developer shell can contaminate a fixture.
- README documents the platform limitation around already-open conversation views and the upstream issue tracking it (anthropics/claude-code#82655).

## Verification

- 186 bats tests green (13 new: file-read paths, env override, legacy fallback, the leash guard, fail-closed behavior for gate, hardhat, and watchman, template completeness), shellcheck clean, `claude plugin validate --strict` passes

Supersedes #13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)