### PR TITLE
fix: resolve skill paths against the project directory

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,21 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.7.1 — the site is where the owner put it
+
+Every skill resolves `.nightshift/` and `.claude/` against `$CLAUDE_PROJECT_DIR`, so the site stays
+the site no matter where a shell has wandered. The working directory persists between commands and
+follows gates, builds, and stack detection into the code repo; on the recommended layout — the code
+repo a level below the project root — anything written relative to it lands in the repo instead of
+the site.
+
+- **Permissions reach the project.** `/nightshift:setup` writes
+  `$CLAUDE_PROJECT_DIR/.claude/settings.local.json`, the file a headless revival inherits. A copy
+  anywhere else grants the project nothing, and the night finds out at its first prompt.
+- **Scaffolding, rules, gates, and the receipts repo are placed by path, not by proximity.** The
+  receipts repo is created with `git -C`, since `git init` follows the working directory too.
+- Six tests hold the rule across every skill, including ones not written yet.
+
 ## v0.7.0 — one place composes work, one place starts it
 
 `/nightshift:start` asks nothing. Everything it needs was decided when the work was composed, so

--- a/skills/archive/SKILL.md
+++ b/skills/archive/SKILL.md
@@ -6,6 +6,10 @@ description: File the finished part of the run state into a dated archive — sh
 Archive the finished paperwork. Work in `$CLAUDE_PROJECT_DIR`. This files records — it never
 does shift work, never ticks a box, never touches the contract.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+The shell's working directory persists between Bash calls and is not necessarily the project root;
+records filed into the wrong directory are records lost.
+
 ## Where it goes
 
 Everything lands in `.nightshift/archive/<YYYY-MM-DD>/` — today's date, one folder per archive

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -6,6 +6,10 @@ description: Compose tonight's shift from the ready catalog — pick the jobs, c
 Compose a shift for `$CLAUDE_PROJECT_DIR`. Propose, never impose: nothing is worked without an
 explicit yes. If `.nightshift/` does not exist, stop and point to `/nightshift:setup` first.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+The shell's working directory persists between Bash calls and is not necessarily the project root,
+so a bare relative path lands wherever the last `cd` left it.
+
 ## 1. Offer the catalog
 
 Present every entry in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/shift-catalog.md`, one

--- a/skills/nightshift/SKILL.md
+++ b/skills/nightshift/SKILL.md
@@ -11,6 +11,11 @@ finish every item to its own standard, safely, leaving receipts. This skill is h
 If `.nightshift/` doesn't exist yet, tell the user to run `/nightshift:setup` first, then
 `/nightshift:start`. The commands own scaffolding and preflight; this skill owns the work.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. The shell's
+working directory persists between Bash calls and is not the project root once a gate or a build has
+run from inside the code repo; a bare relative path then reads a punch list that isn't there and
+writes receipts nobody will find.
+
 ## The contract is above `## Items`
 
 `.nightshift/punch-list.md` has a contract section, then `## Items`. The contract binds YOU for the

--- a/skills/quality/SKILL.md
+++ b/skills/quality/SKILL.md
@@ -7,6 +7,10 @@ Survey this project's existing quality debt and turn what matters into proposed 
 The scan is read-only: run checks in report mode, fix nothing, write nothing without an explicit
 yes. Work in `$CLAUDE_PROJECT_DIR`.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. The shell's
