### PR TITLE
feat: the skills speak both hosts

### DIFF
--- a/docs/commands.md
+++ b/docs/commands.md
@@ -49,6 +49,8 @@ shell that spends no tokens and needs no session:
 
 ```bash
 plugin/runtime/claude/schedule.sh --project . --at 04:05    # print the config + the install command
+plugin/runtime/claude/schedule.sh --project . --at 04:05 --agent 'codex exec -a never -s workspace-write'
+                                                     # same entry, run by Codex instead of Claude
 plugin/runtime/claude/schedule.sh --project . --list        # what is already registered for this project
 plugin/runtime/claude/schedule.sh --project . --remove      # the command that unregisters it
 ```

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -21,4 +21,4 @@ Everything is named from a real construction site — learn one term, guess the 
 | **red-tag** | stall guard | a stuck run is flagged in the shift log and held open by default; `NIGHTSHIFT_STALL_MAX=N` clocks it out after N stuck attempts instead |
 | **stop-work order** | `.nightshift/STOP` | `/nightshift:stop` — or `touch .nightshift/STOP` from any terminal — ends the shift at the agent's next stop attempt; the site rules stay armed until it actually stops |
 | **morning whistle** | `NIGHTSHIFT_NOTIFY_CMD` | optional shift-end ping (ntfy / Pushover / `say`) |
-| **night watchman** | `plugin/runtime/claude/watchman.sh` | revives a session that DIED mid-shift (crash, API outage) by resuming its own conversation; stands down at every honest ending |
+| **night watchman** | `plugin/runtime/claude/watchman.sh` | Claude Code sessions only today — revives a session that DIED mid-shift (crash, API outage) by resuming its own conversation; stands down at every honest ending |

--- a/plugin/runtime/claude/schedule.sh
+++ b/plugin/runtime/claude/schedule.sh
@@ -6,9 +6,11 @@
 # This generates their config, filled in for one project, and prints the single command that
 # installs it. It registers nothing itself.
 #
-#   schedule.sh [--project DIR] [--at HH:MM] [--list] [--remove]
+#   schedule.sh [--project DIR] [--at HH:MM] [--agent CMD] [--list] [--remove]
 #
 #   --at HH:MM   24-hour local time. Required unless --list or --remove.
+#   --agent CMD  the headless runner the entry invokes (default: claude -p).
+#                Codex projects pass: --agent 'codex exec -a never -s workspace-write'
 #   --list       what is already registered for this project, and nothing else
 #   --remove     print the command that unregisters it
 #
@@ -20,6 +22,7 @@ set -u
 
 PROJECT="$PWD"
 AT=""
+AGENT="claude -p"
 MODE="generate"
 
 usage() {
@@ -32,6 +35,7 @@ while [ $# -gt 0 ]; do
   case "$1" in
     --project) need_value "$1" $#; PROJECT="$2"; shift 2 ;;
     --at) need_value "$1" $#; AT="$2"; shift 2 ;;
+    --agent) need_value "$1" $#; AGENT="$2"; shift 2 ;;
     --list) MODE="list"; shift ;;
     --remove) MODE="remove"; shift ;;
     -h | --help) usage ;;
@@ -54,7 +58,7 @@ ID="${slug}-${hash}"
 LABEL="com.nightshift.${ID}"
 MARKER="# nightshift:${ID}"
 LOG="$PROJECT/.nightshift/scheduled.log"
-RUN="cd $PROJECT && claude -p '/nightshift:start' >> $LOG 2>&1"
+RUN="cd $PROJECT && $AGENT '/nightshift:start' >> $LOG 2>&1"
 
 case "$(uname -s)" in
   Darwin) OS="macos"; PLIST="$HOME/Library/LaunchAgents/${LABEL}.plist" ;;

--- a/plugin/skills/archive/SKILL.md
+++ b/plugin/skills/archive/SKILL.md
@@ -6,7 +6,9 @@ description: File the finished part of the run state into a dated archive — sh
 Archive the finished paperwork. Work in `$CLAUDE_PROJECT_DIR`. This files records — it never
 does shift work, never ticks a box, never touches the contract.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
+variable. (On Codex the variable does not exist; the session's working directory is the
+project root — treat it identically.)
 The shell's working directory persists between Bash calls and is not necessarily the project root;
 records filed into the wrong directory are records lost.
 

--- a/plugin/skills/hunt/SKILL.md
+++ b/plugin/skills/hunt/SKILL.md
@@ -6,7 +6,9 @@ description: Compose tonight's shift from the ready catalog — pick the jobs, c
 Compose a shift for `$CLAUDE_PROJECT_DIR`. Propose, never impose: nothing is worked without an
 explicit yes. If `.nightshift/` does not exist, stop and point to `/nightshift:setup` first.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
