### PR TITLE
feat: a shift is a file

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "nightshift",
-  "version": "0.7.2",
+  "version": "0.7.3",
   "description": "Claude works the night shift: accountable autonomous runs that can't clock out until the punch list is done.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,9 @@ jobs:
             echo "no bats tests yet"
             exit 0
           fi
-          bats tests/
+          # -r so tests/shifts/ runs too: a contributed shift brings its own test file, and a
+          # suite that skipped the subdirectory would report green on an entry nobody checked.
+          bats -r tests/
 
   bats-macos:
     runs-on: macos-latest
@@ -88,7 +90,7 @@ jobs:
           export PATH
           command -v bash
           bash --version
-          "$bats_bin" tests/
+          "$bats_bin" -r tests/
 
   validate:
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,29 @@
 Installs pin to the `version` in `.claude-plugin/plugin.json`, so every entry here is a version
 users receive. Dates are release dates; the tags carry the exact trees.
 
+## v0.7.3 — a shift is a file
+
+Catalog entries live one per file in `skills/nightshift/references/shifts/`, and
+`/nightshift:hunt` lists that directory rather than reading a single page. Adding a shift is two
+new files — the entry and its test — with no edit to anything shared, so two people can contribute
+one the same week without meeting in a diff. The structural rules glob the directory, so a new
+entry is checked the moment it lands: its title declares its ending, and it carries a pasteable
+item, a Verify line and a stated ending condition.
+
+Two entries join the catalog, both finite, both working from a list the project's own tooling
+produces:
+
+- **Dependency upgrade sweep** — direct dependencies brought current one at a time, patches before
+  majors, each behind the item gate and its own commit. The release notes are the work: a version
+  bump that compiles is not an upgrade. A major that sprawls past a bounded attempt is reverted
+  clean and parked, because a half-migrated major leaves the tree worse than the old version did.
+  Prereleases are refused, and the lockfile, the package manager and the runtime version are the
+  owner's.
+- **Vulnerability sweep** — advisories cleared critical-first, so an interrupted night cleared what
+  mattered. It never downgrades to satisfy an advisory and never adds a suppression: where the only
+  offered fix is an older version, or the advisory sits in a transitive dependency, it parks the
+  decision with the link and the severity.
+
 ## v0.7.2 — a shift starts when you start it
 
 `/nightshift:start` is what puts a session on shift. It writes `.nightshift/.shift-armed`, and

--- a/skills/hunt/SKILL.md
+++ b/skills/hunt/SKILL.md
@@ -12,12 +12,15 @@ so a bare relative path lands wherever the last `cd` left it.
 
 ## 1. Offer the catalog
 
-Present every entry in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/shift-catalog.md`, one
-line each, with its ending marked. **More than one may be chosen** — a night can clear the lint
-backlog and then hunt coverage until the whistle.
+Entries live one per file in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/shifts/`. **List
+that directory and read every file in it** — one offer line each, with its ending marked.
+`shift-catalog.md` beside it explains the two endings; it does not list the entries.
 
-Read the catalog file rather than reciting from memory: entries are added there over time, and a
-job that exists in the file but not in the offer is a job the owner never gets.
+**More than one may be chosen** — a night can clear the lint backlog and then hunt coverage until
+the whistle.
+
+Read the directory rather than reciting from memory: entries are added over time, and a job that
+exists in the folder but not in the offer is a job the owner never gets.
 
 ## 2. Ask how it ends
 

--- a/skills/nightshift/references/catalog-recipe.md
+++ b/skills/nightshift/references/catalog-recipe.md
@@ -1,8 +1,23 @@
 # Adding a shift to the catalog
 
 A shift is markdown, not code. It touches no hooks and changes no enforcement, which is why the
-catalog can grow without the product growing. Adding one is a small PR against
-[`shift-catalog.md`](shift-catalog.md).
+catalog can grow without the product growing.
+
+**Adding one is two new files and no edits to existing ones:**
+
+```
+skills/nightshift/references/shifts/<your-shift>.md   the entry
+tests/shifts/<your-shift>.bats                        what your entry promises
+```
+
+Nothing shared changes — not the index, not a test file someone else is also editing — so two
+contributors can add a shift the same week and never meet in a diff. `/nightshift:hunt` lists the
+directory, so a new file is offered the moment it lands.
+
+The structural rules in `tests/catalog.bats` glob the directory and already cover your entry:
+its title must declare the ending, and it must carry a pasteable item, a Verify line, and a stated
+ending condition. Your own `tests/shifts/<your-shift>.bats` is for what is specific to yours —
+above all its refusals, which are the lines a tired model reaches past at 4am.
 
 Before writing, understand what you are writing: **a shift is a contract handed to an agent that
 will work unattended, on a stranger's repository, while they sleep.** It is not documentation and