+working directory persists between Bash calls and drifts into the code repo while running the
+project's own check commands, so a bare relative path lands wherever the last `cd` left it.
+
 ## 1. Detect and scan
 
 Detect the stack from the table in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/gates-catalog.md`

--- a/skills/schedule/SKILL.md
+++ b/skills/schedule/SKILL.md
@@ -6,6 +6,9 @@ description: Set a shift to start at a fixed time — check the work is queued, 
 Get `$CLAUDE_PROJECT_DIR` ready to start on a clock, then hand the owner the config. Work through
 these in order; each one is a check the owner would otherwise discover at 4am.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. The shell's
+working directory persists between Bash calls and is not necessarily the project root.
+
 ## 1. Is there a site at all?
 
 No `.nightshift/` — stop and point at `/nightshift:setup`. Nothing below is meaningful without it.

--- a/skills/setup/SKILL.md
+++ b/skills/setup/SKILL.md
@@ -6,17 +6,21 @@ description: Scaffold .nightshift/ from the templates and propose stack-aware qu
 Set up nightshift in this project. Do the scaffolding first, then the gates conversation, then print
 a summary. Work in `$CLAUDE_PROJECT_DIR`.
 
+Every `.nightshift/` and `.claude/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with
+the variable. The shell's working directory persists between Bash calls and drifts into the code
+repo during stack detection, so a bare relative path lands wherever the last `cd` left it.
+
 ## 1. Scaffold `.nightshift/` (never clobber an existing shift)
 
 For each target below, copy the template only if the target does not already exist:
 
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/punch-list-template.md`   → `.nightshift/punch-list.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/drafting-table-template.md` → `.nightshift/drafting-table.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/parking-lot-template.md`  → `.nightshift/parking-lot.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/snag-log-template.md`     → `.nightshift/snag-log.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/punch-list-template.md`   → `$CLAUDE_PROJECT_DIR/.nightshift/punch-list.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/drafting-table-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/drafting-table.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/parking-lot-template.md`  → `$CLAUDE_PROJECT_DIR/.nightshift/parking-lot.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/snag-log-template.md`     → `$CLAUDE_PROJECT_DIR/.nightshift/snag-log.md`
 
-Create `.nightshift/shift-log.md` and `.nightshift/work-orders.md` with a one-line header each if
-they do not exist.
+Create `$CLAUDE_PROJECT_DIR/.nightshift/shift-log.md` and
+`$CLAUDE_PROJECT_DIR/.nightshift/work-orders.md` with a one-line header each if they do not exist.
 
 ## 2. Private by default
 
@@ -31,7 +35,8 @@ they do not exist.
   receipts repo? (never pushed, never touches your project's history)"* — and on anything but a
   clear yes, skip it: the receipts still exist as plain files. Present the question neutrally —
   never describe the repo as recommended; the default is no. On yes: if `.nightshift/.git` does
-  not exist, `git init` inside `.nightshift/`, add a `.nightshift/.gitignore` that ignores the
+  not exist, run `git -C "$CLAUDE_PROJECT_DIR/.nightshift" init` rather than `cd`-ing there, add a
+  `$CLAUDE_PROJECT_DIR/.nightshift/.gitignore` that ignores the
   transient markers `STOP`, `.stall`, `.notified`, `deadline`, `.session-end`, `.shift-session`,
   `.watchman`, `.watchman-tick`, and `.lock.d/`, and make one initial commit. **Never add a
   remote to it, never push it.**
@@ -46,8 +51,9 @@ Detect the stack from the table in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/refe
 - **none** — fully respected: the shift runs without automated checks.
 
 If gates were accepted or edited, also ask the **site-inspection interval** (every N items or every
-H hours). Write the result into the `## Gates` block of `.nightshift/punch-list.md`, replacing the
-placeholder. If the answer was none, leave the placeholder as-is.
+H hours). Write the result into the `## Gates` block of
+`$CLAUDE_PROJECT_DIR/.nightshift/punch-list.md`, replacing the placeholder. If the answer was none,
+leave the placeholder as-is.
 
 The `## Gates` block is plain markdown the owner may edit anytime — re-run `/nightshift:setup` to
 re-detect after a stack change. The contract's immutability binds the agent, not the owner.
