### PR TITLE
fix: a shift starts when the owner starts it

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.7.1",
+  "version": "0.7.2",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@ stops freely. Every way in already runs start: interactively, from the scheduler
   the gate, so the two can't disagree about whether work remains.
 - **The contract names the Items list without repeating its heading**, leaving one `## Items` in
   the file for anything that splits on it.
-- Eleven tests cover the arming boundary from both sides.
+- **Every path that starts a shift arms it** — `/nightshift:hunt` answering *now* and
+  `/nightshift:quality` answering *fix now* both begin the shift where they stand, so both write
+  the marker. A stop-work order disarms the site whether or not a list survived to summarise.
+- **`/nightshift:status` says whether a shift is running**, rather than leaving open boxes to imply
+  it, and counts the same range the gate does.
+- Fifteen tests cover the arming boundary from both sides.
 
 ## v0.7.1 — the site is where the owner put it
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,24 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.7.2 — a shift starts when you start it
+
+`/nightshift:start` is what puts a session on shift. It writes `.nightshift/.shift-armed`, and
+until that marker exists the punch list is an ordinary to-do file — the clock-out gate holds
+nobody, hardhat's guards apply to no one, and a session that writes items while planning still
+stops freely. Every way in already runs start: interactively, from the scheduler's
+`claude -p '/nightshift:start'`, and through a revival that re-claims the record it left behind.
+
+- **The gate binds the session start hands it.** The hooks read the shift record; they no longer
+  create one, so the shift is never inherited by whichever session happens to trip a hook first.
+  Ending a shift disarms the site, so the guards leave with the night that needed them.
+- **Boxes count under the `## Items` heading only.** A checkbox anywhere above it is contract
+  prose — an owner's note, an example — and holds nothing. The watchman counts the same range as
+  the gate, so the two can't disagree about whether work remains.
+- **The contract names the Items list without repeating its heading**, leaving one `## Items` in
+  the file for anything that splits on it.
+- Eleven tests cover the arming boundary from both sides.
+
 ## v0.7.1 — the site is where the owner put it
 
 Every skill resolves `.nightshift/` and `.claude/` against `$CLAUDE_PROJECT_DIR`, so the site stays

--- a/adapters/watchman.sh
+++ b/adapters/watchman.sh
@@ -131,9 +131,12 @@ fi
 printf '%s\n' "$$" >"$PIDFILE"
 trap 'rm -f "$PIDFILE"' EXIT
 
+# Counted below the `## Items` heading only, exactly as the gate counts them — a watchman that
+# read a checkbox out of the contract prose would keep reviving a shift the gate considers done.
 open_boxes() {
   local n
-  n="$(grep -cE '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]' "$PUNCH" 2>/dev/null || true)"
+  n="$(sed -n '/^## Items[[:space:]]*$/,$p' "$PUNCH" 2>/dev/null \
+    | grep -cE '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]' 2>/dev/null || true)"
   printf '%s' "${n:-0}"
 }
 

--- a/hooks/clock-out-gate.sh
+++ b/hooks/clock-out-gate.sh
@@ -201,6 +201,9 @@ if [ -f "$STOP" ]; then
     summary="shift ended${reason:+ ($reason)}: $TICKED/$TOTAL done"
     end_shift "$summary"
   fi
+  # A stop-work order ends the shift whether or not a list survived to summarise, so the site is
+  # disarmed either way — otherwise the guards would outlive the night that armed them.
+  rm -f "$NS/.shift-armed"
   exit 0
 fi
 

