### PR TITLE
feat: keep long coding runs on task

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -4,7 +4,7 @@
   "plugins": [
     {
       "name": "nightshift",
-      "description": "Give Codex a checklist before bed. It can't clock out until every box is ticked, never stalls on a question, and revives itself if the API dies at 3 AM.",
+      "description": "Keep long Codex runs on task across compaction, resume, interruptions, and unattended engineering shifts.",
       "source": { "source": "local", "path": "./plugins/nightshift" },
       "policy": { "installation": "AVAILABLE", "authentication": "ON_INSTALL" },
       "category": "Productivity"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -5,14 +5,14 @@
     "url": "https://github.com/orwa-mahmoud"
   },
   "metadata": {
-    "description": "Home of nightshift: accountable autonomous runs for Claude Code \u2014 the agent can't clock out until the punch list is done, and a dead session is revived rather than mourned."
+    "description": "Home of nightshift: accountable Claude Code and Codex engineering shifts with persistent state, enforced boundaries, recovery, and evidence-backed product evolution."
   },
   "plugins": [
     {
       "name": "nightshift",
       "source": "./plugins/nightshift",
       "displayName": "nightshift",
-      "description": "Claude works the night shift: it can't clock out until the punch list is done, parks questions instead of waking you, and revives the session an API 500 killed at 3 AM.",
+      "description": "Keep long Claude Code runs on task: enforce the punch list, park questions, preserve progress, recover crashes, and run product or quality shifts until done.",
       "category": "workflow",
       "tags": [
         "autonomous",
@@ -22,7 +22,8 @@
         "guardrails",
         "hooks",
         "crash-recovery",
-        "agent-harness"
+        "agent-harness",
+        "product-evolution"
       ],
       "keywords": [
         "claude-code",
@@ -33,7 +34,8 @@
         "hooks",
         "crash-recovery",
         "session-resume",
-        "api-error-500"
+        "api-error-500",
+        "product-evolution"
       ],
       "author": {
         "name": "Orwa Mahmoud",

--- a/README.md
+++ b/README.md
@@ -1,15 +1,30 @@
 # nightshift
 
-> **Give Claude a checklist before bed. It can't clock out until every box is ticked, never stalls
-> on a question, and revives itself if the API dies at 3 AM.**
+> **Keep long coding runs on task.**
 
-A [Claude Code](https://claude.com/claude-code) plugin for long, unattended runs (hours → days) —
-a harness for the accountability half of an agent loop. You write the checklist. Hooks keep the
-agent on site until every box is ticked, under rules you set and it can't bend. You go to sleep.
+Nightshift gives [OpenAI Codex](https://openai.com/codex/) and
+[Claude Code](https://claude.com/claude-code) accountable, time-bounded engineering shifts. Hand it
+your own punch list or let it research the product, rank opportunities, and build the strongest
+complete improvements until quitting time. State stays on disk, safety rules are enforced by
+hooks, and the morning handoff is reviewable. Claude Code cannot quietly clock out with open work;
+Codex can recover the active objective and exact next action after compaction or resume.
 
 Overview and FAQ: <https://orwamahmoud.com/nightshift/>
 
 ## Install
+
+### Codex and ChatGPT
+
+[Install Nightshift from the official OpenAI Plugin Directory](https://chatgpt.com/plugins/plugins_6a7c58f65d708191b3a705a8625baffe).
+
+For local Codex development, the same package can be installed from its marketplace:
+
+```text
+codex plugin marketplace add orwa-mahmoud/claude-nightshift
+codex plugin add nightshift@nightshift
+```
+
+### Claude Code
 
 Two commands inside Claude Code — no npm, no Homebrew, no separate CLI, no API keys, no server:
 
@@ -18,14 +33,7 @@ Two commands inside Claude Code — no npm, no Homebrew, no separate CLI, no API
 /plugin install nightshift
 ```
 
-Also runs on **OpenAI Codex** — same package, same skills, its own hook wiring:
-
-```text
-codex plugin marketplace add orwa-mahmoud/claude-nightshift
-codex plugin add nightshift@nightshift
-```
-
-The clock-out gate, the guards, the skills and crash revival are live-verified on Codex — a
+The punch-list gate, guards, skills and crash revival are live-verified on Codex — a
 killed session is resumed into its own conversation, same as on Claude Code. One boundary
 remains: a Codex session that is alive but wedged on an API error is left alone until that
 signature has been observed in the wild.
@@ -34,7 +42,8 @@ signature has been observed in the wild.
 
 You do not need to learn the whole system first.
 
-1. Open a project you trust and run `/nightshift:setup`. Accept the proposed gates you want.
+1. Open a project you trust and ask Nightshift to set itself up (`/nightshift:setup` on Claude
+   Code). Accept the proposed gates you want.
    For an unattended run, either pre-allow the tools your work needs or let setup configure
    `bypassPermissions` for that project.
 2. In `.nightshift/punch-list.md`, add one small, real task under `## Items`:
@@ -46,18 +55,19 @@ You do not need to learn the whole system first.
      - Commit: `<type: concise message>`
    ```
 
-3. Run `/nightshift:start`.
-4. Later, run `/nightshift:status`.
+3. Ask Nightshift to start (`/nightshift:start` on Claude Code).
+4. Later, ask for status (`/nightshift:status` on Claude Code).
 5. Review the local commit, then push it yourself.
 
 Only four ideas matter on the first run:
 
-- **Punch list:** the work Claude must finish.
+- **Punch list:** the work the agent must finish.
 - **Gates:** checks that must pass before an item is ticked.
 - **Parking lot:** questions Claude records instead of waking you.
 - **Shift log:** the record of progress and problems.
 
-Drafting tables, work orders, hunts, the watchman, receipts, and archives are useful later, but
+Product research, opportunity maps, drafting tables, work orders, hunts, the watchman, receipts,
+and archives are useful later, but
 none is required to try one shift.
 
 ## The screen that made me build nightshift
@@ -166,9 +176,14 @@ clocks out only once every box is ticked.
 ## When to call in the night shift
 
 - **Two days left in the cycle, 80% of your credit unspent.** It doesn't roll over — and you do
-  not need a backlog ready to spend it. `/nightshift:hunt` offers a ready-made shift, writes it as
-  the punch list, and the night turns the credit into tests, fixes or upgrades you would otherwise
-  have lost.
+  not need a backlog ready to spend it. Ask for the product-evolution shift: Nightshift studies the
+  product and its history, researches comparable tools and user needs, ranks opportunities by
+  evidence, value, differentiation, effort and risk, then builds the strongest complete
+  improvements on an isolated branch. Or choose a bounded test, quality, defect, security or
+  dependency shift. On Claude Code, `/nightshift:hunt` stages any of them in seconds.
+  During a long build, the active opportunity records completed work, rejected paths, the exact
+  next action and verification still due, so a compacted or resumed session continues the cycle
+  instead of rediscovering it.
 - **The API is throwing 500s and you are about to leave.** Write the items, start the shift, and
   go. The first call comes back `API Error: 500` and nothing runs — the watchman keeps knocking
   all night, and picks up that same conversation the moment the API answers.
@@ -181,8 +196,7 @@ clocks out only once every box is ticked.
   nobody owns. `/nightshift:quality` turns the debt into punch-list items — accept the ones you
   care about, decline the rest, and let the night clear them.
 - **The classics.** Add real test coverage overnight, ride the review → fix loop until it
-  converges, or run the standing loop until the whistle. All ready-made — `/nightshift:hunt`
-  stages one in seconds.
+  converges, or evolve the product until the whistle. All ready-made.
 
 If you can write it as a checklist, you can hand it to the night.
 
@@ -206,8 +220,8 @@ receipts repo if you opt in at setup.
 ## The ready shifts
 
 You do not have to invent the night's work. `/nightshift:hunt` reads the catalog, offers what it
-finds — test coverage, a review loop ridden to convergence, your lint and type debt, dependency
-upgrades, security advisories, a standing improve-and-discover loop — and writes the one you pick
+finds — evidence-backed product evolution, test coverage, a review loop ridden to convergence,
+your lint and type debt, dependency upgrades, and security advisories — and writes the one you pick
 as a work order: the item plus its hours, parked with the clock not running. Say the word and it
 cuts the order into the punch list and the gate takes over.
 
@@ -249,17 +263,29 @@ my-project/            ← plain folder, not a repo — open Claude Code here
 Outside the repo, run state can never be committed by any mistake — separation by construction,
 not configuration. (This repo is built exactly this way.)
 
-## Built into Claude Code, not bolted on
+## Built into both hosts, not pasted into a prompt
 
-nightshift extends Claude Code through its own extension points — hooks for enforcement, skills
-for the method, the plugin marketplace for install. It wraps nothing, proxies nothing, and needs
-no package manager: `/plugin install` is the whole setup. A harness that stands outside an agent
-can only re-invoke it; one that runs inside can refuse the exit, deny the tool call, and park the
-question.
+Nightshift ships native skills and hook wiring for Codex and Claude Code from one package. It wraps
+nothing and proxies nothing. The skills carry the working method; disk files keep the objective,
+evidence and decisions available across compaction or a resumed session; hooks enforce the
+host-specific boundaries that are available.
 
-The *method* travels further than the plugin does. A punch list, one commit per item, decisions
-parked instead of asked — that is plain markdown and git, and you can follow it by hand with any
-agent. The mechanical enforcement is Claude Code's, deliberately.
+Claude Code gets the original hard clock-out guarantee: an attempted stop with open boxes receives
+the focused contract again, questions are parked, and a dead session can be revived. Codex already
+persists more naturally through an active task, so its strongest value is different: a bounded
+shift, a durable product-research and opportunity trail, mechanical safety rules, isolated changes,
+and reviewable progress that converts otherwise-unused capacity into product work.
+
+This does not claim to repair a host's conversation history. It makes the important state
+independent of it. That matters when long Codex tasks lose intent after compaction, limits, or
+resume—failure modes reported by users in
+[#25900](https://github.com/openai/codex/issues/25900),
+[#8310](https://github.com/openai/codex/issues/8310), and
+[#29356](https://github.com/openai/codex/issues/29356). Claude Code users report the other side of
+the same continuity problem—premature completion and lost resume context—in
+[#6159](https://github.com/anthropics/claude-code/issues/6159) and
+[#43044](https://github.com/anthropics/claude-code/issues/43044). Nightshift addresses the working
+contract around those failures; it does not claim to patch either host's internal context engine.
 
 ## The fine print
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -13,6 +13,10 @@
 # you review the local commits and push — or forbid pushing outright (one env line below)
 ```
 
+Those are Claude Code's slash spellings. In Codex or ChatGPT, mention Nightshift and ask naturally:
+“set up Nightshift,” “show me the ready-made shifts,” “run product evolution for four hours,”
+“start the shift,” or “show shift status.” The same skills and `.nightshift/` files are used.
+
 Stop-work order, any time, from any terminal: `touch .nightshift/STOP`. In an interactive session
 Escape is the immediate halt; STOP is what reaches a headless run, and it ends
 the shift at the agent's next stop attempt.
@@ -60,7 +64,6 @@ that already has one, and identifies projects by path rather than folder name, s
 called `api` never collide. It cannot queue your work for you, though — that part has to be in the
 punch list already.
 
-One more appears in your slash menu: `/nightshift:nightshift` is the method itself — how to work an
-item, park a decision, keep a snag log. Claude loads it on its own whenever a shift is running, so
-you rarely type it; invoke it directly only to have Claude follow the method on a list you are
-driving by hand.
+One more appears in Claude Code's slash menu: `/nightshift:nightshift` is the method itself — how to
+work an item, park a decision, keep a snag log, and run product evolution. The agent loads it on its
+own whenever a shift is running, so you rarely invoke it directly.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -13,6 +13,8 @@ Everything is named from a real construction site — learn one term, guess the 
 | **hunt** | `/nightshift:hunt` | writes a ready-made walkthrough as a work order; cuts it into the punch list only on your word |
 | **work order** | `.nightshift/work-orders.md` | a prepared job ticket — the item plus its hours, clock not running until the cut |
 | **snag log** | `.nightshift/snag-log.md` | findings ledger across runs — cycle 4 never re-reports cycle 1 |
+| **product research** | `.nightshift/product-research.md` | dated evidence about the product, users, comparable tools, and unmet needs; conclusions keep their source links |
+| **opportunity map** | `.nightshift/opportunity-map.md` | ranked product opportunities with evidence, value, differentiation, effort, reversibility, risk, and an honest status; its single `building` entry is the resumable current cycle |
 | **parking lot** | `.nightshift/parking-lot.md` | decisions for the human — parked with a default chosen, the run continues |
 | **park, don't ask** | hardhat rule | during a shift the ask-tool is denied — the question is parked with a default chosen; answer mid-run in the session and the agent applies it |
 | **quality survey** | `/nightshift:quality` | the optional debt audit — existing lint/type findings become proposed items; accept, edit, or decline |

--- a/plugins/nightshift/.claude-plugin/plugin.json
+++ b/plugins/nightshift/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nightshift",
   "version": "0.8.1",
-  "description": "Claude works the night shift: it can't clock out until the punch list is done, parks questions instead of waking you, and revives the session an API 500 killed at 3 AM.",
+  "description": "Keep long Claude Code runs on task: enforce the punch list, park questions, preserve progress, recover crashes, and run product or quality shifts until done.",
   "author": {
     "name": "Orwa Mahmoud",
     "url": "https://github.com/orwa-mahmoud"
@@ -18,6 +18,7 @@
     "hooks",
     "crash-recovery",
     "session-resume",
-    "api-error-500"
+    "api-error-500",
+    "product-evolution"
   ]
 }

--- a/plugins/nightshift/.codex-plugin/plugin.json
+++ b/plugins/nightshift/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nightshift",
   "version": "0.8.1",
-  "description": "Give Codex a job for the night. Run accountable, time-bounded engineering shifts from a persistent punch list, with ready-made hunts for test coverage, quality debt, defects, vulnerabilities, dependency upgrades, and continuous improvement.",
+  "description": "Keep long Codex runs on task with a persistent punch list, durable progress across compaction and resume, mechanical safety rules, recovery, and ready-made product and quality shifts.",
   "author": {
     "name": "Orwa Mahmoud",
     "url": "https://github.com/orwa-mahmoud"
@@ -13,14 +13,15 @@
   "hooks": "./hooks/codex/hooks.json",
   "interface": {
     "displayName": "Nightshift",
-    "shortDescription": "Put Codex to work on an accountable engineering shift",
-    "longDescription": "Give Codex a persistent punch list and a time budget, then leave it working. Start with your own tasks or choose a ready-made shift: increase meaningful test coverage, clear lint and type debt, hunt and fix defects, address security advisories, upgrade direct dependencies, or continuously improve bugs, UX, performance, contracts, and dead code. Nightshift parks decisions instead of waiting, enforces owner-defined safety rules, leaves reviewable progress, and recovers interrupted sessions.",
+    "shortDescription": "Keep long coding runs on task",
+    "longDescription": "Keep long Codex runs anchored to an authoritative punch list when conversations compact, sessions resume, or unattended work is interrupted. Nightshift keeps goals, completion state, decisions, research, active progress, exact next actions, and verification on disk; parks questions instead of waiting; enforces owner-defined safety rules; and leaves reviewable commits and run history. Give it your own work or use a ready-made shift for evidence-backed product evolution, meaningful test coverage, lint and type debt, defect hunting, security advisories, or direct dependency upgrades. Add a time budget to turn otherwise-unused capacity into product progress on an isolated branch while you retain the decision to merge or publish.",
     "developerName": "Orwa Mahmoud",
     "category": "Productivity",
     "capabilities": [
       "Persistent punch-list shifts",
       "Time-bounded engineering work",
       "Ready-made quality hunts",
+      "Evidence-backed product evolution",
       "Mechanical safety rules",
       "Question parking",
       "Reviewable run history",
@@ -29,8 +30,11 @@
     "defaultPrompt": [
       "Set up Nightshift in this project.",
       "Show me the ready-made shifts I can run tonight.",
-      "Find useful work for a four-hour shift."
+      "Use the next four hours to research and improve this product."
     ],
+    "websiteURL": "https://orwamahmoud.com/nightshift/",
+    "privacyPolicyURL": "https://orwamahmoud.com/nightshift/privacy/",
+    "termsOfServiceURL": "https://orwamahmoud.com/nightshift/terms/",
     "composerIcon": "./assets/nightshift-logo.png",
     "logo": "./assets/nightshift-logo.png"
   }

--- a/plugins/nightshift/skills/archive/SKILL.md
+++ b/plugins/nightshift/skills/archive/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: archive
-description: File the finished part of the run state into a dated archive — shipped items, the rotated journal, handled snags. The live files stay lean; the facts stay on disk.
+description: File the finished part of the run state into a dated archive — shipped items, research, opportunities, the rotated journal, and handled snags. The live files stay lean; the facts stay on disk.
 ---
 
 Archive the finished paperwork. Work in `$CLAUDE_PROJECT_DIR`. This files records — it never
@@ -32,6 +32,16 @@ run (create parents; re-running on the same day appends to that day's files).
 - **Parking lot — only what's answered.** Same rule: answered entries move, unanswered stay.
 - **Work orders — only what's spent.** Orders already cut into a punch list or marked done
   move; pending orders stay.
+- **Product research → the archive after its shift.** When no shift is active, append the completed
+  entries from `product-research.md` to the archive's `product-research.md`, preserving their dates,
+  sources, evidence, and conclusions; then restore the live file from the shipped template. During
+  an active shift, leave all research live. Research is evidence, so never summarize it away or
+  strip its source URLs while filing it.
+- **Opportunity map — only terminal outcomes.** Move `shipped` and `rejected` entries from
+  `opportunity-map.md` into the archive's `opportunity-map.md`, preserving their evidence links and
+  reasons. Keep `candidate`, `building`, and `parked` entries live: they can still affect a future
+  cycle or need the owner. Restore the shipped headings if moving the last terminal entry leaves an
+  empty section. Never renumber or silently change a status during archive.
 
 ## Timing
 

--- a/plugins/nightshift/skills/hunt/SKILL.md
+++ b/plugins/nightshift/skills/hunt/SKILL.md
@@ -28,7 +28,7 @@ exists in the folder but not in the offer is a job the owner never gets.
 
 Per the entry's declared ending:
 
-- **Open-ended** (coverage hunt, defect hunt, standing loop) — hours are REQUIRED. These have no
+- **Open-ended** (coverage hunt, defect hunt, product evolution / standing loop) — hours are REQUIRED. These have no
   natural end but the clock; a walkthrough may not start without a deadline.
 - **Finite** (clear quality debt) — ask the ending as an explicit either/or: *until every finding
   is clear, or capped at N hours?* Both are real answers; the work ends when the list is empty

--- a/plugins/nightshift/skills/nightshift/SKILL.md
+++ b/plugins/nightshift/skills/nightshift/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: nightshift
-description: Run an accountable autonomous shift — work a punch list to completion without clocking out early, park decisions instead of asking, and leave receipts. Use when the user wants to work through a todo list autonomously, run overnight, "don't stop until it's done", "keep going until the list is clear", add test coverage overnight, find and fix everything, or keep reviewing until it's clean.
+description: Run an accountable autonomous shift — work a punch list to completion, evolve a product from research, park decisions instead of asking, and leave receipts. Use when the user wants to work through a todo list autonomously, spend remaining agent usage, run overnight, polish or improve a product, research competitors and ship opportunities, add test coverage, find and fix everything, or keep reviewing until it is clean.
 ---
 
 # nightshift — the brain
@@ -64,10 +64,13 @@ honestly:
 - **Defect hunt** — review, dedupe against the snag log, fix behind the gate, re-review. Stop when a
   full pass finds nothing NEW (converged) or at quitting time. **Zero new findings is success** —
   stop honestly even with time on the clock.
-- **Standing loop** — improve and discover: rotate 1–2 fresh lenses per cycle (bugs, UX,
-  performance, contracts, dead code), walk the live UI every few cycles, run the quality tooling
-  at each site inspection. No convergence ending — an empty cycle means a deeper lens, and only
-  quitting time ends the item.
+- **Product evolution (standing loop)** — understand the product, research its space, rank an
+  evidence-backed opportunity map, and build the strongest complete improvements that fit the
+  clock on an isolated branch. Lint and tests verify the work; they do not choose the roadmap.
+  Small fixes through substantial features are valid, but the shift never merges itself and never
+  leaves a half-built production path. The single `building` opportunity is the continuation
+  record: read it first on resume and keep its completed work, rejected paths, exact next action,
+  and remaining verification current at meaningful boundaries. Only quitting time ends the item.
 
 Log one line per cycle to `shift-log.md`. A cycle that finds nothing new is success, not idleness.
 

--- a/plugins/nightshift/skills/nightshift/references/opportunity-map-template.md
+++ b/plugins/nightshift/skills/nightshift/references/opportunity-map-template.md
@@ -1,0 +1,42 @@
+# Opportunity map
+
+Rank opportunities by user value, evidence/confidence, differentiation, effort, reversibility, and
+regression risk. Every entry carries one status: candidate, building, shipped, rejected, or parked.
+
+Only one opportunity may be `building` at a time. Its entry is the live continuation record for a
+long product-evolution cycle: keep it precise enough that a resumed session can take the stated
+next action without reconstructing the work from conversation history. Refresh it at meaningful
+boundaries, not after every command.
+
+## Opportunities
+
+<!-- Candidate / shipped / rejected / parked entries:
+
+### <title>
+Status: candidate | shipped | rejected | parked
+Evidence: <repository facts and research links>
+Value: <user outcome>
+Confidence: <high / medium / low and why>
+Differentiation: <why this belongs in this product>
+Effort: <small / medium / substantial>
+Reversibility: <rollback boundary>
+Risk: <regression and product risks>
+Reference: <commit, spec, or parking-lot entry when applicable>
+
+The single active entry additionally carries:
+
+### <title>
+Status: building
+Evidence: <why it was selected>
+Scope: <the complete improvement being built>
+Acceptance: <observable conditions that make it finished>
+Current phase: <research / design / build / verify>
+Completed: <meaningful finished steps and commit ids>
+Decisions: <stable conclusions that must survive resume>
+Rejected: <approaches not to repeat and why>
+Next: <one exact concrete action>
+Verify remaining: <checks still required>
+Effort: <small / medium / substantial>
+Reversibility: <rollback boundary>
+Risk: <regression and product risks>
+-->

--- a/plugins/nightshift/skills/nightshift/references/product-research-template.md
+++ b/plugins/nightshift/skills/nightshift/references/product-research-template.md
@@ -1,0 +1,10 @@
+# Product research
+
+Append-only evidence for product-evolution shifts. Never put secrets, private code, customer data,
+or unpublished plans in a web query.
+
+## Research
+
+<!-- Per shift: date, current product promise and audience, repository evidence, dated public source
+     URLs with observations, competitor/alternative notes, and explicit limits when browsing was
+     unavailable. Research supports decisions; it does not make owner decisions. -->

--- a/plugins/nightshift/skills/nightshift/references/shifts/standing-loop.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/standing-loop.md
@@ -1,28 +1,60 @@
-# Standing loop — open-ended — improve and discover until quitting time
+# Product evolution — open-ended — research the space and improve until quitting time
 
-The greedy one: no convergence ending. An empty cycle is not "done" — it means the lens was too
-shallow. For when there is credit and hours, and the job is "make the product better".
+The flagship shift for spare agent capacity. The product, its users, and its market decide the
+work; lint and tests prove each change rather than supplying the roadmap. It may ship a sharp fix
+or a substantial feature, but never merges its own branch and never leaves a half-built path.
 
 ```text
-- [ ] **Standing loop — improve and discover until quitting time.**
-  - Open-ended: the deadline is the ONLY thing that ends this item. A cycle that finds nothing
-    means the lens was too shallow — go deeper (a new subsystem, a new entry point, a new user
-    path) and start the next cycle at once. Never idle between cycles.
-  - Each cycle pick 1–2 fresh lenses and rotate — never repeat the same shallow pass:
-    - Real bugs — trace one concrete user scenario end-to-end through every layer: races,
-      permission holes, stale state after mutations, timezone and edge inputs.
-    - UX friction — dead ends, hidden state, missing empty/loading/error states, too many clicks
-      to high-frequency work.
-    - Performance — hot-path waste, N+1 queries, missing indexes, chatty endpoints, needless
-      re-renders.
-    - Contracts — type drift between layers, duplicated enums out of sync, permission gating
-      parity on both sides (fail closed).
-    - Dead code — verify truly unreachable first, then delete fully; never stub.
-  - If the project has a UI, walk it live every few cycles with real clicks and the console open —
-    code-only scans miss what clicking finds.
-  - At every site inspection (the interval in `## Gates`; hourly if none is set), run the
-    project's quality tooling in report mode and feed new findings into the next cycle.
-  - Dedupe every finding against snag-log.md (ALL seen — fixed and rejected) before acting; append
-    dispositions after. Park owner decisions in parking-lot.md and keep working.
-  - Verify: the item gate is green at every commit; one conventional commit per coherent fix.
+- [ ] **Product evolution — research, build, and improve until quitting time.**
+  - Isolate first: work on a dedicated nightshift branch, never the default branch. Never merge,
+    push, open a PR, deploy, publish, or mutate an external service unless the owner explicitly
+    authorized that exact action. The owner decides what ships in the morning.
+  - Understand before inventing: read the product docs, issues, architecture, existing features,
+    user-facing flows, and recent history. Write the current promise, audience, strengths, and
+    weak spots to product-research.md before selecting work.
+  - Research the space when web access is available: find comparable products, competing
+    approaches, public user complaints, expectations, and relevant standards. Record dated source
+    URLs plus observations in product-research.md. Never send private code, secrets, customer data,
+    unpublished plans, or proprietary text to a search service; never copy a competitor's wording,
+    assets, or implementation. If browsing is unavailable, say so in the record and continue from
+    repository evidence rather than pretending research happened.
+  - Maintain opportunity-map.md. Rank each opportunity by user value, evidence/confidence,
+    differentiation, effort, reversibility, and regression risk. Mark it candidate, building,
+    shipped, rejected, or parked, with the evidence behind the disposition.
+  - Resume before exploring: if opportunity-map.md has a building entry, read its scope,
+    acceptance, completed work, decisions, rejected paths, exact next action, and remaining
+    verification; continue that opportunity first. Never open a second building opportunity.
+  - Each cycle: choose the strongest complete improvement that fits the remaining time. Before
+    substantial implementation, make it the single building entry using the shipped structure.
+    Small fixes, coherent medium work, and substantial features are all valid. Build end-to-end,
+    run the item gate, commit separately, update the opportunity map, then reassess the product
+    before choosing again. Keep the branch buildable after every commit.
+  - The building entry is the cycle's continuation record. Refresh Current phase, Completed,
+    Decisions, Rejected, Next, and Verify remaining after meaningful boundaries — research or
+    design concludes, a coherent implementation step lands, a decision closes a path, a commit is
+    made, or verification changes state. Do not rewrite it after every command and do not use the
+    snag log as a progress journal.
+  - Large is allowed; half-built is not. Start a larger feature only when the problem is supported
+    by evidence, it fits the product direction, it has a clean rollback boundary, and it can be
+    completed and verified inside the remaining shift. Otherwise leave research, a specification,
+    or an isolated prototype and park the production decision.
+  - Owner decisions stay owner decisions: park pricing, licensing, branding, privacy/legal policy,
+    destructive data migrations, new external services, telemetry, authentication, paid
+    dependencies, and architectural commitments. Do not turn an unattended guess into policy.
+  - Rotate lenses between cycles: product gaps, real user-path defects, UX friction, performance,
+    contracts between layers, meaningful test gaps, and verified dead code. If the project has a
+    UI, walk it live every few cycles with real clicks and the console open.
+  - At every site inspection (the interval in `## Gates`; hourly if none is set), run the project's
+    quality tooling in report mode. Treat new findings as evidence for the opportunity map, not as
+    a requirement to spend the whole shift polishing lint.
+  - Dedupe findings against snag-log.md (ALL seen — fixed and rejected). Park human decisions in
+    parking-lot.md and keep working. Log one line per cycle to shift-log.md.
+  - Open-ended: the deadline is the ONLY thing that ends this item. An empty cycle means the lens
+    was too shallow — research a new user, competitor, subsystem, entry point, or workflow.
+  - At quitting time finish the current coherent unit, leave the branch green, write a morning
+    handoff covering research, opportunities, shipped commits, parked decisions, and how to review
+    or reject the branch. If the current unit must remain unfinished, leave its building entry with
+    an exact Next and Verify remaining before the wip commit and handover, then clock out orderly.
+  - Verify: the item gate is green at every commit; every implemented change traces to evidence in
+    product-research.md and a disposition in opportunity-map.md.
 ```

--- a/plugins/nightshift/skills/setup/SKILL.md
+++ b/plugins/nightshift/skills/setup/SKILL.md
@@ -19,6 +19,8 @@ For each target below, copy the template only if the target does not already exi
 - `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/drafting-table-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/drafting-table.md`
 - `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/parking-lot-template.md`  → `$CLAUDE_PROJECT_DIR/.nightshift/parking-lot.md`
 - `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/snag-log-template.md`     → `$CLAUDE_PROJECT_DIR/.nightshift/snag-log.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/product-research-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/product-research.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/opportunity-map-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/opportunity-map.md`
 
 Create `$CLAUDE_PROJECT_DIR/.nightshift/shift-log.md` and
 `$CLAUDE_PROJECT_DIR/.nightshift/work-orders.md` with a one-line header each if they do not exist.
@@ -113,5 +115,7 @@ punch list with open boxes is never touched at all.
 
 Print what was scaffolded, whether a receipts repo was created, and the gates that were written (or
 that none were). Tell the user to draft items in `.nightshift/drafting-table.md`, promote them into
-the punch list, then run `/nightshift:start` — and that `/nightshift:quality` can turn existing
-lint/type debt into proposed items whenever they want it.
+the punch list, then start the shift (`/nightshift:start` on Claude Code, or ask Nightshift to start
+on Codex). Mention that the open-ended product-evolution shift keeps its evidence and ranked work in
+`.nightshift/product-research.md` and `.nightshift/opportunity-map.md`, while the quality skill can
+turn existing lint/type debt into proposed items whenever they want it.

--- a/plugins/nightshift/skills/start/SKILL.md
+++ b/plugins/nightshift/skills/start/SKILL.md
@@ -48,6 +48,12 @@ so it looks at what is parked and asks which of it to work.
 - **The punch list is the shift.** If `.nightshift/punch-list.md` has at least one open `- [ ]`
   under `## Items`, that is the work — start it. Do not promote, cut, or add anything: parked
   orders and drafts stay exactly where the owner left them.
+- **Resume the active product cycle before rediscovery.** When the open item is product evolution,
+  inspect `.nightshift/opportunity-map.md` for its single `Status: building` entry before doing new
+  research or selecting work. If present, its `Next` action and `Verify remaining` are the
+  continuation point. More than one building entry is inconsistent state: do not guess between
+  them; keep the earliest one active, mark the others `candidate`, record the repair in
+  `shift-log.md`, and continue.
 - **Only when the punch list is empty, offer what is parked.** Read `.nightshift/work-orders.md`
   and `.nightshift/drafting-table.md`. If either holds work, show it in one short list and ask
   which to work now. On the owner's choice, **cut it — move, never copy**: the item goes under
@@ -86,7 +92,7 @@ The deadline is written when the work is composed, not here.
 - No deadline and the list is entirely **finite** items: correct — their natural end is the last
   tick, and a stuck run is red-flagged in the shift log and held for review.
 - No deadline and `## Items` contains an **open-ended walkthrough** (coverage hunt, defect hunt,
-  standing loop): **refuse to start.** A walkthrough with no clock never ends. Say so in one line
+  product evolution / standing loop): **refuse to start.** A walkthrough with no clock never ends. Say so in one line
   and point at `/nightshift:hunt`, which asks for hours; never invent a number.
 - One deadline governs the whole shift: finite items first, the walkthrough soaks up the rest.
 

--- a/plugins/nightshift/skills/status/SKILL.md
+++ b/plugins/nightshift/skills/status/SKILL.md
@@ -21,6 +21,12 @@ Read `.nightshift/` and print:
   the gate does not count it either.
 - **Parked** — the count and one-line titles of entries in `.nightshift/parking-lot.md`.
 - **Snag log** — the last few dispositions from `.nightshift/snag-log.md`, if any.
+- **Product evolution** — when `.nightshift/product-research.md` or
+  `.nightshift/opportunity-map.md` contains more than its template headings, report the most recent
+  research entry and the counts of candidate, building, shipped, rejected, and parked
+  opportunities. If one opportunity is building, show its title, current phase, exact Next action,
+  and Verify remaining. Flag multiple building entries as inconsistent without changing them.
+  Do not turn the map into work or change a status.
 - **Deadline** — if `.nightshift/deadline` exists, the time remaining until quitting time (it holds a
   UNIX epoch; compare with `date +%s`). Otherwise "no deadline (finite list)".
 - **State** — whether `.nightshift/STOP` is present (and its reason), and the current

--- a/tests/shifts/standing-loop.bats
+++ b/tests/shifts/standing-loop.bats
@@ -1,11 +1,42 @@
 E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/standing-loop.md"
 
-@test "the standing loop ends only at the deadline, never by convergence" {
+@test "product evolution ends only at the deadline, never by convergence" {
   grep -qi 'deadline is the ONLY thing' "$E"
   grep -qiE 'too shallow' "$E"
 }
 
-@test "the standing loop runs the quality tooling at site inspections" {
-  grep -qi 'site inspection' "$E"
-  grep -qi 'report mode' "$E"
+@test "product evolution is research-led rather than a lint loop" {
+  grep -qi 'product-research.md' "$E"
+  grep -qi 'opportunity-map.md' "$E"
+  grep -qi 'rather than supplying the roadmap' "$E"
+}
+
+@test "product evolution researches safely and records sources" {
+  grep -qi 'dated source' "$E"
+  grep -qi 'private code' "$E"
+  grep -qi "copy a competitor's" "$E"
+}
+
+@test "product evolution permits substantial work without external publication" {
+  grep -qi 'substantial' "$E"
+  grep -qi 'push, open a PR, deploy, publish' "$E"
+  grep -qi 'dedicated nightshift branch' "$E"
+}
+
+@test "product evolution leaves an evidence-backed morning handoff" {
+  grep -qi 'handoff covering research' "$E"
+  grep -qi 'traces to evidence' "$E"
+}
+
+@test "product evolution resumes the single active opportunity before exploring" {
+  grep -qi 'if opportunity-map.md has a building entry' "$E"
+  grep -qi 'Never open a second building opportunity' "$E"
+  grep -qi 'exact next action' "$E"
+  grep -qi 'verification; continue that opportunity' "$E"
+}
+
+@test "the active opportunity is refreshed at meaningful boundaries, not every command" {
+  grep -qi 'meaningful boundaries' "$E"
+  grep -qi 'Do not rewrite it after every command' "$E"
+  grep -qi 'snag log as a progress journal' "$E"
 }

--- a/tests/skill-paths.bats
+++ b/tests/skill-paths.bats
@@ -31,7 +31,7 @@ SETUP="$SKILLS/setup/SKILL.md"
 }
 
 @test "setup scaffolds every template to an absolute path" {
-  for f in punch-list drafting-table parking-lot snag-log; do
+  for f in punch-list drafting-table parking-lot snag-log product-research opportunity-map; do
     grep -qF "\$CLAUDE_PROJECT_DIR/.nightshift/$f.md" "$SETUP" \
       || { echo "scaffold target not absolute: $f"; return 1; }
   done

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -36,11 +36,21 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
 }
 
 @test "every template setup copies is present" {
-  for t in punch-list drafting-table parking-lot snag-log; do
+  for t in punch-list drafting-table parking-lot snag-log product-research opportunity-map; do
     [ -f "$REF/$t-template.md" ] || { echo "missing $t-template.md"; return 1; }
     grep -qF "$t-template.md" "$BATS_TEST_DIRNAME/../plugins/nightshift/skills/setup/SKILL.md" \
       || { echo "setup does not scaffold $t-template.md"; return 1; }
   done
+}
+
+@test "the opportunity map carries a resumable single-building record" {
+  t="$REF/opportunity-map-template.md"
+  grep -qF 'Only one opportunity may be `building` at a time' "$t"
+  grep -qF 'Current phase:' "$t"
+  grep -qF 'Completed:' "$t"
+  grep -qF 'Rejected:' "$t"
+  grep -qF 'Next:' "$t"
+  grep -qF 'Verify remaining:' "$t"
 }
 
 # The rules template is the owner's whole config surface — every synced key ships in it.

--- a/tests/walkthroughs.bats
+++ b/tests/walkthroughs.bats
@@ -115,4 +115,14 @@ START="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/start/SKILL.md"
   grep -qF 'never ticks a box' "$s"                # files paperwork, does no work
   grep -qF 'archive/<YYYY-MM-DD>/' "$s"            # dated folders are the shape
   grep -qF 'unanswered stay' "$s"                  # open questions are not history
+  grep -qF 'product-research.md' "$s"             # completed research is preserved
+  grep -qF '`candidate`, `building`, and `parked`' "$s" # nonterminal opportunities stay live
+}
+
+@test "status surfaces the active product cycle without mutating it" {
+  s="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/status/SKILL.md"
+  grep -qF 'current phase' "$s"
+  grep -qF 'exact Next action' "$s"
+  grep -qF 'Verify remaining' "$s"
+  grep -qF 'without changing them' "$s"
 }


### PR DESCRIPTION
## Summary

- evolve the existing standing-loop shift into evidence-backed product evolution for Codex and Claude Code
- preserve product research and a ranked opportunity map, with one structured `building` entry as the resumable current cycle
- integrate the new state into setup, start/resume, status, archive, manifests, marketplace metadata, and documentation
- position unused capacity as a strong use case while keeping persistent task completion and continuity as Nightshift's core promise

## Safety and compatibility

- augments the existing open-ended shift instead of adding a competing workflow
- keeps the punch list authoritative and preserves all existing finite shifts
- archives only terminal opportunities (`shipped` and `rejected`); candidates, active work, and parked decisions remain live
- never authorizes merge, push, PR creation, deployment, publication, or owner policy decisions during a product-evolution shift

## Verification

- `bats -r tests` — 276 passing
- `git ls-files '*.sh' | xargs shellcheck -x`
- `claude plugin validate . --strict`
- JSON manifests validated
- `git diff --check`
