### PR TITLE
fix(codex): park native user questions during shifts

### DIFF
--- a/plugins/nightshift/hooks/codex/README.md
+++ b/plugins/nightshift/hooks/codex/README.md
@@ -17,12 +17,13 @@ the PreToolUse denial as the `hookSpecificOutput` `permissionDecision` shape; `$
 as the plugin root in commands. Codex-side mapping: shell commands, including unified exec,
 match as `Bash`; file edits arrive as `apply_patch` with the patch text in
 `tool_input.command`, with `Edit`/`Write` as matcher-side aliases; hosted tools never reach
-the hook path.
+the hook path. Codex's local `request_user_input` function tool does reach `PreToolUse`; an
+armed shift denies it mechanically and reuses the shared `AskUserQuestion` parking message.
 
-Two points the docs leave open are held conservatively in `lib-io.sh`: no project-dir env var
+One point the docs leave open is held conservatively in `lib-io.sh`: no project-dir env var
 is documented for hooks, so the payload's `cwd` locates the shift and `CODEX_PROJECT_DIR` is
-honored first as an explicit override; and no ask-the-user tool is documented, so the
-`AskUserQuestion` wiring stays armed for any tool that carries the name.
+honored first as an explicit override. `AskUserQuestion` stays wired as a compatibility alias
+beside Codex's native `request_user_input` name.
 
 The repo-root `.agents/plugins/marketplace.json` is the Codex marketplace entry; the
 `.claude-plugin/marketplace.json` beside it is also read as a legacy-compatible path, and both

--- a/plugins/nightshift/hooks/codex/hardhat.sh
+++ b/plugins/nightshift/hooks/codex/hardhat.sh
@@ -2,8 +2,9 @@
 # hardhat.sh — Codex PreToolUse guard. Same rules as Claude's hardhat; only the wire format
 # differs, and that lives entirely in lib-io.sh.
 #
-# One zero-config rule: AskUserQuestion is denied during an active shift — park, don't
-# ask. Every other rule is shift-scoped and opt-in, read from the owner's rules file
+# One zero-config rule: the host's ask-user tool is denied during an active shift — park,
+# don't ask. Codex calls it request_user_input; AskUserQuestion remains a compatibility
+# alias. Every other rule is shift-scoped and opt-in, read from the owner's rules file
 # (.nightshift/rules.json) — each empty by default, so an unset one is skipped silently:
 #   protectedDirs        space/pipe-separated dir names never to git add/commit/tag/remote
 #   expectedEmail        commits must be authored by this identity
@@ -95,8 +96,9 @@ fi
 
 # Tool rules — the rules file's toolDeny map: tool name -> denial message. A key's message
 # is the denial the model reads; an empty message lifts the rule; an absent key means the
-# default — AskUserQuestion parked so a 2:40am question cannot kill the run, every other
-# tool allowed. (sed backs up the jq path; the park rule holds even without jq.)
+# default — ask-user tools parked so a 2:40am question cannot kill the run, every other
+# tool allowed. Both Codex names use the shared AskUserQuestion rule, so the owner has one
+# policy to configure across hosts. (sed backs up jq; the park rule holds without jq.)
 TOOL_RULES="$(rule "$PROJECT_DIR" toolDeny "${NIGHTSHIFT_TOOL_RULES:-}")"
 rules_has() {
   [ -n "$TOOL_RULES" ] || return 1
@@ -117,7 +119,9 @@ if [ -n "$TOOL_RULES" ] && command -v jq >/dev/null 2>&1 \
   && ! printf '%s' "$TOOL_RULES" | jq -e 'type == "object"' >/dev/null 2>&1; then
   deny "BLOCKED: the toolDeny rules are not a JSON object, so the tool rules cannot run. Fix .nightshift/rules.json or re-run /nightshift:setup."
 fi
-if [ "$TOOL" = "AskUserQuestion" ] || codex_input_mentions_tool "AskUserQuestion"; then
+if [ "$TOOL" = "AskUserQuestion" ] || [ "$TOOL" = "request_user_input" ] \
+  || codex_input_mentions_tool "AskUserQuestion" \
+  || codex_input_mentions_tool "request_user_input"; then
   # The park message is the map's AskUserQuestion entry — the one copy, shipped in the
   # template setup copies. No readable entry still parks the question (fail closed), with the
   # repair named.

--- a/plugins/nightshift/hooks/codex/hooks.json
+++ b/plugins/nightshift/hooks/codex/hooks.json
@@ -12,7 +12,7 @@
         ]
       },
       {
-        "matcher": "AskUserQuestion",
+        "matcher": "AskUserQuestion|request_user_input",
         "hooks": [
           {
             "type": "command",

--- a/tests/codex/hardhat.bats
+++ b/tests/codex/hardhat.bats
@@ -13,11 +13,16 @@ codex_hardhat_bash() {
     env "$@" CODEX_PROJECT_DIR="$p" bash "$CODEX_HOOKS/hardhat.sh"
 }
 
-# codex_hardhat_ask <project> [ENV=VAL ...]
+# codex_hardhat_ask <project> [tool-name] [ENV=VAL ...]
 codex_hardhat_ask() {
   local p="$1"
   shift
-  jq -nc '{tool_name:"AskUserQuestion",tool_input:{}}' |
+  local tool="AskUserQuestion"
+  if [ "${1:-}" = "AskUserQuestion" ] || [ "${1:-}" = "request_user_input" ]; then
+    tool="$1"
+    shift
+  fi
+  jq -nc --arg tool "$tool" '{tool_name:$tool,tool_input:{}}' |
     env "$@" CODEX_PROJECT_DIR="$p" bash "$CODEX_HOOKS/hardhat.sh"
 }
 
@@ -89,6 +94,22 @@ codex_hardhat_ask() {
   printf '%s' "$output" | grep -q "park" # the template's toolDeny entry, read from the file
 }
 
+@test "request_user_input is parked with the shared template message" {
+  p="$(new_project)"
+  punch_open "$p"
+  run codex_hardhat_ask "$p" request_user_input
+  is_deny "$output"
+  printf '%s' "$output" | grep -q "park"
+}
+
+@test "request_user_input remains available outside an armed shift" {
+  p="$(new_project)"
+  punch_open "$p"
+  rm "$p/.nightshift/.shift-armed"
+  run codex_hardhat_ask "$p" request_user_input
+  is_allow
+}
+
 @test "an open checkbox outside Items does not activate the codex hardhat" {
   p="$(new_project)"
   printf '%s\n' '- [ ] planning example' '## Items' '- [x] **1. done.**' >"$p/.nightshift/punch-list.md"
@@ -115,6 +136,15 @@ codex_hardhat_ask() {
   p="$(new_project)"
   punch_open "$p"
   run codex_hardhat_ask "$p" NIGHTSHIFT_TOOL_RULES='{"AskUserQuestion":"park it and keep welding"}'
+  is_deny "$output"
+  printf '%s' "$output" | grep -q "park it and keep welding"
+}
+
+@test "request_user_input uses the owner's shared AskUserQuestion message" {
+  p="$(new_project)"
+  punch_open "$p"
+  run codex_hardhat_ask "$p" request_user_input \
+    NIGHTSHIFT_TOOL_RULES='{"AskUserQuestion":"park it and keep welding"}'
   is_deny "$output"
   printf '%s' "$output" | grep -q "park it and keep welding"
 }


### PR DESCRIPTION
## What does this PR do?

Blocks Codex's native `request_user_input` tool during an armed Nightshift and routes it through the existing shared parking policy. Claude Code behavior is unchanged.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] Harness support
- [ ] Docs / chore / refactor
- [ ] Gate behaviour change

## Verification

- [x] Full Bats suite: 259 tests passed
- [x] ShellCheck passed
- [x] `claude plugin validate . --strict` passed
- [x] Added regression coverage for armed, unarmed, and owner-configured `request_user_input` behavior