### PR TITLE
Link tasks to authoritative Nightshift state

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ you see how your permissions, gates, STOP order, notifications, and host-specifi
 4. Later, ask for status (`/nightshift:status` on Claude Code).
 5. Review the local commit, then push it yourself.
 
+If the Codex or Claude Code task must remain open on a different folder, explicitly link it to the
+workspace that owns `.nightshift/`; Nightshift never searches nearby folders:
+
+```bash
+plugins/nightshift/runtime/link-workspace.sh \
+  --host-root /absolute/task/root \
+  --workspace /absolute/nightshift/workspace
+```
+
+The task root receives one local-only `.nightshift-link`; all run state remains authoritative in
+the linked workspace and every hook resolves the same pointer.
+
 Only four ideas matter on the first run:
 
 - **Punch list:** the work the agent must finish.

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -17,6 +17,16 @@ Those are Claude Code's slash spellings. In Codex or ChatGPT, mention Nightshift
 “set up Nightshift,” “show me the ready-made shifts,” “run product evolution for four hours,”
 “start the shift,” or “show shift status.” The same skills and `.nightshift/` files are used.
 
+When the task root and Nightshift workspace differ, setup can create an explicit local link after
+showing both absolute paths and receiving confirmation. The offline equivalent is:
+
+```bash
+plugins/nightshift/runtime/link-workspace.sh --host-root /absolute/task/root --workspace /absolute/workspace
+```
+
+The target must already contain `.nightshift/`. Relative, missing, multiline, and symlink pointers
+are rejected; Nightshift never searches for a workspace automatically.
+
 Stop-work order, any time, from any terminal: `touch .nightshift/STOP`. In an interactive session
 Escape is the immediate halt; STOP is what reaches a headless run, and it ends
 the shift at the agent's next stop attempt.

--- a/plugins/nightshift/hooks/clock-out-gate.sh
+++ b/plugins/nightshift/hooks/clock-out-gate.sh
@@ -40,7 +40,11 @@ else
   TPATH="$(printf '%s' "$INPUT" | sed -n 's/.*"transcript_path"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
 fi
 
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+HOST_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+if ! PROJECT_DIR="$(ns_workspace_root "$HOST_DIR" 2>/dev/null)"; then
+  printf '%s\n' '{"decision":"block","reason":"DO NOT STOP — .nightshift-link is invalid. Open the correct project task or repair the explicit link to an absolute workspace containing .nightshift/."}'
+  exit 0
+fi
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 STOP="$NS/STOP"

--- a/plugins/nightshift/hooks/codex/clock-out-gate.sh
+++ b/plugins/nightshift/hooks/codex/clock-out-gate.sh
@@ -30,7 +30,11 @@ codex_read_input
 SID="$CODEX_SESSION_ID"
 TPATH="$CODEX_TRANSCRIPT_PATH"
 
-PROJECT_DIR="$(codex_project_dir)"
+HOST_DIR="$(codex_project_dir)"
+if ! PROJECT_DIR="$(ns_workspace_root "$HOST_DIR" 2>/dev/null)"; then
+  codex_emit_block "DO NOT STOP — .nightshift-link is invalid. Open the correct project task or repair the explicit link to an absolute workspace containing .nightshift/."
+  exit 0
+fi
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 STOP="$NS/STOP"

--- a/plugins/nightshift/hooks/codex/hardhat.sh
+++ b/plugins/nightshift/hooks/codex/hardhat.sh
@@ -33,7 +33,9 @@ CWD="$CODEX_CWD"
 SID="$CODEX_SESSION_ID"
 TPATH="$CODEX_TRANSCRIPT_PATH"
 
-PROJECT_DIR="$(codex_project_dir)"
+HOST_DIR="$(codex_project_dir)"
+LINK_ERROR=""
+PROJECT_DIR="$(ns_workspace_root "$HOST_DIR" 2>/dev/null)" || LINK_ERROR=1
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 ENDED="$NS/.ended"
@@ -50,6 +52,8 @@ deny() {
   codex_emit_deny "$1"
   exit 0
 }
+
+[ -z "$LINK_ERROR" ] || deny "BLOCKED: .nightshift-link is invalid. Open the correct project task or repair the explicit link to an absolute workspace containing .nightshift/."
 
 # A commit message must not read as the command it mentions, so blank the message argument
 # before matching. Only that argument: scrubbing every quoted span would also hide a genuinely

--- a/plugins/nightshift/hooks/hardhat.sh
+++ b/plugins/nightshift/hooks/hardhat.sh
@@ -24,7 +24,9 @@ _here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
 . "$_here/shared/hardhat-core.sh"
 
 INPUT="$(cat)"
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+HOST_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+LINK_ERROR=""
+PROJECT_DIR="$(ns_workspace_root "$HOST_DIR" 2>/dev/null)" || LINK_ERROR=1
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 ENDED="$NS/.ended"
@@ -43,6 +45,8 @@ deny() {
   printf '{"hookSpecificOutput":{"hookEventName":"PreToolUse","permissionDecision":"deny","permissionDecisionReason":"%s"}}\n' "$reason"
   exit 0
 }
+
+[ -z "$LINK_ERROR" ] || deny "BLOCKED: .nightshift-link is invalid. Open the correct project task or repair the explicit link to an absolute workspace containing .nightshift/."
 
 # Extract tool + command. jq preferred; the raw payload is the fallback so a missing jq
 # can never silently disable the guard.