+variable. (On Codex the variable does not exist; the session's working directory is the
+project root — treat it identically.)
 The shell's working directory persists between Bash calls and is not necessarily the project root,
 so a bare relative path lands wherever the last `cd` left it.
 

--- a/plugin/skills/nightshift/SKILL.md
+++ b/plugin/skills/nightshift/SKILL.md
@@ -11,7 +11,7 @@ finish every item to its own standard, safely, leaving receipts. This skill is h
 If `.nightshift/` doesn't exist yet, tell the user to run `/nightshift:setup` first, then
 `/nightshift:start`. The commands own scaffolding and preflight; this skill owns the work.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. The shell's
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.) The shell's
 working directory persists between Bash calls and is not the project root once a gate or a build has
 run from inside the code repo; a bare relative path then reads a punch list that isn't there and
 writes receipts nobody will find.

--- a/plugin/skills/quality/SKILL.md
+++ b/plugin/skills/quality/SKILL.md
@@ -7,7 +7,7 @@ Survey this project's existing quality debt and turn what matters into proposed 
 The scan is read-only: run checks in report mode, fix nothing, write nothing without an explicit
 yes. Work in `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. The shell's
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.) The shell's
 working directory persists between Bash calls and drifts into the code repo while running the
 project's own check commands, so a bare relative path lands wherever the last `cd` left it.
 

--- a/plugin/skills/schedule/SKILL.md
+++ b/plugin/skills/schedule/SKILL.md
@@ -6,7 +6,7 @@ description: Set a shift to start at a fixed time — check the work is queued, 
 Get `$CLAUDE_PROJECT_DIR` ready to start on a clock, then hand the owner the config. Work through
 these in order; each one is a check the owner would otherwise discover at 4am.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. The shell's
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.) The shell's
 working directory persists between Bash calls and is not necessarily the project root.
 
 ## 1. Is there a site at all?
@@ -32,8 +32,11 @@ before the scheduled time, because start will not promote it.
 
 ## 3. Will the permissions hold?
 
-A scheduled run is headless and cannot answer a prompt. If neither `.claude/settings.local.json`
-nor `.claude/settings.json` grants frictionless permissions, warn once — the run will stall on the
+A scheduled run is headless and cannot answer a prompt. On Claude Code, if neither
+`.claude/settings.local.json` nor `.claude/settings.json` grants frictionless permissions, warn
+once. On Codex the grant travels in the command itself — the generator's
+`--agent 'codex exec -a never -s workspace-write'` carries it — so a Codex entry generated
+without that agent will stall on the
 first tool that asks. `/nightshift:setup` offers the fix.
 
 ## 4. Queuing arms the gate — say so
@@ -51,6 +54,7 @@ and show its output as it comes:
 
 ```bash
 "${CLAUDE_PLUGIN_ROOT}/runtime/claude/schedule.sh" --project "$CLAUDE_PROJECT_DIR" --at <HH:MM>
+# Codex projects add:  --agent 'codex exec -a never -s workspace-write'
 ```
 
 `--list` shows what is already registered for this project; `--remove` prints the command that

--- a/plugin/skills/setup/SKILL.md
+++ b/plugin/skills/setup/SKILL.md
@@ -6,7 +6,8 @@ description: Scaffold .nightshift/ from the templates and propose stack-aware qu
 Set up nightshift in this project. Do the scaffolding first, then the gates conversation, then print
 a summary. Work in `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` and `.claude/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with
