### PR TITLE
fix: redirect temporary ChatGPT workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ codex plugin marketplace add orwa-mahmoud/claude-nightshift
 codex plugin add nightshift@nightshift
 ```
 
+Use Nightshift with the real project open in Codex, or with Codex connected to its GitHub
+repository. If invoked from a normal ChatGPT conversation backed by `/workspace/scratch/`, setup
+stops before writing anything and points the user to Codex—the scratch files would not affect the
+real repository.
+
 ### Claude Code
 
 Two commands inside Claude Code — no npm, no Homebrew, no separate CLI, no API keys, no server:

--- a/plugins/nightshift/.codex-plugin/plugin.json
+++ b/plugins/nightshift/.codex-plugin/plugin.json
@@ -14,7 +14,7 @@
   "interface": {
     "displayName": "Nightshift",
     "shortDescription": "Keep long coding runs on task",
-    "longDescription": "Keep long Codex runs anchored to an authoritative punch list when conversations compact, sessions resume, or unattended work is interrupted. Nightshift keeps goals, completion state, decisions, research, active progress, exact next actions, and verification on disk; parks questions instead of waiting; enforces owner-defined safety rules; and leaves reviewable commits and run history. Give it your own work or use a ready-made shift for evidence-backed product evolution, meaningful test coverage, lint and type debt, defect hunting, security advisories, or direct dependency upgrades. Add a time budget to turn otherwise-unused capacity into product progress on an isolated branch while you retain the decision to merge or publish.",
+    "longDescription": "Keep long Codex runs anchored to an authoritative punch list when conversations compact, sessions resume, or unattended work is interrupted. Use Nightshift with a real project opened in Codex or connected to its GitHub repository—not a temporary ChatGPT scratch workspace. Nightshift keeps goals, completion state, decisions, research, active progress, exact next actions, and verification on disk; parks questions instead of waiting; enforces owner-defined safety rules; and leaves reviewable commits and run history. Give it your own work or use a ready-made shift for evidence-backed product evolution, meaningful test coverage, lint and type debt, defect hunting, security advisories, or direct dependency upgrades.",
     "developerName": "Orwa Mahmoud",
     "category": "Productivity",
     "capabilities": [
@@ -28,7 +28,7 @@
       "Interrupted-session recovery"
     ],
     "defaultPrompt": [
-      "Set up Nightshift in this project.",
+      "Set up Nightshift in this real project workspace.",
       "Show me the ready-made shifts I can run tonight.",
       "Use the next four hours to research and improve this product."
     ],

--- a/plugins/nightshift/skills/nightshift/SKILL.md
+++ b/plugins/nightshift/skills/nightshift/SKILL.md
@@ -16,6 +16,15 @@ working directory persists between Bash calls and is not the project root once a
 run from inside the code repo; a bare relative path then reads a punch list that isn't there and
 writes receipts nobody will find.
 
+## Real-project boundary
+
+Nightshift is an engineering workflow for a real project workspace. If the resolved project root
+is under `/workspace/scratch/`, stop before setup or shift work and give the OpenAI-native redirect
+from the setup skill: open the real project in Codex (or connect Codex to its GitHub repository),
+then mention Nightshift there. Never create durable-looking run state in a disposable ChatGPT
+scratch workspace, and never claim those temporary files affect or preserve the user's repository.
+A non-git project outside that explicit scratch path remains valid.
+
 ## The contract is above `## Items`
 
 `.nightshift/punch-list.md` has a contract section, then `## Items`. The contract binds YOU for the

--- a/plugins/nightshift/skills/setup/SKILL.md
+++ b/plugins/nightshift/skills/setup/SKILL.md
@@ -11,6 +11,24 @@ session's working directory is the project root — treat it identically) — wr
 the variable. The shell's working directory persists between Bash calls and drifts into the code
 repo during stack detection, so a bare relative path lands wherever the last `cd` left it.
 
+## 0. Require a real project workspace
+
+Before creating or changing any file, resolve the project root to an absolute path. If it is under
+`/workspace/scratch/`, this is a disposable ChatGPT scratch workspace rather than the user's real
+repository. **Stop immediately: create no `.nightshift/` directory, rules, settings, receipts repo,
+or other files.** Tell the user directly:
+
+> Nightshift needs a real software project workspace. This ChatGPT conversation is using a
+> temporary workspace, so files created here will not affect your repository.
+>
+> Open your project in Codex, or start Codex connected to its GitHub repository. Then mention
+> Nightshift and say: “Set up Nightshift in this project.”
+
+Do not mention Claude Code in this ChatGPT-specific redirect: the user is already in an OpenAI
+product, so give them the shortest OpenAI-native route. Do not infer “temporary” merely because the
+project is not a git repository — local non-git projects and the recommended parent-workspace
+layout remain valid. The explicit disposable scratch path is the stop signal.
+
 ## 1. Scaffold `.nightshift/` (never clobber an existing shift)
 
 For each target below, copy the template only if the target does not already exist:

--- a/tests/skill-paths.bats
+++ b/tests/skill-paths.bats
@@ -42,3 +42,17 @@ SETUP="$SKILLS/setup/SKILL.md"
 @test "setup inits the receipts repo without relying on the working directory" {
   grep -qF 'git -C "$CLAUDE_PROJECT_DIR/.nightshift" init' "$SETUP"
 }
+
+@test "setup refuses disposable ChatGPT scratch before writing" {
+  grep -qF '/workspace/scratch/' "$SETUP"
+  grep -qF 'Before creating or changing any file' "$SETUP"
+  grep -qF 'create no `.nightshift/` directory' "$SETUP"
+  grep -qF 'Open your project in Codex' "$SETUP"
+  grep -qF 'Do not mention Claude Code' "$SETUP"
+}
+
+@test "scratch detection does not reject legitimate non-git projects" {
+  grep -qF 'Do not infer “temporary” merely because the' "$SETUP"
+  grep -qF 'project is not a git repository' "$SETUP"
+  grep -qF 'A non-git project outside that explicit scratch path remains valid' "$SKILLS/nightshift/SKILL.md"
+}


### PR DESCRIPTION
## What does this PR do?

Prevents Nightshift from creating durable-looking run state inside ChatGPT's disposable `/workspace/scratch/` environment.

When invoked there, Nightshift now stops before writing files and directs the user to open the real project in Codex or connect Codex to its GitHub repository. Real Codex projects, Claude Code projects, parent-workspace layouts, and non-Git project folders remain supported.

This also updates the Codex directory description and default setup prompt so users understand that Nightshift operates on a real project workspace.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Adapter (support for another harness)
- [ ] Docs / chore / refactor (no behaviour change)
- [ ] Gate behaviour change (discussed in an issue first — see CONTRIBUTING)

## Verification

- Both modified skills pass `quick_validate.py`.
- The complete 222-test Bats suite passes locally.
- Strict Claude plugin validation passes.
- The new focused tests verify that `/workspace/scratch/` is rejected before writes and legitimate non-Git projects remain valid.

## Checklist

- [x] `shellcheck` and the `bats` suite pass locally.
- [x] Shell stays portable: no shell implementation changed.
- [x] Stop gate unchanged; blocked/permitted-stop transcript is not applicable.
- [x] Docs and Codex plugin metadata updated.
