### PR TITLE
ci: publish only what passed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,7 +1,11 @@
 name: ci
 
+# A branch push and its pull request are the same commit, so an unfiltered `push` ran every job
+# twice for no extra signal. Branch work is covered by `pull_request`; `push` is here for main,
+# where there is no PR to carry it — and where a green run is what lets release publish.
 on:
   push:
+    branches: [main]
   pull_request:
 
 jobs:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -4,9 +4,15 @@ name: release
 # Landing a version bump on main tags that commit and publishes its CHANGELOG section as the
 # release notes; a push that leaves the version alone is a no-op. Nothing else is published —
 # the marketplace serves main directly.
+#
+# It runs on ci's completion rather than on the push itself: both trigger from the same event, so
+# as parallel workflows this one published while the tests were still running. A version users
+# install is a version whose suite went green on that exact commit.
 
 on:
-  push:
+  workflow_run:
+    workflows: [ci]
+    types: [completed]
     branches: [main]
 
 permissions:
@@ -15,10 +21,16 @@ permissions:
 jobs:
   release:
     runs-on: ubuntu-latest
+    # A failed or cancelled run publishes nothing.
+    if: github.event.workflow_run.conclusion == 'success'
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          # The commit ci actually tested. Without this, workflow_run checks out whatever main
+          # points at now, which is a different tree the moment a second merge lands behind this
+          # one — and the tag would name a commit nothing verified.
+          ref: ${{ github.event.workflow_run.head_sha }}
 
       - name: Read the manifest version
         id: manifest


### PR DESCRIPTION
`release` ran on push to main, the same event as `ci`. As parallel workflows the tag and the GitHub release were published while the suite was still running — v0.7.3 was tagged with `ci #68` still in progress. A version users install could name a commit nothing had verified.

It now triggers on ci's completion for main:

```yaml
on:
  workflow_run:
    workflows: [ci]
    types: [completed]
    branches: [main]
```

with `if: github.event.workflow_run.conclusion == 'success'`, and checkout pinned to `workflow_run.head_sha` — the commit ci actually tested, so a second merge landing behind it cannot move the tree under the tag.

Release keys off the `push`/`main` run, which is unchanged. PR runs carry `head_branch` = the PR branch and are filtered out; neither workflow sets `concurrency`, so no run is cancelled by a later one, and each merge gets its own ci run and its own release decision.

`ci` also stops running on branch pushes. A branch push and its pull request are the same commit, so every job ran twice — `push`/`<branch>` and `pull_request`/`<branch>` — for no extra signal. Branch work is covered by the PR event; `push` remains for main.

## Behaviour change worth knowing

If ci goes red on main, a version bump sits unreleased until ci is green on that commit. The fix is re-running the ci job, not pushing again.

## Verification

Both workflows parse; triggers and conditions confirmed by parsing the YAML. 228 tests green, shellcheck clean, `plugin validate --strict` passes. No version bump: the gate's filter covers `hooks/ skills/ adapters/ .claude-plugin/`, so a CI-only change needs none and release correctly stays a no-op on merge.