@@ -39,11 +54,11 @@ rejected is never raised twice.
 
 ## Shape
 
-Follow the entries already in the catalog. Heading, one-line ending marker, a sentence on when to
-use it, then the item in a fenced block ready to paste under `## Items`:
+Follow the entries already in `shifts/`. The file's title line carries the name and the ending, then
+a sentence on when to use it, then the item in a fenced block ready to paste under `## Items`:
 
 ```text
-## <Name> — <finite|open-ended> — <one line on what it is for>
+# <Name> — <finite|open-ended> — <one line on what it is for>
 
 <A short paragraph: when an owner would choose this, and what they wake up to.>
 

--- a/skills/nightshift/references/shift-catalog.md
+++ b/skills/nightshift/references/shift-catalog.md
@@ -3,7 +3,11 @@
 The ready shifts `/nightshift:hunt` offers. Each entry is a punch-list item, complete with its own
 contract and Verify line — paste one into `## Items` by hand, or let hunt assemble it for you.
 
-Two endings exist, and every entry declares which it has:
+**Entries live one per file in [`shifts/`](shifts/).** Read that directory; this page never lists
+them. A catalog that enumerated its own contents would put every contributor in the same diff, and
+the point of a file per shift is that two people can add one the same week without meeting.
+
+Two endings exist, and every entry declares which it has in its title line:
 
 - **Open-ended** — no natural end but the clock. It stays a single open box while its loop runs and
   closes at the whistle (or at convergence, where the entry says so). `/nightshift:hunt` requires
@@ -15,76 +19,6 @@ Open-ended entries share the loop — scan → verify → fix behind the item ga
 line per cycle to `shift-log.md` (`cycle N · <scanned> · <found> · <fixed>`). They differ in the scan
 and in the ending.
 