--- a/hooks/clock-out-gate.sh
+++ b/hooks/clock-out-gate.sh
@@ -62,10 +62,15 @@ GATE_MESSAGE="$(rule "$PROJECT_DIR" clockOutMessage "${NIGHTSHIFT_GATE_MESSAGE:-
 ts() { date '+%Y-%m-%d %H:%M:%S'; }
 log_line() { [ -d "$NS" ] && printf '%s · %s\n' "$(ts)" "$1" >>"$LOG"; }
 
+# Only the Items list is the shift. A checkbox above it is prose — an owner's note, an example in
+# the contract — and counting it would hold a session over something nobody queued. The heading
+# must stand alone on its line, so the contract's inline `## Items` references never match.
+items_section() { sed -n '/^## Items[[:space:]]*$/,$p' "$PUNCH" 2>/dev/null; }
+
 # grep -c prints the count AND exits 1 on zero matches; keep only the number.
 count() {
   local n
-  n="$(grep -cE "$1" "$PUNCH" 2>/dev/null || true)"
+  n="$(items_section | grep -cE "$1" 2>/dev/null || true)"
   printf '%s' "${n:-0}"
 }
 open_boxes()   { count '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'; }
@@ -133,6 +138,9 @@ receipts_commit() {
 # working until its next stop attempt.
 end_shift() {
   [ -d "$NS" ] && : >"$ENDED"
+  # The shift is over, so the site stops being on shift: without this the guards would still apply
+  # to whatever ordinary session opens this project next.
+  rm -f "$NS/.shift-armed"
   receipts_commit "$1"
   whistle "$1"
 }
@@ -155,8 +163,12 @@ record_shift_session() {
   [ -z "$pid" ] || start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
   (set -C; printf '%s\n%s\n%s\n%s\n' "$SID" "${TPATH:-}" "$pid" "$start" >"$NS/.shift-session") 2>/dev/null || true
 }
-if [ -f "$PUNCH" ] && [ "$OPEN" -gt 0 ] && [ ! -f "$ENDED" ] \
-  && [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
+# A shift exists because the owner started one, never because a list exists. `/nightshift:start`
+# writes .shift-armed; without it the punch list is a to-do file and every session stops freely —
+# including the one that just wrote the list while planning.
+[ -f "$NS/.shift-armed" ] || exit 0
+
+if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
   record_shift_session
 fi
 

--- a/hooks/hardhat.sh
+++ b/hooks/hardhat.sh
@@ -94,6 +94,11 @@ record_shift_session() {
   [ -z "$pid" ] || start="$(ps -o lstart= -p "$pid" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
   (set -C; printf '%s\n%s\n%s\n%s\n' "$SID" "${TPATH:-}" "$pid" "$start" >"$NS/.shift-session") 2>/dev/null || true
 }
+# The guards are the shift's, so they arrive with the shift. `/nightshift:start` writes
+# .shift-armed; before it exists this is an ordinary session in an ordinary project and nothing
+# here applies to it.
+[ -f "$NS/.shift-armed" ] || exit 0
+
 if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
   record_shift_session
 fi

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -74,8 +74,11 @@ One question: **start now, or park it for later?**
 On **now** — start the shift yourself, here, without making the owner type another command. Follow
 `/nightshift:start` exactly: clear the stale markers, **move** the item out of `work-orders.md` and
 under `## Items` in the punch list (a cut, never a copy — it must not exist in two places), write
-`.nightshift/deadline` from the recorded hours, log the start, arm the watchman. From that second
-the gate holds this session until the list is done, a stop-work order lands, or the whistle blows.
+`.nightshift/deadline` from the recorded hours, **arm the gate** with
+`touch "$CLAUDE_PROJECT_DIR/.nightshift/.shift-armed"`, log the start, arm the watchman. The
+marker is what starts the shift — without it the list is written and nothing is holding it. From
+that second the gate holds this session until the list is done, a stop-work order lands, or the
+whistle blows.
 
 On **later** — the order stays parked in `work-orders.md` with its hours, costing nothing. It arms
 nothing and the gate stays inert. `/nightshift:start` will offer it when the owner is ready.

--- a/skills/nightshift/references/punch-list-template.md
+++ b/skills/nightshift/references/punch-list-template.md
@@ -1,9 +1,9 @@
 # Punch List
 
 > The enforced to-do for this shift. The clock-out gate (a Stop hook) blocks ending the session
-> while any item under `## Items` is an open `- [ ]`. Everything above `## Items` is the contract —
-> binding for the duration of the shift. Only the `## Items` list changes: tick boxes to `- [x]` as
-> work finishes.
+> while any item in the **Items** list below is an open `- [ ]`. Everything above that heading is
+> the contract — binding for the duration of the shift. Only the Items list changes: tick boxes to
+> `- [x]` as work finishes.
 
 ## Never idle, never ask, never wait
 
@@ -15,7 +15,7 @@
 
 ## How the shift ends (and only these ways)
 
-- **Done** — every box under `## Items` is `- [x]`. The ticks are the truth; no magic phrase ends it.
+- **Done** — every box in the Items list is `- [x]`. The ticks are the truth; no magic phrase ends it.
 - **Stop-work order** — `.nightshift/STOP` exists (`/nightshift:stop`, or `touch .nightshift/STOP`
   from any terminal). Open boxes stay open — an honest snapshot of where work stopped.
 - **Quitting time** — past `.nightshift/deadline`, the gate clocks the shift out. Belongs to
@@ -45,9 +45,9 @@
 
 ## Immutable
 
-Everything above `## Items` is the contract. It binds the agent for the shift — never modify, trim,
-or reword it. The owner may edit the `## Gates` block anytime, so re-read it each item. Only the
-`## Items` list changes.
+Everything above the Items heading is the contract. It binds the agent for the shift — never
+modify, trim, or reword it. The owner may edit the `## Gates` block anytime, so re-read it each
+item. Only the Items list changes.
 
 ## Gates
 

--- a/skills/quality/SKILL.md
+++ b/skills/quality/SKILL.md
@@ -30,10 +30,12 @@ Draft one punch-list item per meaningful cluster (e.g. "clear the 12 shellcheck 
 Verify and Commit lines. Show the drafts, then ask — with three first-class answers:
 
 - **fix now** — write the items straight under `## Items` in `.nightshift/punch-list.md` and start
-  the shift here, following `/nightshift:start`: clear the stale markers, log the start, arm the
-  watchman. These are finite items, so no deadline is required; offer an optional hours cap in one
-  line and write `.nightshift/deadline` only if the owner names a number. From that second the gate
-  holds this session until every box is ticked.
+  the shift here, following `/nightshift:start`: clear the stale markers, **arm the gate** with
+  `touch "$CLAUDE_PROJECT_DIR/.nightshift/.shift-armed"`, log the start, arm the watchman. The
+  marker is what starts the shift; the items alone hold nothing. These are finite items, so no
+  deadline is required; offer an optional hours cap in one line and write `.nightshift/deadline`
+  only if the owner names a number. From that second the gate holds this session until every box
+  is ticked.
 - **draft for later** — append them to `.nightshift/drafting-table.md` and arm nothing. The
   drafting table is staging: it is never read by the gate, which is exactly why proposals can wait
   there safely. Tell the owner they can promote what they want into the punch list and run
@@ -42,9 +44,9 @@ Verify and Commit lines. Show the drafts, then ask — with three first-class an
 - **ignore** — write nothing at all; fully respected. A finding the owner does not care about is
   not a defect.
 
-Never write to the punch list on anything but an explicit **fix now**. An open `- [ ]` there arms
-the clock-out gate for every session in this project, including the one running now — so the box
-and the start belong together, or neither happens.
+Never write to the punch list on anything but an explicit **fix now**. Items there are the shift
+the next start will work, so writing them on a survey puts work in front of the owner that nobody
+agreed to — the box and the start belong together, or neither happens.
 
 If the stack no longer matches the current `## Gates` block, say so in one line and point to
 `/nightshift:setup` — gates belong to setup, not to this command.

--- a/skills/start/SKILL.md
+++ b/skills/start/SKILL.md
@@ -29,9 +29,10 @@ so it looks at what is parked and asks which of it to work.
 - **Clear every stale run-control marker first**, before anything writes a new one — last night's
   leftovers would otherwise end tonight's shift at its first stop attempt. Remove them all if
   present: `.nightshift/STOP`, `.nightshift/.stall`, `.nightshift/.notified`, `.nightshift/.ended`,
-  `.nightshift/.session-end`, `.nightshift/.shift-session`, `.nightshift/.watchman-tick`, and the
-  `.nightshift/.lock.d/` directory. If `.nightshift/.watchman` holds a live pid, kill it — last
-  night's watchman must not double-arm tonight's.
+  `.nightshift/.session-end`, `.nightshift/.shift-session`, `.nightshift/.shift-armed`,
+  `.nightshift/.watchman-tick`, and the `.nightshift/.lock.d/` directory. If
+  `.nightshift/.watchman` holds a live pid, kill it — last night's watchman must not double-arm
+  tonight's.
 - **The deadline is cleared only if it has already passed.** A shift that reached the whistle
   leaves a spent deadline behind, and keeping it clocks tonight out immediately with zero items
   done. But a deadline still in the future is tonight's plan — written by the owner or by hunt's
@@ -78,13 +79,29 @@ The deadline is written when the work is composed, not here.
   and point at `/nightshift:hunt`, which asks for hours; never invent a number.
 - One deadline governs the whole shift: finite items first, the walkthrough soaks up the rest.
 
-## 3. Heads-up
+## 3. Arm the gate
+
+Every check has passed and the work is known, so the shift begins here. Create the marker:
+
+```bash
+touch "$CLAUDE_PROJECT_DIR/.nightshift/.shift-armed"
+```
+
+**This, and nothing else, is what puts a session on shift.** Until it exists the punch list is an
+ordinary to-do file: the clock-out gate holds nobody and hardhat's guards apply to no one, so a
+session that writes items while planning still stops freely. From here the hooks bind the first
+session that trips them — this one — and hold it to the list.
+
+Write it last. A marker left behind by a preflight that stopped early would put the next session
+on a shift it never started.
+
+## 4. Heads-up
 
 Surface any still-unanswered entries in `.nightshift/parking-lot.md` (read-only) so the owner sees
 what the last shift parked — printed, never waited on. Append a `shift started` line to
 `.nightshift/shift-log.md`.
 
-## 4. Arm the night watchman
+## 5. Arm the night watchman
 
 Unless the rules file's `watchMinutes` is `0` (or `NIGHTSHIFT_WATCH=0` overrides), arm it in
 the background — it reads its cadence from the rules file itself:
@@ -99,7 +116,7 @@ stop-work order, quitting time, or a clean exit. Esc is honored — the watchman
 interrupt from the session transcript and stands by rather than resuming; `STOP` remains the
 stop-work order, and the only stop a headless run can receive.
 
-## 5. Work
+## 6. Work
 
 Begin item 1 and follow the nightshift skill: one item at a time, gate before each commit, tick
 honestly, park don't ask, leave pushing to the owner unless the punch list says otherwise. From

--- a/skills/status/SKILL.md
+++ b/skills/status/SKILL.md
@@ -12,13 +12,19 @@ and a status read from the wrong directory reports a shift that does not exist.
 
 Read `.nightshift/` and print:
 
-- **Items** — ticked vs open counts from `.nightshift/punch-list.md` (open = lines matching a
-  dash + bracketed space; ticked = bracketed x), and the title of the current open item.
+- **Shift** — whether one is running: `.nightshift/.shift-armed` exists. Without it the punch list
+  is a to-do file and nothing is holding it, however many boxes are open — say so plainly and name
+  `/nightshift:start` as what begins the shift.
+- **Items** — ticked vs open counts from `.nightshift/punch-list.md`, counted **below the `## Items`
+  heading only** (open = lines matching a dash + bracketed space; ticked = bracketed x), and the
+  title of the current open item. A checkbox above that heading is contract prose, not work, and
+  the gate does not count it either.
 - **Parked** — the count and one-line titles of entries in `.nightshift/parking-lot.md`.
 - **Snag log** — the last few dispositions from `.nightshift/snag-log.md`, if any.
 - **Deadline** — if `.nightshift/deadline` exists, the time remaining until quitting time (it holds a
   UNIX epoch; compare with `date +%s`). Otherwise "no deadline (finite list)".
 - **State** — whether `.nightshift/STOP` is present (and its reason), and the current
-  `.nightshift/.stall` attempt count if any.
+  `.nightshift/.stall` attempt count if any. If a shift is running, the bound session from
+  `.nightshift/.shift-session` and whether its process is still alive.
 
 Keep it a compact glanceable summary. Do not modify any file, do not begin work.

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -239,6 +239,7 @@ load helpers
 @test "an unresolvable repo leaves the string-matching guards untouched" {
   w="$BATS_TEST_TMPDIR/bare"
   mkdir -p "$w/.nightshift"
+  : >"$w/.nightshift/.shift-armed"
   punch_open "$w"
   run hardhat_bash "$w" "git push" NIGHTSHIFT_FORBIDDEN_COMMANDS='git push'
   is_deny "$output"

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -13,6 +13,7 @@ new_project() {
   local p="$BATS_TEST_TMPDIR/${1:-proj}"
   mkdir -p "$p/.nightshift"
   cp "$RULES_TEMPLATE" "$p/.nightshift/rules.json" # as setup does — the one copy of every knob
+  : >"$p/.nightshift/.shift-armed"                 # as /nightshift:start does — a shift is running
   git -C "$p" init -q
   git -C "$p" config user.email dev@example.com
   git -C "$p" config user.name tester
@@ -26,6 +27,7 @@ new_workspace() {
   local w="$BATS_TEST_TMPDIR/${1:-ws}"
   mkdir -p "$w/.nightshift"
   cp "$RULES_TEMPLATE" "$w/.nightshift/rules.json"
+  : >"$w/.nightshift/.shift-armed"
   add_repo "$w" repo
   printf '%s' "$w"
 }

--- a/tests/shift-arming.bats
+++ b/tests/shift-arming.bats
@@ -93,3 +93,24 @@ load helpers
   grep -qF '.nightshift/.shift-armed' "$s"
   grep -qF 'Arm the gate' "$s"
 }
+
+# hunt and quality both start shifts without the owner typing another command. A start path that
+# skips the marker writes the items and holds nothing — the failure is silent and looks like work.
+@test "every skill that starts a shift arms the gate" {
+  for s in start hunt quality; do
+    grep -qF '.nightshift/.shift-armed' "$BATS_TEST_DIRNAME/../skills/$s/SKILL.md" \
+      || { echo "starts a shift without arming: $s"; return 1; }
+  done
+}
+
+@test "a stop-work order disarms the site even with no punch list" {
+  p="$(new_project)"
+  : >"$p/.nightshift/STOP"
+  run gate "$p"
+  is_release
+  [ ! -f "$p/.nightshift/.shift-armed" ]
+}
+
+@test "status reports whether a shift is running" {
+  grep -qF '.nightshift/.shift-armed' "$BATS_TEST_DIRNAME/../skills/status/SKILL.md"
+}

--- a/tests/shift-arming.bats
+++ b/tests/shift-arming.bats
@@ -1,0 +1,95 @@
+load helpers
+
+# A shift exists because the owner started one. Before v0.7.2 the hooks themselves claimed the
+# first session that tripped them while a box was open, so writing a punch list while planning put
+# that session on shift — it then could not end its turn and had to either fight the gate or start
+# working. `/nightshift:start` writes .shift-armed; nothing else does.
+
+@test "an unarmed site releases the session even with open boxes" {
+  p="$(new_project)"
+  rm -f "$p/.nightshift/.shift-armed"
+  punch_open "$p"
+  run gate "$p"
+  is_release
+}
+
+@test "an unarmed site never claims a session" {
+  p="$(new_project)"
+  rm -f "$p/.nightshift/.shift-armed"
+  punch_open "$p"
+  run gate "$p"
+  [ ! -f "$p/.nightshift/.shift-session" ]
+}
+
+@test "an armed site still holds a session with open boxes" {
+  p="$(new_project)"
+  punch_open "$p"
+  run gate "$p"
+  is_block "$output"
+}
+
+@test "arming is what binds the session, so the record appears only once armed" {
+  p="$(new_project)"
+  punch_open "$p"
+  run gate "$p"
+  [ -f "$p/.nightshift/.shift-session" ]
+}
+
+# The guards are the shift's. Outside one, this is an ordinary session in an ordinary project.
+@test "an unarmed site applies no hardhat guard" {
+  p="$(new_project)"
+  rm -f "$p/.nightshift/.shift-armed"
+  punch_open "$p"
+  run hardhat_bash "$p" "git push" NIGHTSHIFT_FORBIDDEN_COMMANDS='git push'
+  is_allow
+}
+
+@test "an armed site applies the hardhat guard" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "git push" NIGHTSHIFT_FORBIDDEN_COMMANDS='git push'
+  is_deny "$output"
+}
+
+# A finished shift stops being a shift, or the guards would follow the project into whatever
+# ordinary session opens it next.
+@test "ending the shift disarms the site" {
+  p="$(new_project)"
+  punch_done "$p"
+  run gate "$p"
+  is_release
+  [ ! -f "$p/.nightshift/.shift-armed" ]
+}
+
+# Only the Items list is the shift. A checkbox in the contract prose above it is an example, and
+# counting it would hold a session over work nobody queued.
+@test "a checkbox above the Items heading is not the shift" {
+  p="$(new_project)"
+  printf '# Punch List\n\n- [ ] this is prose, not work\n\n## Items\n- [x] **1. done.**\n' \
+    >"$p/.nightshift/punch-list.md"
+  run gate "$p"
+  is_release
+}
+
+@test "a checkbox below the Items heading is the shift" {
+  p="$(new_project)"
+  printf '# Punch List\n\n- [ ] this is prose, not work\n\n## Items\n- [ ] **1. real.**\n' \
+    >"$p/.nightshift/punch-list.md"
+  run gate "$p"
+  is_block "$output"
+}
+
+# The contract references the Items list in prose. If those references were the literal heading,
+# scoping the count would start at the first sentence and the whole contract would read as work.
+@test "the shipped template carries the Items heading exactly once" {
+  n="$(grep -c '^## Items[[:space:]]*$' "$BATS_TEST_DIRNAME/../skills/nightshift/references/punch-list-template.md")"
+  [ "$n" -eq 1 ]
+  m="$(grep -c '## Items' "$BATS_TEST_DIRNAME/../skills/nightshift/references/punch-list-template.md")"
+  [ "$m" -eq 1 ]
+}
+
+@test "start is the command that arms the gate" {
+  s="$BATS_TEST_DIRNAME/../skills/start/SKILL.md"
+  grep -qF '.nightshift/.shift-armed' "$s"
+  grep -qF 'Arm the gate' "$s"
+}


### PR DESCRIPTION
`/nightshift:start` writes `.nightshift/.shift-armed`, and the hooks read it. Until that marker exists the punch list is an ordinary to-do file: the clock-out gate holds nobody and hardhat's guards apply to no one.

Previously the hooks created the shift record themselves, so the first session to trip one while a box was open became the shift — a session that wrote a punch list while planning could not then end its turn. `hardhat.sh` claimed on the first tool call, with no punch-list check at all.

## Changes

- Hooks read the shift record; they no longer create one. Ending a shift disarms the site, so the guards leave with the night that needed them.
- Boxes count under the `## Items` heading only, in both the gate and the watchman, so a checkbox in the contract prose holds nothing and the two cannot disagree about whether work remains.
- The contract refers to the Items list without repeating its heading, leaving one `## Items` in the file for anything that splits on it.
- Every path that starts a shift arms it: `hunt` answering *now*, `quality` answering *fix now*. A stop-work order disarms the site whether or not a list survived to summarise.
- `/nightshift:status` reports whether a shift is running rather than leaving open boxes to imply it.

## Verification

212 tests, green under bash 5 and macOS system bash 3.2. shellcheck clean, `claude plugin validate --strict` passes.

Fifteen of those tests cover the arming boundary from both sides. Run against `main`, the gate blocks *and* claims the session on an unarmed site — the behaviour this fixes.

Anyone mid-shift when they update loses the hold, since their site has no marker; re-running `/nightshift:start` restores it.