--- a/plugins/nightshift/hooks/session-end.sh
+++ b/plugins/nightshift/hooks/session-end.sh
@@ -26,8 +26,8 @@ PROJECT_DIR="$(ns_workspace_root "$HOST_DIR" 2>/dev/null)" || exit 0
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 
-if [ ! -f "$PUNCH" ] || [ -f "$NS/.ended" ] \
-  || ! grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]' "$PUNCH" 2>/dev/null; then
+if [ ! -f "$NS/.shift-armed" ] || [ ! -f "$PUNCH" ] || [ -f "$NS/.ended" ] \
+  || [ "$(ns_open_boxes "$PUNCH")" -eq 0 ]; then
   exit 0
 fi
 

--- a/plugins/nightshift/hooks/session-end.sh
+++ b/plugins/nightshift/hooks/session-end.sh
@@ -11,13 +11,18 @@
 # nothing, so ordinary sessions leave no residue.
 set -u
 
+_here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
+# shellcheck source=plugins/nightshift/lib/lib.sh
+. "$_here/../lib/lib.sh"
+
 # A watchman-spawned revival carries this mark. Its exit — finished, or dead on the API again —
 # is never the owner's hand on the door; writing the marker for it would stand the watchman down
 # mid-outage after the first revival.
 [ "${NIGHTSHIFT_REVIVAL:-}" != "1" ] || exit 0
 
 INPUT="$(cat)"
-PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+HOST_DIR="${CLAUDE_PROJECT_DIR:-$PWD}"
+PROJECT_DIR="$(ns_workspace_root "$HOST_DIR" 2>/dev/null)" || exit 0
 NS="$PROJECT_DIR/.nightshift"
 PUNCH="$NS/punch-list.md"
 