-**Adding an entry:** see `catalog-recipe.md` in this directory. An entry that does not declare its
-ending, its definition of done, and what it will never do is not reviewable, and will not be merged.
-
-## Coverage hunt — open-ended — "give it the night, wake up to tests"
-
-```text
-- [ ] **Coverage hunt — add meaningful tests until quitting time.**
-  - Each cycle: find the highest-value untested behaviour, write real tests for it, run the item
-    gate, commit. Coverage is a tripwire, never a target — no padding tests to move a number; any
-    exclusion needs a written reason.
-  - Log one line per cycle. Stop only at quitting time, then clock out orderly.
-  - Verify: the item gate is green at every commit.
-```
-
-## Defect hunt — open-ended — the review cycle, ridden to convergence
-
-```text
-- [ ] **Defect hunt — review, fix, re-review until it converges.**
-  - Each cycle: review for defects; dedupe every finding against snag-log.md (ALL seen — fixed and
-    rejected) so a later cycle never re-reports an earlier one; fix each behind the item gate;
-    append dispositions; re-review.
-  - Stop at the first honest ending: a full pass finds nothing NEW (converged), or quitting time.
-    Zero new findings is success — stop even with time on the clock.
-  - Verify: the item gate is green at every commit; snag-log.md dispositions are current.
-```
-
-## Standing loop — open-ended — improve and discover until quitting time
-
-The greedy one: no convergence ending. An empty cycle is not "done" — it means the lens was too
-shallow. For when there is credit and hours, and the job is "make the product better".
-
-```text
-- [ ] **Standing loop — improve and discover until quitting time.**
-  - Open-ended: the deadline is the ONLY thing that ends this item. A cycle that finds nothing
-    means the lens was too shallow — go deeper (a new subsystem, a new entry point, a new user
-    path) and start the next cycle at once. Never idle between cycles.
-  - Each cycle pick 1–2 fresh lenses and rotate — never repeat the same shallow pass:
-    - Real bugs — trace one concrete user scenario end-to-end through every layer: races,
-      permission holes, stale state after mutations, timezone and edge inputs.
-    - UX friction — dead ends, hidden state, missing empty/loading/error states, too many clicks
-      to high-frequency work.
-    - Performance — hot-path waste, N+1 queries, missing indexes, chatty endpoints, needless
-      re-renders.
-    - Contracts — type drift between layers, duplicated enums out of sync, permission gating
-      parity on both sides (fail closed).
-    - Dead code — verify truly unreachable first, then delete fully; never stub.
-  - If the project has a UI, walk it live every few cycles with real clicks and the console open —
-    code-only scans miss what clicking finds.
-  - At every site inspection (the interval in `## Gates`; hourly if none is set), run the
-    project's quality tooling in report mode and feed new findings into the next cycle.
-  - Dedupe every finding against snag-log.md (ALL seen — fixed and rejected) before acting; append
-    dispositions after. Park owner decisions in parking-lot.md and keep working.
-  - Verify: the item gate is green at every commit; one conventional commit per coherent fix.
-```
-
-## Clear quality debt — finite — the backlog your tools already know about
-
-The finite counterpart to the hunts: the work is a list your own tooling produces, so it ends when
-that list is clear. `/nightshift:quality` runs the same scan read-only and proposes items without
-starting anything; this entry works them.
-
-```text
-- [ ] **Clear quality debt — fix what the project's own tooling reports.**
-  - Scan first: run the item-gate commands from `## Gates` in report mode (lint, types, tests),
-    per top-level package in a monorepo. Cluster the findings by tool and directory.
-  - Work one cluster per cycle: fix the real cause behind the item gate, commit, re-scan.
-  - Never silence instead of fixing — no new suppressions, no relaxed config, no deleted tests. A
-    finding the owner should decide on goes to parking-lot.md with a default, and work continues.
-  - Dedupe against snag-log.md (ALL seen — fixed and rejected) so a rejected finding is not raised
-    a second time.
-  - Ends when a full scan reports nothing new, or at quitting time if hours were set.
-  - Verify: the item gate is green at every commit.
-```
+**Adding an entry:** see [`catalog-recipe.md`](catalog-recipe.md) in this directory. An entry that
+does not declare its ending, its definition of done, and what it will never do is not reviewable,
+and will not be merged.

--- a/skills/nightshift/references/shifts/clear-quality-debt.md
+++ b/skills/nightshift/references/shifts/clear-quality-debt.md
@@ -1,0 +1,18 @@
+# Clear quality debt — finite — the backlog your tools already know about
+
+The finite counterpart to the hunts: the work is a list your own tooling produces, so it ends when
+that list is clear. `/nightshift:quality` runs the same scan read-only and proposes items without
+starting anything; this entry works them.
+
+```text
+- [ ] **Clear quality debt — fix what the project's own tooling reports.**
+  - Scan first: run the item-gate commands from `## Gates` in report mode (lint, types, tests),
+    per top-level package in a monorepo. Cluster the findings by tool and directory.
+  - Work one cluster per cycle: fix the real cause behind the item gate, commit, re-scan.
+  - Never silence instead of fixing — no new suppressions, no relaxed config, no deleted tests. A
+    finding the owner should decide on goes to parking-lot.md with a default, and work continues.
+  - Dedupe against snag-log.md (ALL seen — fixed and rejected) so a rejected finding is not raised
+    a second time.
+  - Ends when a full scan reports nothing new, or at quitting time if hours were set.
+  - Verify: the item gate is green at every commit.
+```

--- a/skills/nightshift/references/shifts/coverage-hunt.md
+++ b/skills/nightshift/references/shifts/coverage-hunt.md
@@ -1,0 +1,10 @@
+# Coverage hunt — open-ended — "give it the night, wake up to tests"
+
+```text
+- [ ] **Coverage hunt — add meaningful tests until quitting time.**
+  - Each cycle: find the highest-value untested behaviour, write real tests for it, run the item
+    gate, commit. Coverage is a tripwire, never a target — no padding tests to move a number; any
+    exclusion needs a written reason.
+  - Log one line per cycle. Stop only at quitting time, then clock out orderly.
+  - Verify: the item gate is green at every commit.
+```

--- a/skills/nightshift/references/shifts/defect-hunt.md
+++ b/skills/nightshift/references/shifts/defect-hunt.md
@@ -1,0 +1,11 @@
+# Defect hunt — open-ended — the review cycle, ridden to convergence
+
+```text
+- [ ] **Defect hunt — review, fix, re-review until it converges.**
+  - Each cycle: review for defects; dedupe every finding against snag-log.md (ALL seen — fixed and
+    rejected) so a later cycle never re-reports an earlier one; fix each behind the item gate;
+    append dispositions; re-review.
+  - Stop at the first honest ending: a full pass finds nothing NEW (converged), or quitting time.
+    Zero new findings is success — stop even with time on the clock.
+  - Verify: the item gate is green at every commit; snag-log.md dispositions are current.
+```

--- a/skills/nightshift/references/shifts/dependency-upgrade-sweep.md
+++ b/skills/nightshift/references/shifts/dependency-upgrade-sweep.md
@@ -1,0 +1,29 @@
+# Dependency upgrade sweep — finite — the version drift your package manager already tracks
+
+The work nobody schedules: hundreds of small mechanical steps, each one provable by the test suite.
+The list is whatever the package manager reports as outdated, so it ends. Six to eight hours clears
+a year of drift on a mid-sized project; a monorepo wants a second night.
+
+Supported wherever a package manager reports outdated direct dependencies — npm/pnpm/yarn, uv/pip,
+cargo, go modules.
+
+```text
+- [ ] **Dependency upgrade sweep — bring direct dependencies current, one at a time.**
+  - Discovery: the project's own outdated report — `pnpm outdated` / `npm outdated`,
+    `uv pip list --outdated`, `cargo outdated`, `go list -u -m all`. **Direct dependencies only**:
+    a transitive version is not yours to pin, and forcing one is the owner's call.
+  - Order patches, then minors, then majors, so a night that ends early still landed the safe wins.
+  - Per package: read the release notes and migration guide FIRST, upgrade, adapt the code the
+    breaking changes require, run the item gate, commit. One package per commit — a failing gate
+    has to point at one cause.
+  - Time-box a major. If adapting it sprawls past a bounded attempt, revert clean and park it with
+    what was learned: a half-migrated major leaves the tree worse than the old version did.
+  - A green gate proves only what it covers. Where a core package is thinly tested, park it rather
+    than claim the adaptation worked.
+  - Never take a prerelease (`rc`, `beta`, `next`). Never hand-edit the lockfile — let the package
+    manager write it, and commit it with the change that caused it. Never change the package
+    manager, the runtime version, or add overrides to force a pass; park those instead.
+  - Dedupe against snag-log.md (ALL seen — fixed and rejected) so a rejected upgrade is not retried.
+  - Ends when the outdated report names no direct dependency, or at quitting time if hours were set.
+  - Verify: the item gate is green at every commit.
+```

--- a/skills/nightshift/references/shifts/standing-loop.md
+++ b/skills/nightshift/references/shifts/standing-loop.md
@@ -1,0 +1,28 @@
+# Standing loop — open-ended — improve and discover until quitting time
+
+The greedy one: no convergence ending. An empty cycle is not "done" — it means the lens was too
+shallow. For when there is credit and hours, and the job is "make the product better".
+
+```text
+- [ ] **Standing loop — improve and discover until quitting time.**
+  - Open-ended: the deadline is the ONLY thing that ends this item. A cycle that finds nothing
+    means the lens was too shallow — go deeper (a new subsystem, a new entry point, a new user
+    path) and start the next cycle at once. Never idle between cycles.
+  - Each cycle pick 1–2 fresh lenses and rotate — never repeat the same shallow pass:
+    - Real bugs — trace one concrete user scenario end-to-end through every layer: races,
+      permission holes, stale state after mutations, timezone and edge inputs.
+    - UX friction — dead ends, hidden state, missing empty/loading/error states, too many clicks
+      to high-frequency work.
+    - Performance — hot-path waste, N+1 queries, missing indexes, chatty endpoints, needless
+      re-renders.
+    - Contracts — type drift between layers, duplicated enums out of sync, permission gating
+      parity on both sides (fail closed).
+    - Dead code — verify truly unreachable first, then delete fully; never stub.
+  - If the project has a UI, walk it live every few cycles with real clicks and the console open —
+    code-only scans miss what clicking finds.
+  - At every site inspection (the interval in `## Gates`; hourly if none is set), run the
+    project's quality tooling in report mode and feed new findings into the next cycle.
+  - Dedupe every finding against snag-log.md (ALL seen — fixed and rejected) before acting; append
+    dispositions after. Park owner decisions in parking-lot.md and keep working.
+  - Verify: the item gate is green at every commit; one conventional commit per coherent fix.
+```

--- a/skills/nightshift/references/shifts/vulnerability-sweep.md
+++ b/skills/nightshift/references/shifts/vulnerability-sweep.md
@@ -1,0 +1,24 @@
+# Vulnerability sweep — finite — the advisories filed against what you already ship
+
+Advisories are not lint: no tool in the project reports them, and they arrive on someone else's
+schedule. The list is what the audit tool publishes today, so it ends — usually in an hour or two,
+unless a major upgrade turns out to be the only route to a fix.
+
+Supported wherever the ecosystem publishes advisories — npm/pnpm/yarn, pip, cargo, go.
+
+```text
+- [ ] **Vulnerability sweep — clear the advisories the audit tool reports.**
+  - Discovery: the project's own audit — `pnpm audit` / `npm audit`, `pip-audit`, `cargo audit`,
+    `govulncheck`. Work critical and high first, so an interrupted night cleared what mattered.
+  - Per advisory: read what the vulnerability actually is and whether the project's usage reaches
+    it, move to the fixed version, adapt the code that change requires, run the item gate, commit.
+  - **Never downgrade to satisfy an advisory.** Where the only offered fix is an older version,
+    park it with the advisory link — a silent regression is not a fix.
+  - Never add an ignore or suppression entry, and never reach for an audit tool's `--force`.
+    Silencing an advisory is not clearing it.
+  - An advisory reachable only through a transitive dependency, or with no fixed version published,
+    goes to parking-lot.md with its link and severity: overrides and resolutions are owner calls.
+  - Record every disposition in snag-log.md so the next sweep does not re-raise a parked advisory.
+  - Ends when the audit reports clean, or every advisory still standing is parked with a reason.
+  - Verify: the item gate is green at every commit; the audit is re-run after the last fix.
+```

--- a/tests/catalog.bats
+++ b/tests/catalog.bats
@@ -1,0 +1,68 @@
+SHIFTS="$BATS_TEST_DIRNAME/../skills/nightshift/references/shifts"
+CAT="$BATS_TEST_DIRNAME/../skills/nightshift/references/shift-catalog.md"
+RECIPE="$BATS_TEST_DIRNAME/../skills/nightshift/references/catalog-recipe.md"
+
+# Structural rules only. Every assertion here globs the directory, so a contributed shift is
+# covered the moment its file lands — nobody edits this file to add an entry, which is the whole
+# reason entries are one per file.
+
+@test "the catalog directory has entries" {
+  [ -d "$SHIFTS" ]
+  n="$(find "$SHIFTS" -name '*.md' | wc -l | tr -d ' ')"
+  [ "$n" -gt 0 ]
+}
+
+# The ending decides whether hunt asks for hours at all, so every entry states it in its title
+# line where both a reader and the skill see it without parsing the body.
+@test "every entry declares its ending in its title" {
+  for f in "$SHIFTS"/*.md; do
+    head -n1 "$f" | grep -qE '^# .+ — (finite|open-ended) — ' \
+      || { echo "entry does not declare its ending: $f"; return 1; }
+  done
+}
+
+@test "every entry ships a pasteable punch-list item" {
+  for f in "$SHIFTS"/*.md; do
+    grep -q '^```text$' "$f" || { echo "no fenced item block: $f"; return 1; }
+    grep -qE '^- \[ \] \*\*.+\*\*$' "$f" || { echo "no punch-list item: $f"; return 1; }
+  done
+}
+
+# An item with no Verify line cannot prove its work, and the gate has nothing to be green about.
+@test "every entry ends with a Verify line" {
+  for f in "$SHIFTS"/*.md; do
+    grep -qE '^[[:space:]]*- Verify: ' "$f" || { echo "no Verify line: $f"; return 1; }
+  done
+}
+
+# The definition of done is the lever the whole product rests on. An entry that never says what
+# ends it is a shift that ends whenever the model feels finished.
+@test "every entry states what ends it" {
+  for f in "$SHIFTS"/*.md; do
+    grep -qiE 'ends when|stop (only )?at|quitting time|converge' "$f" \
+      || { echo "entry does not state its ending condition: $f"; return 1; }
+  done
+}
+
+# One file per entry is what keeps two contributors out of the same diff. An index that listed
+# them would put everyone back in it.
+@test "the catalog index points at the directory and lists no entries" {
+  grep -qF 'shifts/' "$CAT"
+  grep -qi 'this page never lists' "$CAT"
+  ! grep -qE '^## .+ — (finite|open-ended) — ' "$CAT"
+}
+
+# A contributed shift is a contract handed to an unattended agent on a stranger's repo. The six
+# declarations are what makes such a PR reviewable at all.
+@test "the catalog recipe demands every declaration a reviewer needs" {
+  [ -f "$RECIPE" ]
+  for d in 'finite or open-ended' 'Discovery' 'Definition of done' 'never do' 'Verification' 'Supported stacks'; do
+    grep -qi "$d" "$RECIPE" || { echo "recipe does not demand: $d"; return 1; }
+  done
+  grep -qi 'read by a human before merge' "$RECIPE"
+}
+
+@test "the recipe tells a contributor to add a file, not edit a shared one" {
+  grep -qF 'shifts/' "$RECIPE"
+  grep -qi 'tests/shifts/' "$RECIPE"
+}

--- a/tests/shifts/clear-quality-debt.bats
+++ b/tests/shifts/clear-quality-debt.bats
@@ -1,0 +1,9 @@
+E="$BATS_TEST_DIRNAME/../../skills/nightshift/references/shifts/clear-quality-debt.md"
+
+# This entry works the same findings /nightshift:quality only reports. It must fix causes, never
+# silence them — the one failure mode that would make a quality shift worse than nothing.
+@test "the quality-debt entry fixes causes and never silences" {
+  grep -qi 'never silence instead of fixing' "$E"
+  grep -qi 'no new suppressions' "$E"
+  grep -qi 'snag-log.md' "$E"
+}

--- a/tests/shifts/dependency-upgrade-sweep.bats
+++ b/tests/shifts/dependency-upgrade-sweep.bats
@@ -1,0 +1,36 @@
+E="$BATS_TEST_DIRNAME/../../skills/nightshift/references/shifts/dependency-upgrade-sweep.md"
+
+# A version bump that compiles is not an upgrade. The release notes are the work, and skipping
+# them is how a green gate hides a behaviour change nobody read about.
+@test "the upgrade sweep reads the release notes and adapts the code" {
+  grep -qi 'release notes and migration guide FIRST' "$E"
+  grep -qi 'adapt the code' "$E"
+}
+
+# Without a bound, one bad major eats the night and leaves the tree half-migrated — worse than the
+# old version it replaced.
+@test "the upgrade sweep bounds a single major" {
+  grep -qi 'Time-box a major' "$E"
+  grep -qi 'revert clean and park' "$E"
+}
+
+@test "the upgrade sweep refuses prereleases and stays on direct dependencies" {
+  grep -qi 'Never take a prerelease' "$E"
+  grep -qF 'Direct dependencies only' "$E"
+}
+
+# One package per commit is what makes a failing gate diagnosable at 4am.
+@test "the upgrade sweep commits one package at a time, safest first" {
+  grep -qi 'One package per commit' "$E"
+  grep -qi 'patches, then minors, then majors' "$E"
+}
+
+# A gate can only prove what it covers, so a thinly tested core package is a park, not a claim.
+@test "the upgrade sweep does not mistake a green gate for proof" {
+  grep -qi 'proves only what it covers' "$E"
+}
+
+@test "the upgrade sweep leaves owner decisions to the owner" {
+  grep -qi 'Never hand-edit the lockfile' "$E"
+  grep -qi 'never change the package' "$E"
+}

--- a/tests/shifts/standing-loop.bats
+++ b/tests/shifts/standing-loop.bats
@@ -1,0 +1,11 @@
+E="$BATS_TEST_DIRNAME/../../skills/nightshift/references/shifts/standing-loop.md"
+
+@test "the standing loop ends only at the deadline, never by convergence" {
+  grep -qi 'deadline is the ONLY thing' "$E"
+  grep -qiE 'too shallow' "$E"
+}
+
+@test "the standing loop runs the quality tooling at site inspections" {
+  grep -qi 'site inspection' "$E"
+  grep -qi 'report mode' "$E"
+}

--- a/tests/shifts/vulnerability-sweep.bats
+++ b/tests/shifts/vulnerability-sweep.bats
@@ -1,0 +1,31 @@
+E="$BATS_TEST_DIRNAME/../../skills/nightshift/references/shifts/vulnerability-sweep.md"
+
+# The advisory tool will happily offer an older version as the "fix". Taking it trades a known
+# vulnerability for a silent regression, unattended, with nobody watching.
+@test "the vulnerability sweep never downgrades to clear an advisory" {
+  grep -qF 'Never downgrade to satisfy an advisory' "$E"
+  grep -qi 'silent regression is not a fix' "$E"
+}
+
+# Every audit tool makes silencing a one-liner, which is exactly why the refusal has to be written.
+@test "the vulnerability sweep never silences instead of fixing" {
+  grep -qi 'never add an ignore or suppression entry' "$E"
+  grep -qi 'force' "$E"
+  grep -qi 'Silencing an advisory is not clearing it' "$E"
+}
+
+@test "the vulnerability sweep parks what is not its call" {
+  grep -qi 'transitive dependency' "$E"
+  grep -qi 'no fixed version published' "$E"
+  grep -qi 'parking-lot.md' "$E"
+}
+
+# An interrupted night should have cleared the advisories that mattered, not an alphabetical prefix.
+@test "the vulnerability sweep works severity first" {
+  grep -qi 'critical and high first' "$E"
+}
+
+@test "the vulnerability sweep re-runs the audit before it calls itself done" {
+  grep -qi 'audit reports clean' "$E"
+  grep -qi 're-run after the last fix' "$E"
+}

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -28,9 +28,11 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
 
 # The drafting table is where work waits, so it must show the item shape. It is never read by
 # the gate — only the punch list is — which is exactly why proposals land there first.
-@test "the drafting table and walkthrough templates do show the item shape" {
+@test "the drafting table and catalog entries do show the item shape" {
   [ "$(grep -cE "$OPEN_BOX" "$REF/drafting-table-template.md" || true)" -gt 0 ]
-  [ "$(grep -cE "$OPEN_BOX" "$REF/shift-catalog.md" || true)" -gt 0 ]
+  for f in "$REF"/shifts/*.md; do
+    [ "$(grep -cE "$OPEN_BOX" "$f" || true)" -gt 0 ] || { echo "no item shape: $f"; return 1; }
+  done
 }
 
 @test "every template setup copies is present" {

--- a/tests/walkthroughs.bats
+++ b/tests/walkthroughs.bats
@@ -1,51 +1,8 @@
-CAT="$BATS_TEST_DIRNAME/../skills/nightshift/references/shift-catalog.md"
-RECIPE="$BATS_TEST_DIRNAME/../skills/nightshift/references/catalog-recipe.md"
 HUNT="$BATS_TEST_DIRNAME/../skills/hunt/SKILL.md"
 START="$BATS_TEST_DIRNAME/../skills/start/SKILL.md"
 
-@test "the catalog ships the three open-ended shifts and the finite one" {
-  grep -q '^## Coverage hunt' "$CAT"
-  grep -q '^## Defect hunt' "$CAT"
-  grep -q '^## Standing loop' "$CAT"
-  grep -q '^## Clear quality debt' "$CAT"
-}
-
-# The ending decides whether hunt asks for hours at all, so every entry must state it in the
-# heading where both a reader and the skill can see it without parsing the body.
-@test "every catalog entry declares its ending in the heading" {
-  while IFS= read -r h; do
-    printf '%s' "$h" | grep -qE '^## .+ — (finite|open-ended) — ' \
-      || { echo "catalog entry does not declare its ending: $h"; return 1; }
-  done < <(grep '^## ' "$CAT" | grep -v '^## Shift catalog')
-}
-
-@test "the standing loop ends only at the deadline, never by convergence" {
-  grep -qi 'deadline is the ONLY thing' "$CAT"
-  grep -qiE 'too shallow' "$CAT"
-}
-
-@test "the standing loop runs the quality tooling at site inspections" {
-  grep -qi 'site inspection' "$CAT"
-  grep -qi 'report mode' "$CAT"
-}
-
-# The finite entry works the same findings /nightshift:quality only reports. It must fix causes,
-# never silence them — the one failure mode that would make a quality shift worse than nothing.
-@test "the quality-debt entry fixes causes and never silences" {
-  grep -qi 'never silence instead of fixing' "$CAT"
-  grep -qi 'no new suppressions' "$CAT"
-  grep -qi 'snag-log.md' "$CAT"
-}
-
-# A contributed shift is a contract handed to an unattended agent on a stranger's repo. The six
-# declarations are what makes such a PR reviewable at all.
-@test "the catalog recipe demands every declaration a reviewer needs" {
-  [ -f "$RECIPE" ]
-  for d in 'finite or open-ended' 'Discovery' 'Definition of done' 'never do' 'Verification' 'Supported stacks'; do
-    grep -qi "$d" "$RECIPE" || { echo "recipe does not demand: $d"; return 1; }
-  done
-  grep -qi 'read by a human before merge' "$RECIPE"
-}
+# The catalog's own rules live in catalog.bats (structural, globbed) and tests/shifts/<entry>.bats
+# (one file per entry), so adding a shift never edits a test file someone else is also editing.
 
 # Both entry points into a live shift must clear the same leftovers. They drifted once: start
 # cleared three markers, hunt's cut cleared none, so a spent deadline or a leftover STOP from
@@ -101,10 +58,13 @@ START="$BATS_TEST_DIRNAME/../skills/start/SKILL.md"
   grep -q 'work-orders.md' "$BATS_TEST_DIRNAME/../skills/setup/SKILL.md"
 }
 
-@test "hunt composes from the catalog and may pick more than one" {
-  grep -q 'shift-catalog.md' "$HUNT"
+# Entries are files in a directory, so hunt must list it. Reciting from memory is how a shift that
+# shipped last week never reaches the owner who could have used it tonight.
+@test "hunt composes from the catalog directory and may pick more than one" {
+  grep -qF 'references/shifts/' "$HUNT"
+  grep -qi 'read every file in it' "$HUNT"
   grep -qi 'more than one may be chosen' "$HUNT"
-  grep -qi 'read the catalog file rather than reciting from memory' "$HUNT"
+  grep -qi 'read the directory rather than reciting from memory' "$HUNT"
 }
 
 # Hours are mandatory only where nothing else can end the shift. Where the work has a natural


### PR DESCRIPTION
Catalog entries live one per file in `skills/nightshift/references/shifts/`, and `/nightshift:hunt` lists that directory instead of reading a single page.

**Adding a shift is two new files and no edits to anything shared:**

```
skills/nightshift/references/shifts/<name>.md   the entry
tests/shifts/<name>.bats                        what it promises
```

The index no longer enumerates its own contents — an index that listed the entries would put every contributor back in the same diff, which is the thing a file per shift exists to avoid.

`tests/catalog.bats` holds the structural rules and globs the directory, so a contributed entry is checked the moment it lands: its title declares its ending, and it carries a pasteable item, a Verify line, and a stated ending condition. Per-entry assertions live in the entry's own test file.

Both CI jobs now run `bats -r tests/`. Without it the subdirectory is skipped silently — 213 tests instead of 228 — and a contributed shift's tests never run.

## New entries

**Dependency upgrade sweep** (finite) — direct dependencies brought current one at a time, patches before majors, each behind the item gate and its own commit. The release notes are the work: a version bump that compiles is not an upgrade. A major that sprawls past a bounded attempt is reverted clean and parked, since a half-migrated major leaves the tree worse than the old version did. Prereleases refused; lockfile, package manager and runtime version left to the owner.

**Vulnerability sweep** (finite) — advisories cleared critical-first, so an interrupted night cleared what mattered. Never downgrades to satisfy an advisory and never adds a suppression: where the only offered fix is an older version, or the advisory sits in a transitive dependency, the decision is parked with its link and severity.

## Verification

228 tests, green under bash 5 and macOS system bash 3.2. shellcheck clean, `claude plugin validate --strict` passes.