@@ -61,9 +67,10 @@ denied means denied. Ask one question:
 > (recommended — nightshift's guards are hooks and stay armed in every permission mode)
 
 - **Yes** → merge `{"permissions": {"defaultMode": "bypassPermissions"}}` into
-  `.claude/settings.local.json` in the project (create the file if absent; never clobber keys the
-  owner already has). Settings on disk are what revivals inherit — a mode picked at launch dies
-  with the process.
+  `$CLAUDE_PROJECT_DIR/.claude/settings.local.json` (create the file if absent; never clobber keys
+  the owner already has). Write the full path: a copy that lands in a nested code repo grants the
+  project nothing, and the first prompt of the night proves it. Settings on disk are what revivals
+  inherit — a mode picked at launch dies with the process.
 - **No** → respect it and say the cost plainly: *"a permission prompt mid-shift freezes the night
   until morning — if the shift stalls on one, that was tonight's trade."* Suggest the narrower
   alternative: pre-allow just the punch list's tools (test runner, linter, git) in the same file.
@@ -71,20 +78,20 @@ denied means denied. Ask one question:
 ## 5. The rules file — every knob in one place
 
 Copy `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/nightshift-rules-template.json` to
-`.nightshift/rules.json` as-is, if it does not already exist — the owner's one config file,
+`$CLAUDE_PROJECT_DIR/.nightshift/rules.json` as-is, if it does not already exist — the owner's one config file,
 defaults inline. It lives in nightshift's own folder on purpose: everything nightshift is in
 one place, kept out of repo history by the same `.nightshift/` gitignore, versioned by the
 receipts repo when one exists — and deleting `.nightshift/` removes all of nightshift, rules
-included. If a pre-0.6.1 `.claude/nightshift-rules.json` exists, move it here — the owner's
-values, not the template. Then validate it with `jq -e 'type == "object"'` and report a
+included. If a pre-0.6.1 `$CLAUDE_PROJECT_DIR/.claude/nightshift-rules.json` exists, move it here —
+the owner's values, not the template. Then validate it with `jq -e 'type == "object"'` and report a
 broken file plainly — never half-apply it.
 
 The hooks read this file directly on every tool call: an owner's edit applies from their very
 next action. Nothing is synced anywhere, nothing needs a restart, and there is no second copy.
 Env vars of the matching names (`NIGHTSHIFT_FORBIDDEN_COMMANDS`, `NIGHTSHIFT_TOOL_RULES`, …)
 remain session-start overrides for tests and one-off exceptions — say so only if asked. If
-`.claude/settings.local.json` still carries `NIGHTSHIFT_*` env keys that an earlier version
-synced from this file, offer to remove them: the file is the one copy.
+`$CLAUDE_PROJECT_DIR/.claude/settings.local.json` still carries `NIGHTSHIFT_*` env keys that an
+earlier version synced from this file, offer to remove them: the file is the one copy.
 
 **Template evolution — offer, never impose.** On a re-run with the file already present,
 compare the shipped template's keys to the owner's file (`jq -r 'keys[]'` on each): offer any

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -5,6 +5,10 @@ description: Begin the shift — preflight, cut whatever is queued, arm the site
 
 Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+The shell's working directory persists between Bash calls and drifts into the code repo while
+running gates, so a bare relative path reads or writes wherever the last `cd` left it.
+
 **With work in the punch list, this command asks nothing.** It reads the list, arms the site and
 works — which is what lets cron run it at 04:00 and lets the watchman revive it after a crash. It
 promotes nothing on its own: what is in the punch list is the shift, exactly as the owner left it.

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -6,6 +6,10 @@ description: Read-only shift status — open vs ticked items, parked decisions, 
 Report the shift status for `$CLAUDE_PROJECT_DIR` **without starting or changing anything** — this is
 read-only.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — read it with the variable.
+The shell's working directory persists between Bash calls and is not necessarily the project root,
+and a status read from the wrong directory reports a shift that does not exist.
+
 Read `.nightshift/` and print:
 
 - **Items** — ticked vs open counts from `.nightshift/punch-list.md` (open = lines matching a

--- a/skills/stop/SKILL.md
+++ b/skills/stop/SKILL.md
@@ -5,6 +5,10 @@ description: Issue a stop-work order — end the shift at once, leaving open ite
 
 Issue a stop-work order for `$CLAUDE_PROJECT_DIR`.
 
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+The shell's working directory persists between Bash calls and is not necessarily the project root;
+a stop-work order written to the wrong directory stops nothing.
+
 1. Write `.nightshift/STOP` with a one-line reason and a timestamp (e.g. `stopped by owner ·
    <ISO time>`).
 2. Append an `ended by user` line to `.nightshift/shift-log.md`.

--- a/tests/skill-paths.bats
+++ b/tests/skill-paths.bats
@@ -1,0 +1,44 @@
+SKILLS="$BATS_TEST_DIRNAME/../skills"
+SETUP="$SKILLS/setup/SKILL.md"
+
+# A skill's paths resolve against the shell's working directory, which persists between Bash calls
+# and drifts into the code repo the moment a gate, a build, or stack detection runs from inside it.
+# On the recommended layout — code repo a level below the project root — a bare relative path then
+# writes into the repo instead of the site. Every skill has to say so; one that doesn't is the next
+# misplaced settings file.
+@test "every skill states that its paths resolve against CLAUDE_PROJECT_DIR" {
+  for s in "$SKILLS"/*/SKILL.md; do
+    grep -qF 'path below is relative to `$CLAUDE_PROJECT_DIR`' "$s" \
+      || { echo "no path rule: $s"; return 1; }
+  done
+}
+
+@test "every skill names the working directory as the reason" {
+  for s in "$SKILLS"/*/SKILL.md; do
+    grep -qF 'working directory persists between Bash calls' "$s" \
+      || { echo "no cwd caveat: $s"; return 1; }
+  done
+}
+
+# The permission mode is what a headless revival inherits. A copy written into a nested code repo
+# grants the project nothing, and the shift discovers it at the first prompt of the night.
+@test "setup writes the permission settings to an absolute path" {
+  grep -qF '$CLAUDE_PROJECT_DIR/.claude/settings.local.json' "$SETUP"
+}
+
+@test "setup writes the rules file to an absolute path" {
+  grep -qF '$CLAUDE_PROJECT_DIR/.nightshift/rules.json' "$SETUP"
+}
+
+@test "setup scaffolds every template to an absolute path" {
+  for f in punch-list drafting-table parking-lot snag-log; do
+    grep -qF "\$CLAUDE_PROJECT_DIR/.nightshift/$f.md" "$SETUP" \
+      || { echo "scaffold target not absolute: $f"; return 1; }
+  done
+}
+
+# git resolves its repo from the working directory, so the receipts repo is the one place a stray
+# cd would init a repo inside the code tree instead of the site.
+@test "setup inits the receipts repo without relying on the working directory" {
+  grep -qF 'git -C "$CLAUDE_PROJECT_DIR/.nightshift" init' "$SETUP"
+}

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -71,7 +71,7 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
 @test "setup pins the neutral ask, the rules home, and the migration" {
   s="$BATS_TEST_DIRNAME/../skills/setup/SKILL.md"
   grep -qF 'never describe the repo as recommended; the default is no' "$s"
-  grep -qF '`.nightshift/rules.json` as-is' "$s"
+  grep -qF '`$CLAUDE_PROJECT_DIR/.nightshift/rules.json` as-is' "$s"
   grep -qF 'removes all of nightshift, rules' "$s"
   grep -qF 'move it here' "$s"
 }


### PR DESCRIPTION
Every skill writes `.nightshift/` and `.claude/` paths with $CLAUDE_PROJECT_DIR. The shell's working directory persists between commands and follows gates, builds, and stack detection into the code repo, so on the recommended layout — code repo a level below the project root — a relative path resolves inside the repo rather than the site.

The permission settings matter most: they are what a headless revival inherits, and a copy in a nested repo grants the project nothing. The receipts repo is created with `git -C`, since git resolves its repo from the working directory too. Six tests hold the rule across every skill, including ones not written yet.

<!-- Thanks for contributing to claude-nightshift! -->

## What does this PR do?

<!-- A short summary of the change and the motivation. Link any related issue: "Closes #12". -->

## Type of change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] Adapter (support for another harness)
- [ ] Docs / chore / refactor (no behaviour change)
- [ ] Gate behaviour change (discussed in an issue first — see CONTRIBUTING)

## Checklist

- [ ] `shellcheck` and the `bats` suite pass locally.
- [ ] Shell stays portable: macOS bash 3.2 / zsh — no newer bashisms, no GNU-only flags.
- [ ] If the stop-gate changed: the PR description shows a transcript of one
      blocked stop and one permitted stop.
- [ ] Docs updated if commands, hooks, or the contract changed.