+Every `.nightshift/` and `.claude/` path below is relative to `$CLAUDE_PROJECT_DIR` (on Codex, the
+session's working directory is the project root — treat it identically) — write it with
 the variable. The shell's working directory persists between Bash calls and drifts into the code
 repo during stack detection, so a bare relative path lands wherever the last `cd` left it.
 
@@ -66,11 +67,14 @@ denied means denied. Ask one question:
 > Overnight runs can't answer permission prompts. Enable `bypassPermissions` for this project?
 > (recommended — nightshift's guards are hooks and stay armed in every permission mode)
 
-- **Yes** → merge `{"permissions": {"defaultMode": "bypassPermissions"}}` into
+- **Yes, on Claude Code** → merge `{"permissions": {"defaultMode": "bypassPermissions"}}` into
   `$CLAUDE_PROJECT_DIR/.claude/settings.local.json` (create the file if absent; never clobber keys
   the owner already has). Write the full path: a copy that lands in a nested code repo grants the
   project nothing, and the first prompt of the night proves it. Settings on disk are what revivals
   inherit — a mode picked at launch dies with the process.
+- **Yes, on Codex** → there is no settings file to write: approvals are per launch. Tell the owner
+  the unattended spelling — `codex -a never -s workspace-write` — and that a session started
+  without it will stall on its first approval prompt exactly as described above.
 - **No** → respect it and say the cost plainly: *"a permission prompt mid-shift freezes the night
   until morning — if the shift stalls on one, that was tonight's trade."* Suggest the narrower
   alternative: pre-allow just the punch list's tools (test runner, linter, git) in the same file.
@@ -89,7 +93,7 @@ The hooks read this file directly on every tool call: an owner's edit applies fr
 next action. Nothing is synced anywhere, nothing needs a restart, and there is no second copy.
 Env vars of the matching names (`NIGHTSHIFT_FORBIDDEN_COMMANDS`, `NIGHTSHIFT_TOOL_RULES`, …)
 remain session-start overrides for tests and one-off exceptions — say so only if asked. If
-`$CLAUDE_PROJECT_DIR/.claude/settings.local.json` still carries `NIGHTSHIFT_*` env keys that an
+On Claude Code, `$CLAUDE_PROJECT_DIR/.claude/settings.local.json` may still carry `NIGHTSHIFT_*` env keys that an
 earlier version synced from this file, offer to remove them: the file is the one copy.
 
 **Template evolution — offer, never impose.** On a re-run with the file already present,

--- a/plugin/skills/start/SKILL.md
+++ b/plugin/skills/start/SKILL.md
@@ -5,7 +5,9 @@ description: Begin the shift — preflight, cut whatever is queued, arm the site
 
 Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
+variable. (On Codex the variable does not exist; the session's working directory is the project
+root — treat it identically.)
 The shell's working directory persists between Bash calls and drifts into the code repo while
 running gates, so a bare relative path reads or writes wherever the last `cd` left it.
 
@@ -19,13 +21,16 @@ so it looks at what is parked and asks which of it to work.
 ## 1. Preflight
 
 - **One shift, one agent — check before touching anything.** Read `.nightshift/.shift-session`.
-  If it records a session that is still alive — line 3's pid exists and `ps -o lstart= -p <pid>`
-  matches line 4, or the id on line 1 appears in `claude agents --json` — an agent is ALREADY
-  working this punch list. Do not start a second one beside it. Tell the owner and hand them the
-  running thread: `claude --resume <id>` for a terminal,
-  `vscode://anthropic.claude-code/open?session=<id>` for the IDE — and stop here;
-  `touch .nightshift/STOP` is the lever if they want that shift ended first. A record whose
-  process is dead is last night's leftover: fall through and clear it below.
+  Line 5 names the host that owns it. If the record is still alive, an agent is ALREADY working
+  this punch list — do not start a second one beside it; hand the owner the running thread and
+  stop here. On Claude Code, alive means line 3's pid exists and `ps -o lstart= -p <pid>` matches
+  line 4, or the id on line 1 appears in `claude agents --json`; the handoff is
+  `claude --resume <id>` for a terminal, `vscode://anthropic.claude-code/open?session=<id>` for
+  the IDE. On Codex the record carries no pid (lines 3–4 are empty by design), so treat any
+  codex record without an `.ended` beside it as possibly live and hand the owner
+  `codex resume <id>` rather than guessing. `touch .nightshift/STOP` is the lever if they want
+  that shift ended first. A record whose process is provably dead is last night's leftover: fall
+  through and clear it below.
 - **Clear every stale run-control marker first**, before anything writes a new one — last night's
   leftovers would otherwise end tonight's shift at its first stop attempt. Remove them all if
   present: `.nightshift/STOP`, `.nightshift/.stall`, `.nightshift/.notified`, `.nightshift/.ended`,
@@ -60,11 +65,13 @@ so it looks at what is parked and asks which of it to work.
   the file lacks mean a plugin update brought new knobs — say so once and point at
   `/nightshift:setup` to review them; never add them yourself here. (The hooks read the file
   live — there is no drift to check and no restart to suggest.)
-- The night cannot click Allow: if neither `.claude/settings.local.json` nor
+- The night cannot click Allow. On Claude Code: if neither `.claude/settings.local.json` nor
   `.claude/settings.json` grants frictionless permissions (`bypassPermissions` default mode or an
   allowlist covering the gates' commands), warn once — a permission prompt mid-shift freezes the
-  night, and a headless revival is denied outright. `/nightshift:setup` offers the fix. Warn and
-  proceed; the choice stays the owner's.
+  night, and a headless revival is denied outright; `/nightshift:setup` offers the fix. On Codex:
+  approvals are per launch — a shift meant to run unattended is started
+  `codex -a never -s workspace-write`, and a session missing that grant will freeze the same way.
+  Warn and proceed; the choice stays the owner's.
 
 ## 2. Deadline — read, never asked
 
@@ -101,10 +108,15 @@ Surface any still-unanswered entries in `.nightshift/parking-lot.md` (read-only)
 what the last shift parked — printed, never waited on. Append a `shift started` line to
 `.nightshift/shift-log.md`.
 
-## 5. Arm the night watchman
+## 5. Arm the night watchman (Claude Code only)
 
-Unless the rules file's `watchMinutes` is `0` (or `NIGHTSHIFT_WATCH=0` overrides), arm it in
-the background — it reads its cadence from the rules file itself:
+On Codex, skip this step: revival is not built for Codex yet, and Claude's watchman would only
+stand itself down on a codex-owned record. Append one honest line to the shift log —
+`watchman not armed (codex): revival is Claude Code-only today` — so the morning reader knows
+the night ran without a safety net, and continue to the work.
+
+On Claude Code, unless the rules file's `watchMinutes` is `0` (or `NIGHTSHIFT_WATCH=0`
+overrides), arm it in the background — it reads its cadence from the rules file itself:
 
 ```bash
 nohup "${CLAUDE_PLUGIN_ROOT}/runtime/claude/watchman.sh" --project "$CLAUDE_PROJECT_DIR" >/dev/null 2>&1 &

--- a/plugin/skills/status/SKILL.md
+++ b/plugin/skills/status/SKILL.md
@@ -6,7 +6,7 @@ description: Read-only shift status — open vs ticked items, parked decisions, 
 Report the shift status for `$CLAUDE_PROJECT_DIR` **without starting or changing anything** — this is
 read-only.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — read it with the variable.
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — read it with the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.)
 The shell's working directory persists between Bash calls and is not necessarily the project root,
 and a status read from the wrong directory reports a shift that does not exist.
 

--- a/plugin/skills/stop/SKILL.md
+++ b/plugin/skills/stop/SKILL.md
@@ -5,7 +5,9 @@ description: Issue a stop-work order — end the shift at once, leaving open ite
 
 Issue a stop-work order for `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the variable.
+Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
+variable. (On Codex the variable does not exist; the session's working directory is the
+project root — treat it identically.)
 The shell's working directory persists between Bash calls and is not necessarily the project root;
 a stop-work order written to the wrong directory stops nothing.
 

--- a/tests/schedule.bats
+++ b/tests/schedule.bats
@@ -124,3 +124,19 @@ STUB
   grep -qi 'spends no tokens and needs no session' "$r"
   grep -q 'plugin/runtime/claude/schedule.sh --project . --at' "$r"
 }
+
+# One generator serves both hosts: the entry's runner is a parameter, defaulting to Claude's.
+@test "--agent swaps the headless runner in the generated entry" {
+  p="$BATS_TEST_TMPDIR/proj"; mkdir -p "$p/.nightshift"
+  run "$SCHED" --project "$p" --at 04:05 --agent "codex exec -a never -s workspace-write"
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | grep -qF "codex exec -a never -s workspace-write '/nightshift:start'"
+  ! printf '%s' "$output" | grep -qF "claude -p" || false
+}
+
+@test "the default runner stays claude -p" {
+  p="$BATS_TEST_TMPDIR/proj2"; mkdir -p "$p/.nightshift"
+  run "$SCHED" --project "$p" --at 04:05
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | grep -qF "claude -p '/nightshift:start'"
+}


### PR DESCRIPTION
Setup, start and schedule carried Claude-only instructions; a Codex session reading them was told
to write files its host never reads. Each now forks where the hosts differ:

- permissions: a settings file on Claude Code, a per-launch grant on Codex
  (`codex -a never -s workspace-write`)
- the one-shift check hands the owner `claude --resume` or `codex resume`, decided by the
  record's host line
- the watchman step is skipped on Codex with an honest shift-log line — revival is
  Claude Code-only today
- `schedule.sh --agent` parameterises the entry's headless runner (default `claude -p`), so one
  generator schedules either host
- every skill's path rule states the project root where `$CLAUDE_PROJECT_DIR` does not exist

With this and #37, v0.8.0 ships Codex enforcement, shared skills that read correctly on both
hosts, and scheduling for both — recovery on Codex is the one thing that remains, deliberately.

- 257 tests pass (2 new for `--agent`), shellcheck clean, manifests validate