--- a/plugins/nightshift/lib/lib.sh
+++ b/plugins/nightshift/lib/lib.sh
@@ -9,19 +9,22 @@
 # directories: an absent link means local state; a malformed link returns 2 so callers can fail
 # closed instead of silently running without the owner's contract.
 ns_workspace_root() {
-  local host="$1" link="$1/.nightshift-link" target="" extra="" canonical=""
+  local host="$1" link="$1/.nightshift-link" target="" lines="" canonical=""
   canonical="$(cd -P "$host" 2>/dev/null && pwd)" || {
     return 2
   }
-  [ -e "$link" ] || { printf '%s' "$canonical"; return 0; }
-  [ -f "$link" ] && [ ! -L "$link" ] || {
+  if [ ! -e "$link" ] && [ ! -L "$link" ]; then
+    printf '%s' "$canonical"
+    return 0
+  fi
+  if [ ! -f "$link" ] || [ -L "$link" ]; then
     return 2
-  }
+  fi
   IFS= read -r target <"$link" || true
-  extra="$(sed -n '2,$p' "$link" 2>/dev/null)"
-  [ -n "$target" ] && [ -z "$extra" ] || {
+  lines="$(awk 'END { print NR + 0 }' "$link" 2>/dev/null)"
+  if [ -z "$target" ] || [ "$lines" -ne 1 ]; then
     return 2
-  }
+  fi
   case "$target" in /*) ;; *)
     return 2
   esac

--- a/plugins/nightshift/lib/lib.sh
+++ b/plugins/nightshift/lib/lib.sh
@@ -1,6 +1,60 @@
 #!/usr/bin/env bash
 # lib.sh — shared hook helpers.
 
+# ns_workspace_root <host-root>
+#
+# Resolve the one workspace that owns Nightshift state. Normally that is the task root itself.
+# A task opened elsewhere may opt in explicitly with a local .nightshift-link containing one
+# absolute path to a directory that already owns .nightshift/. We never search parent or sibling
+# directories: an absent link means local state; a malformed link returns 2 so callers can fail
+# closed instead of silently running without the owner's contract.
+ns_workspace_root() {
+  local host="$1" link="$1/.nightshift-link" target="" extra="" canonical=""
+  canonical="$(cd -P "$host" 2>/dev/null && pwd)" || {
+    return 2
+  }
+  [ -e "$link" ] || { printf '%s' "$canonical"; return 0; }
+  [ -f "$link" ] && [ ! -L "$link" ] || {
+    return 2
+  }
+  IFS= read -r target <"$link" || true
+  extra="$(sed -n '2,$p' "$link" 2>/dev/null)"
+  [ -n "$target" ] && [ -z "$extra" ] || {
+    return 2
+  }
+  case "$target" in /*) ;; *)
+    return 2
+  esac
+  canonical="$(cd -P "$target" 2>/dev/null && pwd)" || {
+    return 2
+  }
+  [ -d "$canonical/.nightshift" ] || {
+    return 2
+  }
+  printf '%s' "$canonical"
+}
+
+# ns_record_workspace_link <host-root> <workspace>
+# Validate and atomically record a cross-workspace link. The pointer is machine-local, so when
+# the host is a Git repository it goes in .git/info/exclude rather than changing tracked files.
+ns_record_workspace_link() {
+  local host target canonical tmp exclude
+  host="$(cd -P "$1" 2>/dev/null && pwd)" || return 1
+  target="$2"
+  case "$target" in /*) ;; *) return 1 ;; esac
+  canonical="$(cd -P "$target" 2>/dev/null && pwd)" || return 1
+  [ -d "$canonical/.nightshift" ] || return 1
+  tmp="$host/.nightshift-link.$$"
+  printf '%s\n' "$canonical" >"$tmp" || return 1
+  mv "$tmp" "$host/.nightshift-link" || return 1
+  if git_dir="$(git -C "$host" rev-parse --git-dir 2>/dev/null)"; then
+    case "$git_dir" in /*) ;; *) git_dir="$host/$git_dir" ;; esac
+    exclude="$git_dir/info/exclude"
+    mkdir -p "${exclude%/*}" || return 1
+    grep -qxF '.nightshift-link' "$exclude" 2>/dev/null || printf '%s\n' '.nightshift-link' >>"$exclude"
+  fi
+}
+
 # repo_root <project-dir> [candidate-dir ...]
 #
 # Echo the top level of the git repository the hooks should inspect, or return 1 when that

--- a/plugins/nightshift/lib/lib.sh
+++ b/plugins/nightshift/lib/lib.sh
@@ -41,7 +41,7 @@ ns_workspace_root() {
 # Validate and atomically record a cross-workspace link. The pointer is machine-local, so when
 # the host is a Git repository it goes in .git/info/exclude rather than changing tracked files.
 ns_record_workspace_link() {
-  local host target canonical tmp exclude
+  local host target canonical tmp exclude git_dir
   host="$(cd -P "$1" 2>/dev/null && pwd)" || return 1
   target="$2"
   case "$target" in /*) ;; *) return 1 ;; esac

--- a/plugins/nightshift/runtime/link-workspace.sh
+++ b/plugins/nightshift/runtime/link-workspace.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Explicitly connect this task root to an existing authoritative Nightshift workspace.
+set -u
+
+_here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
+# shellcheck source=plugins/nightshift/lib/lib.sh
+. "$_here/../lib/lib.sh"
+
+HOST="${CLAUDE_PROJECT_DIR:-${CODEX_PROJECT_DIR:-$PWD}}"
+WORKSPACE=""
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --host-root) [ "$#" -ge 2 ] || exit 2; HOST="$2"; shift 2 ;;
+    --workspace) [ "$#" -ge 2 ] || exit 2; WORKSPACE="$2"; shift 2 ;;
+    *) printf 'link-workspace: unknown argument: %s\n' "$1" >&2; exit 2 ;;
+  esac
+done
+[ -n "$WORKSPACE" ] || { printf 'link-workspace: --workspace is required\n' >&2; exit 2; }
+ns_record_workspace_link "$HOST" "$WORKSPACE" || {
+  printf 'link-workspace: target must be an absolute existing workspace containing .nightshift/\n' >&2
+  exit 1
+}
+printf 'Nightshift task root: %s\nNightshift workspace: %s\n' \
+  "$(cd -P "$HOST" && pwd)" "$(ns_workspace_root "$HOST")"

--- a/plugins/nightshift/runtime/schedule.sh
+++ b/plugins/nightshift/runtime/schedule.sh
@@ -20,6 +20,10 @@
 # Exit: 0 printed · 1 usage or a missing project · 3 already registered (nothing printed to install)
 set -u
 
+_here="${BASH_SOURCE[0]%/*}"; [ "$_here" != "${BASH_SOURCE[0]}" ] || _here=.
+# shellcheck source=plugins/nightshift/lib/lib.sh
+. "$_here/../lib/lib.sh"
+
 PROJECT="$PWD"
 AT=""
 AGENT="claude -p"
@@ -134,7 +138,7 @@ fi
 
 # The punch list is the shift: a scheduled start works what it finds and promotes nothing, so an
 # empty list at %s means the run does nothing at all.
-if ! grep -qE '^[[:space:]]*-[[:space:]]*\[[[:space:]]\]' "$PROJECT/.nightshift/punch-list.md" 2>/dev/null; then
+if [ "$(ns_open_boxes "$PROJECT/.nightshift/punch-list.md")" -eq 0 ]; then
   printf 'Note: the punch list has no open items. A scheduled start works the list it finds and\n'
   printf 'promotes nothing, so queue the work before %s or the run will find nothing to do.\n\n' "$AT"
 fi

--- a/plugins/nightshift/skills/archive/SKILL.md
+++ b/plugins/nightshift/skills/archive/SKILL.md
@@ -11,11 +11,9 @@ does shift work, never ticks a box, never touches the contract.
 decisions plus the default chosen so work continues; `work-orders.md` → timed catalog work composed
 only through Hunt. Archive each by its own lifecycle; never reclassify one as another.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
-variable. (On Codex the variable does not exist; the session's working directory is the
-project root — treat it identically.)
-The shell's working directory persists between Bash calls and is not necessarily the project root;
-records filed into the wrong directory are records lost.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; write
+every `.nightshift/` path to the validated absolute target, otherwise the task root. Never search
+or guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
 ## Where it goes
 

--- a/plugins/nightshift/skills/hunt/SKILL.md
+++ b/plugins/nightshift/skills/hunt/SKILL.md
@@ -6,11 +6,9 @@ description: Compose tonight's shift from the ready catalog — pick the jobs, c
 Compose a shift for `$CLAUDE_PROJECT_DIR`. Propose, never impose: nothing is worked without an
 explicit yes. If `.nightshift/` does not exist, stop and point to `/nightshift:setup` first.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
-variable. (On Codex the variable does not exist; the session's working directory is the
-project root — treat it identically.)
-The shell's working directory persists between Bash calls and is not necessarily the project root,
-so a bare relative path lands wherever the last `cd` left it.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; write
+every `.nightshift/` path to the validated absolute target, otherwise the task root. Never search
+or guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
 ## 1. Offer the catalog
 
@@ -80,7 +78,7 @@ On **now** — start the shift yourself, here, without making the owner type ano
 `/nightshift:start` exactly: clear the stale markers, **move** the item out of `work-orders.md` and
 under `## Items` in the punch list (a cut, never a copy — it must not exist in two places), write
 `.nightshift/deadline` from the recorded hours, **arm the gate** with
-`touch "${CLAUDE_PROJECT_DIR:-$PWD}/.nightshift/.shift-armed"`, log the start, arm the watchman. The
+`touch "$NIGHTSHIFT_WORKSPACE/.nightshift/.shift-armed"`, log the start, arm the watchman. The
 marker is what starts the shift — without it the list is written and nothing is holding it. From
 that second the gate holds this session until the list is done, a stop-work order lands, or the
 whistle blows.

--- a/plugins/nightshift/skills/nightshift/SKILL.md
+++ b/plugins/nightshift/skills/nightshift/SKILL.md
@@ -17,10 +17,9 @@ decisions plus the default chosen so work continues; `work-orders.md` → timed 
 only through Hunt. Never route an ordinary plan through Hunt, call later work “parked,” or put a
 known task in the parking lot.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.) The shell's
-working directory persists between Bash calls and is not the project root once a gate or a build has
-run from inside the code repo; a bare relative path then reads a punch list that isn't there and
-writes receipts nobody will find.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; use the
+validated absolute target for every `.nightshift/` path, otherwise use the task root. Never search
+or guess. The shell's working directory persists between Bash calls, so never rely on a bare path.
 
 ## Real-project boundary
 

--- a/plugins/nightshift/skills/quality/SKILL.md
+++ b/plugins/nightshift/skills/quality/SKILL.md
@@ -7,9 +7,9 @@ Survey this project's existing quality debt and turn what matters into proposed 
 The scan is read-only: run checks in report mode, fix nothing, write nothing without an explicit
 yes. Work in `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.) The shell's
-working directory persists between Bash calls and drifts into the code repo while running the
-project's own check commands, so a bare relative path lands wherever the last `cd` left it.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; use the
+validated absolute target for every `.nightshift/` path, otherwise the task root. Never search or
+guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
 ## 1. Detect and scan
 
@@ -31,7 +31,7 @@ Verify and Commit lines. Show the drafts, then ask — with three first-class an
 
 - **fix now** — write the items straight under `## Items` in `.nightshift/punch-list.md` and start
   the shift here, following `/nightshift:start`: clear the stale markers, **arm the gate** with
-  `touch "${CLAUDE_PROJECT_DIR:-$PWD}/.nightshift/.shift-armed"`, log the start, arm the watchman. The
+  `touch "$NIGHTSHIFT_WORKSPACE/.nightshift/.shift-armed"`, log the start, arm the watchman. The
   marker is what starts the shift; the items alone hold nothing. These are finite items, so no
   deadline is required; offer an optional hours cap in one line and write `.nightshift/deadline`
   only if the owner names a number. From that second the gate holds this session until every box

--- a/plugins/nightshift/skills/schedule/SKILL.md
+++ b/plugins/nightshift/skills/schedule/SKILL.md
@@ -6,8 +6,9 @@ description: Set a shift to start at a fixed time — check the work is queued, 
 Get `$CLAUDE_PROJECT_DIR` ready to start on a clock, then hand the owner the config. Work through
 these in order; each one is a check the owner would otherwise discover at 4am.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — use the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.) The shell's
-working directory persists between Bash calls and is not necessarily the project root.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; use the
+validated absolute target for every `.nightshift/` path, otherwise the task root. Never search or
+guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
 ## 1. Is there a site at all?
 
@@ -53,7 +54,7 @@ Ask for the time if the owner has not given one — 24-hour `HH:MM`, local — t
 and show its output as it comes:
 
 ```bash
-"${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/runtime/schedule.sh" --project "${CLAUDE_PROJECT_DIR:-$PWD}" --at <HH:MM>
+"${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/runtime/schedule.sh" --project "$NIGHTSHIFT_WORKSPACE" --at <HH:MM>
 # Codex projects add:  --agent 'codex exec -s danger-full-access'
 ```
 

--- a/plugins/nightshift/skills/setup/SKILL.md
+++ b/plugins/nightshift/skills/setup/SKILL.md
@@ -11,10 +11,16 @@ a summary. Work in `$CLAUDE_PROJECT_DIR`.
 decisions plus the default chosen so work continues; `work-orders.md` → timed catalog work composed
 only through Hunt. Ordinary plans belong in the drafting table, never in Hunt or the parking lot.
 
-Every `.nightshift/` and `.claude/` path below is relative to `$CLAUDE_PROJECT_DIR` (on Codex, the
-session's working directory is the project root — treat it identically) — write it with
-the variable. The shell's working directory persists between Bash calls and drifts into the code
-repo during stack detection, so a bare relative path lands wherever the last `cd` left it.
+Resolve the task root as `${CLAUDE_PROJECT_DIR:-$PWD}`. If its `.nightshift-link` exists, validate
+the one absolute workspace path inside it and use that workspace for every `.nightshift/` read or
+write; otherwise use the task root. Never search surrounding folders or guess. Claude's
+`.claude/` settings stay at the task root. The shell's working directory persists between Bash calls,
+so never rely on a bare relative path.
+
+If the user explicitly identifies a different existing workspace containing `.nightshift/`, show
+both absolute paths and ask for confirmation. On yes, run
+`${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/runtime/link-workspace.sh --host-root "$TASK_ROOT" --workspace "$PROPOSED_WORKSPACE"`.
+The pointer is local-only and state remains in the authoritative workspace; never copy it.
 
 ## 0. Require a real project workspace
 
@@ -42,7 +48,7 @@ Resolve the code repository before stack detection:
 - If several child repositories exist and `.nightshift/work-target` does not already select one,
   show the choices and require an explicit target; never guess.
 - Persist the chosen repository's absolute Git top-level path, followed by one newline, in
-  `$CLAUDE_PROJECT_DIR/.nightshift/work-target`. On later setup runs, validate and retain that
+  `$NIGHTSHIFT_WORKSPACE/.nightshift/work-target`. On later setup runs, validate and retain that
   target unless the owner explicitly changes it. Stack detection, Git checks, gates, commits, and
   verification operate in this work target—not necessarily in the workspace holding run state.
 
@@ -50,19 +56,19 @@ Resolve the code repository before stack detection:
 
 For each target below, copy the template only if the target does not already exist:
 
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/punch-list-template.md`   → `$CLAUDE_PROJECT_DIR/.nightshift/punch-list.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/drafting-table-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/drafting-table.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/parking-lot-template.md`  → `$CLAUDE_PROJECT_DIR/.nightshift/parking-lot.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/snag-log-template.md`     → `$CLAUDE_PROJECT_DIR/.nightshift/snag-log.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/product-research-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/product-research.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/opportunity-map-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/opportunity-map.md`
-- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/work-orders-template.md` → `$CLAUDE_PROJECT_DIR/.nightshift/work-orders.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/punch-list-template.md`   → `$NIGHTSHIFT_WORKSPACE/.nightshift/punch-list.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/drafting-table-template.md` → `$NIGHTSHIFT_WORKSPACE/.nightshift/drafting-table.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/parking-lot-template.md`  → `$NIGHTSHIFT_WORKSPACE/.nightshift/parking-lot.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/snag-log-template.md`     → `$NIGHTSHIFT_WORKSPACE/.nightshift/snag-log.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/product-research-template.md` → `$NIGHTSHIFT_WORKSPACE/.nightshift/product-research.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/opportunity-map-template.md` → `$NIGHTSHIFT_WORKSPACE/.nightshift/opportunity-map.md`
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/work-orders-template.md` → `$NIGHTSHIFT_WORKSPACE/.nightshift/work-orders.md`
 
-Create `$CLAUDE_PROJECT_DIR/.nightshift/shift-log.md` with a one-line header if it does not exist.
+Create `$NIGHTSHIFT_WORKSPACE/.nightshift/shift-log.md` with a one-line header if absent.
 
 ## 2. Private by default
 
-- Keep run state out of git. If `$CLAUDE_PROJECT_DIR` is itself a git repo, append a line
+- Keep run state out of git. If `$NIGHTSHIFT_WORKSPACE` is itself a git repo, append a line
   `.nightshift/` to its `.gitignore` (create the file if needed; do not duplicate the line). If it
   is not one — the recommended layout, where the code repo sits a level below — `.nightshift/` is
   already outside every repo, so write no `.gitignore` there. Run history is the owner's; it never
@@ -73,8 +79,8 @@ Create `$CLAUDE_PROJECT_DIR/.nightshift/shift-log.md` with a one-line header if 
   receipts repo? (never pushed, never touches your project's history)"* — and on anything but a
   clear yes, skip it: the receipts still exist as plain files. Present the question neutrally —
   never describe the repo as recommended; the default is no. On yes: if `.nightshift/.git` does
-  not exist, run `git -C "$CLAUDE_PROJECT_DIR/.nightshift" init` rather than `cd`-ing there, add a
-  `$CLAUDE_PROJECT_DIR/.nightshift/.gitignore` that ignores the
+  not exist, run `git -C "$NIGHTSHIFT_WORKSPACE/.nightshift" init` rather than `cd`-ing there, add a
+  `$NIGHTSHIFT_WORKSPACE/.nightshift/.gitignore` that ignores the
   transient markers `STOP`, `.stall`, `.notified`, `deadline`, `.session-end`, `.shift-session`,
   `.watchman`, `.watchman-tick`, and `.lock.d/`, and make one initial commit. **Never add a
   remote to it, never push it.**
@@ -91,7 +97,7 @@ user, showing the detected proposal, with three first-class answers:
 
 If gates were accepted or edited, also ask the **site-inspection interval** (every N items or every
 H hours). Write the result into the `## Gates` block of
-`$CLAUDE_PROJECT_DIR/.nightshift/punch-list.md`, replacing the placeholder. If the answer was none,
+`$NIGHTSHIFT_WORKSPACE/.nightshift/punch-list.md`, replacing the placeholder. If the answer was none,
 leave the placeholder as-is.
 
 The `## Gates` block is plain markdown the owner may edit anytime — re-run `/nightshift:setup` to
@@ -125,7 +131,7 @@ denied means denied. Ask one question:
 ## 5. The rules file — every knob in one place
 
 Copy `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/nightshift-rules-template.json` to
-`$CLAUDE_PROJECT_DIR/.nightshift/rules.json` as-is, if it does not already exist — the owner's one config file,
+`$NIGHTSHIFT_WORKSPACE/.nightshift/rules.json` as-is, if it does not already exist — the owner's one config file,
 defaults inline. It lives in nightshift's own folder on purpose: everything nightshift is in
 one place, kept out of repo history by the same `.nightshift/` gitignore, versioned by the
 receipts repo when one exists — and deleting `.nightshift/` removes all of nightshift, rules

--- a/plugins/nightshift/skills/start/SKILL.md
+++ b/plugins/nightshift/skills/start/SKILL.md
@@ -5,11 +5,17 @@ description: Begin the shift — preflight, cut whatever is queued, arm the site
 
 Start a nightshift. Work in `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
-variable. (On Codex the variable does not exist; the session's working directory is the project
-root — treat it identically.)
-The shell's working directory persists between Bash calls and drifts into the code repo while
-running gates, so a bare relative path reads or writes wherever the last `cd` left it.
+Resolve the task root as `${CLAUDE_PROJECT_DIR:-$PWD}`. If its `.nightshift-link` exists, validate
+the one absolute workspace path inside it and use that workspace for every `.nightshift/` read or
+write; otherwise use the task root. Never search surrounding folders or guess. Print both paths
+when linked. The shell's working directory persists between Bash calls, so never rely on a bare
+relative path.
+
+If the start request itself explicitly names a different existing Nightshift workspace, that
+owner-provided path is authorization to link it: print both absolute paths, run
+`${CLAUDE_PLUGIN_ROOT:-$PLUGIN_ROOT}/runtime/link-workspace.sh --host-root "$TASK_ROOT" --workspace "$PROPOSED_WORKSPACE"`,
+then continue from the resolved workspace. Without an explicit path or an existing valid link,
+refuse to arm outside the task root and direct the owner to Setup; never discover a target.
 
 Read `.nightshift/work-target` before preflight. It is the absolute code repository selected by
 Setup. Keep every `.nightshift/` read and write rooted in the opened workspace, but run project
@@ -113,7 +119,7 @@ The deadline is written when the work is composed, not here.
 Every check has passed and the work is known, so the shift begins here. Create the marker:
 
 ```bash
-touch "${CLAUDE_PROJECT_DIR:-$PWD}/.nightshift/.shift-armed"
+touch "$NIGHTSHIFT_WORKSPACE/.nightshift/.shift-armed"
 ```
 
 **This, and nothing else, is what puts a session on shift.** Until it exists the punch list is an
@@ -139,14 +145,14 @@ shift the other host owns. Unless the rules file's `watchMinutes` is `0` (or
 On Claude Code:
 
 ```bash
-nohup "${CLAUDE_PLUGIN_ROOT}/runtime/claude/watchman.sh" --project "$CLAUDE_PROJECT_DIR" >/dev/null 2>&1 &
+nohup "${CLAUDE_PLUGIN_ROOT}/runtime/claude/watchman.sh" --project "$NIGHTSHIFT_WORKSPACE" >/dev/null 2>&1 &
 ```
 
 On Codex (the plugin root is `$PLUGIN_ROOT` or its `CLAUDE_PLUGIN_ROOT` compatibility twin; if
 neither is set in your shell, it is the installed plugin cache directory):
 
 ```bash
-nohup "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/runtime/codex/watchman.sh" --project "$PWD" >/dev/null 2>&1 &
+nohup "${PLUGIN_ROOT:-$CLAUDE_PLUGIN_ROOT}/runtime/codex/watchman.sh" --project "$NIGHTSHIFT_WORKSPACE" >/dev/null 2>&1 &
 ```
 
 One stance to state plainly on Codex: there is no owner-interrupt tell yet, so closing an

--- a/plugins/nightshift/skills/status/SKILL.md
+++ b/plugins/nightshift/skills/status/SKILL.md
@@ -11,9 +11,9 @@ read-only.
 decisions plus the default chosen so work continues; `work-orders.md` → timed catalog work composed
 only through Hunt. Report these as different categories; do not merge or move them.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — read it with the variable. (On Codex the variable does not exist; the session's working directory is the project root — treat it identically.)
-The shell's working directory persists between Bash calls and is not necessarily the project root,
-and a status read from the wrong directory reports a shift that does not exist.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; read
+every `.nightshift/` path from the validated absolute target, otherwise the task root. Never search
+or guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
 Read `.nightshift/` and print:
 

--- a/plugins/nightshift/skills/stop/SKILL.md
+++ b/plugins/nightshift/skills/stop/SKILL.md
@@ -5,11 +5,9 @@ description: Issue a stop-work order — end the shift at once, leaving open ite
 
 Issue a stop-work order for `$CLAUDE_PROJECT_DIR`.
 
-Every `.nightshift/` path below is relative to `$CLAUDE_PROJECT_DIR` — write it with the
-variable. (On Codex the variable does not exist; the session's working directory is the
-project root — treat it identically.)
-The shell's working directory persists between Bash calls and is not necessarily the project root;
-a stop-work order written to the wrong directory stops nothing.
+Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; write
+every `.nightshift/` path to the validated absolute target, otherwise the task root. Never search
+or guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
 1. Write `.nightshift/STOP` with a one-line reason and a timestamp (e.g. `stopped by owner ·
    <ISO time>`).

--- a/tests/schedule.bats
+++ b/tests/schedule.bats
@@ -74,6 +74,13 @@ setup() {
   printf '%s' "$output" | grep -qi 'no open items'
 }
 
+@test "an open checkbox outside Items is not scheduled work" {
+  printf '%s\n' '- [ ] planning example' '## Items' '- [x] **1. done.**' >"$P/.nightshift/punch-list.md"
+  run "$SCHED" --project "$P" --at 04:05
+  [ "$status" -eq 0 ]
+  printf '%s' "$output" | grep -qi 'no open items'
+}
+
 @test "list and remove are quiet when nothing is registered" {
   run "$SCHED" --project "$P" --list
   [ "$status" -eq 0 ]

--- a/tests/skill-paths.bats
+++ b/tests/skill-paths.bats
@@ -8,16 +8,16 @@ STOP="$SKILLS/stop/SKILL.md"
 # On the recommended layout — code repo a level below the project root — a bare relative path then
 # writes into the repo instead of the site. Every skill has to say so; one that doesn't is the next
 # misplaced settings file.
-@test "every skill states that its paths resolve against CLAUDE_PROJECT_DIR" {
+@test "every skill resolves explicit linked workspaces without searching" {
   for s in "$SKILLS"/*/SKILL.md; do
-    grep -qF 'path below is relative to `$CLAUDE_PROJECT_DIR`' "$s" \
-      || { echo "no path rule: $s"; return 1; }
+    grep -qF '.nightshift-link' "$s" || { echo "no linked-workspace rule: $s"; return 1; }
+    grep -qF 'Never search' "$s" || { echo "no no-search rule: $s"; return 1; }
   done
 }
 
 @test "every skill names the working directory as the reason" {
   for s in "$SKILLS"/*/SKILL.md; do
-    grep -qF 'working directory persists between Bash calls' "$s" \
+    grep -qF "working directory persists between Bash calls" "$s" \
       || { echo "no cwd caveat: $s"; return 1; }
   done
 }
@@ -28,13 +28,13 @@ STOP="$SKILLS/stop/SKILL.md"
   grep -qF '$CLAUDE_PROJECT_DIR/.claude/settings.local.json' "$SETUP"
 }
 
-@test "setup writes the rules file to an absolute path" {
-  grep -qF '$CLAUDE_PROJECT_DIR/.nightshift/rules.json' "$SETUP"
+@test "setup writes the rules file to the resolved workspace" {
+  grep -qF '$NIGHTSHIFT_WORKSPACE/.nightshift/rules.json' "$SETUP"
 }
 
 @test "setup scaffolds every template to an absolute path" {
   for f in punch-list drafting-table parking-lot snag-log product-research opportunity-map; do
-    grep -qF "\$CLAUDE_PROJECT_DIR/.nightshift/$f.md" "$SETUP" \
+    grep -qF "\$NIGHTSHIFT_WORKSPACE/.nightshift/$f.md" "$SETUP" \
       || { echo "scaffold target not absolute: $f"; return 1; }
   done
 }
@@ -42,7 +42,7 @@ STOP="$SKILLS/stop/SKILL.md"
 # git resolves its repo from the working directory, so the receipts repo is the one place a stray
 # cd would init a repo inside the code tree instead of the site.
 @test "setup inits the receipts repo without relying on the working directory" {
-  grep -qF 'git -C "$CLAUDE_PROJECT_DIR/.nightshift" init' "$SETUP"
+  grep -qF 'git -C "$NIGHTSHIFT_WORKSPACE/.nightshift" init' "$SETUP"
 }
 
 @test "setup refuses disposable ChatGPT scratch before writing" {

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -83,7 +83,7 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
 @test "setup pins the neutral ask and the rules home" {
   s="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/setup/SKILL.md"
   grep -qF 'never describe the repo as recommended; the default is no' "$s"
-  grep -qF '`$CLAUDE_PROJECT_DIR/.nightshift/rules.json` as-is' "$s"
+  grep -qF '`$NIGHTSHIFT_WORKSPACE/.nightshift/rules.json` as-is' "$s"
   grep -qF 'removes all of nightshift, rules' "$s"
 }
 

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -129,6 +129,22 @@ calls() { grep -c called "$P/.nightshift/agent-calls" 2>/dev/null || echo 0; }
   grep -q 'clean session end (exit)' "$p/.nightshift/.session-end"
 }
 
+@test "session-end hook is inert while the shift is unarmed" {
+  p="$(new_project)"
+  punch_open "$p"
+  rm "$p/.nightshift/.shift-armed"
+  printf '{"reason":"exit"}' | CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
+  [ ! -f "$p/.nightshift/.session-end" ]
+}
+
+@test "session-end ignores an open checkbox outside the Items list" {
+  p="$(new_project)"
+  touch "$p/.nightshift/.shift-armed"
+  printf '%s\n' '- [ ] planning example' '## Items' '- [x] **1. done.**' >"$p/.nightshift/punch-list.md"
+  printf '{"reason":"exit"}' | CLAUDE_PROJECT_DIR="$p" bash "$SESSION_END"
+  [ ! -f "$p/.nightshift/.session-end" ]
+}
+
 @test "session-end hook is inert when the shift is done or absent" {
   p="$(new_project)"
   punch_done "$p"

--- a/tests/workspace-link.bats
+++ b/tests/workspace-link.bats
@@ -1,0 +1,83 @@
+load helpers
+
+RUNTIME="$BATS_TEST_DIRNAME/../plugins/nightshift/runtime"
+LIB="$BATS_TEST_DIRNAME/../plugins/nightshift/lib/lib.sh"
+CODEX_HOOKS="$HOOKS/codex"
+
+@test "an absent link keeps the task root authoritative" {
+  host="$(new_project host)"
+  expected="$(cd -P "$host" && pwd)"
+  run bash -c '. "$1"; ns_workspace_root "$2"' _ "$LIB" "$host"
+  [ "$status" -eq 0 ]
+  [ "$output" = "$expected" ]
+}
+
+@test "link-workspace records one canonical absolute target and keeps it local" {
+  host="$(new_project host)"
+  workspace="$BATS_TEST_TMPDIR/workspace with spaces"
+  mkdir -p "$workspace/.nightshift"
+  expected="$(cd -P "$workspace" && pwd)"
+  run bash "$RUNTIME/link-workspace.sh" --host-root "$host" --workspace "$workspace"
+  [ "$status" -eq 0 ]
+  [ "$(cat "$host/.nightshift-link")" = "$expected" ]
+  grep -qxF '.nightshift-link' "$host/.git/info/exclude"
+  [ -z "$(git -C "$host" status --short -- .nightshift-link)" ]
+}
+
+@test "link-workspace rejects relative and uninitialized targets" {
+  host="$(new_project host)"
+  mkdir -p "$BATS_TEST_TMPDIR/no-state"
+  run bash "$RUNTIME/link-workspace.sh" --host-root "$host" --workspace relative
+  [ "$status" -ne 0 ]
+  run bash "$RUNTIME/link-workspace.sh" --host-root "$host" --workspace "$BATS_TEST_TMPDIR/no-state"
+  [ "$status" -ne 0 ]
+  [ ! -e "$host/.nightshift-link" ]
+}
+
+@test "Claude gate and hardhat enforce the linked authoritative workspace" {
+  host="$(new_project host)"
+  rm -rf "$host/.nightshift"
+  workspace="$(new_project workspace)"
+  punch_open "$workspace"
+  bash "$RUNTIME/link-workspace.sh" --host-root "$host" --workspace "$workspace" >/dev/null
+
+  run gate "$host"
+  is_block "$output"
+  run hardhat_bash "$host" "git push origin main" NIGHTSHIFT_FORBIDDEN_COMMANDS='git push'
+  is_deny "$output"
+}
+
+@test "Codex gate and hardhat enforce the linked authoritative workspace" {
+  host="$(new_project host)"
+  rm -rf "$host/.nightshift"
+  workspace="$(new_project workspace)"
+  punch_open "$workspace"
+  bash "$RUNTIME/link-workspace.sh" --host-root "$host" --workspace "$workspace" >/dev/null
+
+  run bash -c 'jq -nc '\''{hook_event_name:"Stop",session_id:"test-shift-session",transcript_path:""}'\'' | env CODEX_PROJECT_DIR="$1" bash "$2/clock-out-gate.sh"' _ "$host" "$CODEX_HOOKS"
+  is_block "$output"
+  run bash -c 'jq -nc --arg c "git push origin main" '\''{tool_name:"Bash",tool_input:{command:$c}}'\'' | env CODEX_PROJECT_DIR="$1" NIGHTSHIFT_FORBIDDEN_COMMANDS="git push" bash "$2/hardhat.sh"' _ "$host" "$CODEX_HOOKS"
+  is_deny "$output"
+}
+
+@test "malformed links fail closed on both hosts" {
+  host="$(new_project host)"
+  printf 'relative/path\n' >"$host/.nightshift-link"
+  run gate "$host"
+  is_block "$output"
+  printf '%s' "$output" | grep -q 'invalid'
+  run bash -c 'jq -nc '\''{hook_event_name:"Stop",session_id:"test-shift-session"}'\'' | env CODEX_PROJECT_DIR="$1" bash "$2/clock-out-gate.sh"' _ "$host" "$CODEX_HOOKS"
+  is_block "$output"
+}
+
+@test "Claude clean-session markers land in the linked workspace" {
+  host="$(new_project host)"
+  rm -rf "$host/.nightshift"
+  workspace="$(new_project workspace)"
+  punch_open "$workspace"
+  printf 'linked-session\n\n\n\nclaude\n' >"$workspace/.nightshift/.shift-session"
+  bash "$RUNTIME/link-workspace.sh" --host-root "$host" --workspace "$workspace" >/dev/null
+  jq -nc '{session_id:"linked-session",reason:"exit"}' |
+    env CLAUDE_PROJECT_DIR="$host" bash "$HOOKS/session-end.sh"
+  grep -q 'clean session end' "$workspace/.nightshift/.session-end"
+}

--- a/tests/workspace-link.bats
+++ b/tests/workspace-link.bats
@@ -70,6 +70,19 @@ CODEX_HOOKS="$HOOKS/codex"
   is_block "$output"
 }
 
+@test "blank extra lines and broken symlinks are invalid rather than absent" {
+  host="$(new_project host)"
+  workspace="$(new_project workspace)"
+  printf '%s\n\n' "$workspace" >"$host/.nightshift-link"
+  run bash -c '. "$1"; ns_workspace_root "$2"' _ "$LIB" "$host"
+  [ "$status" -eq 2 ]
+
+  rm "$host/.nightshift-link"
+  ln -s "$BATS_TEST_TMPDIR/missing-target" "$host/.nightshift-link"
+  run bash -c '. "$1"; ns_workspace_root "$2"' _ "$LIB" "$host"
+  [ "$status" -eq 2 ]
+}
+
 @test "Claude clean-session markers land in the linked workspace" {
   host="$(new_project host)"
   rm -rf "$host/.nightshift"


### PR DESCRIPTION
## What does this PR do?

Fixes cross-workspace Nightshift runs for both Codex and Claude Code. A task may now carry a local-only `.nightshift-link` to one authoritative workspace, while hooks, session handling, and every stateful skill consistently read and write that single `.nightshift/` state.

Invalid, relative, multiline, symlinked, or missing targets fail closed. Nightshift never searches parent or sibling folders, and the helper places the pointer in Git's local exclude rather than tracked project files.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Adapter (support for another harness)
- [ ] Docs / chore / refactor (no behaviour change)
- [ ] Gate behaviour change (discussed in an issue first — see CONTRIBUTING)

## Verification

- [x] `bats -r tests/` — 322 passing
- [x] `git ls-files '*.sh' | xargs shellcheck -x`
- [x] `shellcheck -x plugins/nightshift/runtime/link-workspace.sh`
- [x] `claude plugin validate . --strict`
- [x] `git diff --check`
- [x] Claude Code and Codex linked gate/hardhat behavior covered
- [x] Relative, missing, multiline, symlink, spaced-path, and Git-local pointer behavior covered

This is a patch-level bug fix. Release Please should propose `0.9.3`; no manifest version was changed manually.
