### PR TITLE
ci: pin every action to a commit, and scope the token

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+  # The workflows pin every action to a commit SHA, which is what stops a repointed tag changing
+  # what CI runs. A pin only stays safe if something moves it, so Dependabot owns that.
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    commit-message:
+      prefix: ci
+    groups:
+      actions:
+        patterns: ["*"]

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,11 +8,16 @@ on:
     branches: [main]
   pull_request:
 
+# Nothing here writes to the repository: the suite reads the tree and reports. Declaring it means
+# a job that starts wanting more fails rather than inheriting whatever the default happens to be.
+permissions:
+  contents: read
+
 jobs:
   shellcheck:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install shellcheck
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Lint every shell script
@@ -33,7 +38,7 @@ jobs:
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
       - name: Require a version bump when shipped files change, and notes for a bump
@@ -72,7 +77,7 @@ jobs:
   bats:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install bats and shellcheck
         run: sudo apt-get update && sudo apt-get install -y bats shellcheck
       - name: Run the bats suite
@@ -89,7 +94,7 @@ jobs:
   bats-macos:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
       - name: Install bats
         run: brew install bats-core
       - name: Run the bats suite under macOS system bash
@@ -105,8 +110,8 @@ jobs:
   validate:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: 20
       - name: Install Claude Code

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
     # A failed or cancelled run publishes nothing.
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
           # The commit ci actually tested. Without this, workflow_run checks out whatever main

--- a/.github/workflows/scorecard.yaml
+++ b/.github/workflows/scorecard.yaml
@@ -1,0 +1,37 @@
+name: scorecard
+
+# OpenSSF Scorecard grades the things a reader of a security-adjacent tool would otherwise have
+# to take on trust: whether actions are pinned, whether main is protected, whether the token is
+# scoped, whether releases are tagged from a green build. The result lands in the Security tab.
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "27 5 * * 1"
+  push:
+    branches: [main]
+
+permissions: read-all
+
+jobs:
+  analysis:
+    name: analyze
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF result
+      id-token: write # publish the score so the badge can read it
+      contents: read
+      actions: read
+    steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
+
+      - uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - uses: github/codeql-action/upload-sarif@c4dd10e44af883a891fe31ced449bcb4a6728b9b # v3
+        with:
+          sarif_file: results.sarif


### PR DESCRIPTION
Every `uses:` is a commit SHA with the version in a trailing comment; a repointed tag can no
longer change what runs in a job that holds the token. `.github/dependabot.yml` keeps them moving.

`ci` declares `contents: read`. `release` already declared the write it needs. A weekly Scorecard
run reports pinning, branch protection and token scope into the Security tab.

No shipped file changes, so the plugin version is untouched.

- 228 tests pass
- all four workflow/config files parse
- every action across all workflows resolves to a 40-character SHA