### PR TITLE
Rename repository references to Nightshift

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -42,7 +42,7 @@
         "url": "https://github.com/orwa-mahmoud"
       },
       "homepage": "https://orwamahmoud.com/nightshift/",
-      "repository": "https://github.com/orwa-mahmoud/claude-nightshift",
+      "repository": "https://github.com/orwa-mahmoud/nightshift",
       "license": "MIT"
     }
   ]

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: 📖 Documentation
-    url: https://github.com/orwa-mahmoud/claude-nightshift/blob/main/README.md
+    url: https://github.com/orwa-mahmoud/nightshift/blob/main/README.md
     about: Setup, the punch-list contract, gates, and the stop-gate explained.
   - name: 🔒 Security — gate-bypass reports
-    url: https://github.com/orwa-mahmoud/claude-nightshift/security/advisories/new
+    url: https://github.com/orwa-mahmoud/nightshift/security/advisories/new
     about: Ways to make the stop-gate lie go here, privately — not in a public issue.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,4 @@
-<!-- Thanks for contributing to claude-nightshift! -->
+<!-- Thanks for contributing to Nightshift! -->
 
 ## What does this PR do?
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,44 +3,44 @@
 Installs pin to the `version` in `plugins/nightshift/.claude-plugin/plugin.json`, so every entry here is a
 version users receive. Dates are release dates; the tags carry the exact trees.
 
-## [0.9.4](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.9.3...v0.9.4) (2026-08-13)
+## [0.9.4](https://github.com/orwa-mahmoud/nightshift/compare/v0.9.3...v0.9.4) (2026-08-13)
 
 
 ### Bug Fixes
 
-* **codex:** park native user questions during shifts ([a058e36](https://github.com/orwa-mahmoud/claude-nightshift/commit/a058e369f849fef7f23223646ded38cdfdea0f1c))
-* **codex:** park native user questions during shifts ([#58](https://github.com/orwa-mahmoud/claude-nightshift/issues/58)) ([a39626e](https://github.com/orwa-mahmoud/claude-nightshift/commit/a39626e1eee5433749492f9b7e64fa4c8086e32d))
+* **codex:** park native user questions during shifts ([a058e36](https://github.com/orwa-mahmoud/nightshift/commit/a058e369f849fef7f23223646ded38cdfdea0f1c))
+* **codex:** park native user questions during shifts ([#58](https://github.com/orwa-mahmoud/nightshift/issues/58)) ([a39626e](https://github.com/orwa-mahmoud/nightshift/commit/a39626e1eee5433749492f9b7e64fa4c8086e32d))
 
-## [0.9.3](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.9.2...v0.9.3) (2026-08-12)
-
-
-### Bug Fixes
-
-* **state:** align remaining active-shift checks ([7108184](https://github.com/orwa-mahmoud/claude-nightshift/commit/7108184233697097c4f70eabfbfc3999e0dcc593))
-* **workspace:** link tasks to authoritative shift state ([a3a1992](https://github.com/orwa-mahmoud/claude-nightshift/commit/a3a19927bd7fd53371a653df8594d670d31e5423))
-* **workspace:** reject ambiguous link files ([13235d6](https://github.com/orwa-mahmoud/claude-nightshift/commit/13235d6a219ea1b4d373f9b43277c02a070d0b04))
-
-## [0.9.2](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.9.1...v0.9.2) (2026-08-12)
+## [0.9.3](https://github.com/orwa-mahmoud/nightshift/compare/v0.9.2...v0.9.3) (2026-08-12)
 
 
 ### Bug Fixes
 
-* harden Nightshift across Claude Code and Codex ([#53](https://github.com/orwa-mahmoud/claude-nightshift/issues/53)) ([2ebfce5](https://github.com/orwa-mahmoud/claude-nightshift/commit/2ebfce5ceaa2b3daf7f803e2c49a9887b4762ebb))
-* **hardhat:** align active-shift detection across hosts ([0374ac8](https://github.com/orwa-mahmoud/claude-nightshift/commit/0374ac876fb66706da67fa33cd1622ce76f9f67c))
-* **schedule:** safely encode generated cron and launchd paths ([e713d3c](https://github.com/orwa-mahmoud/claude-nightshift/commit/e713d3c1ee8a696d4a7b8ebfaba46410ec433e55))
-* **session:** always record the Claude host in shift identity ([bdfb0aa](https://github.com/orwa-mahmoud/claude-nightshift/commit/bdfb0aaad57369e9f2eceb9be17efef31da0f0af))
-* **setup:** resolve a single repository inside parent workspaces ([20424b1](https://github.com/orwa-mahmoud/claude-nightshift/commit/20424b1432bc55f2e06be75d2c4a4cfbedacb031))
-* **skills:** clarify state-file roles across model workflows ([6ef7014](https://github.com/orwa-mahmoud/claude-nightshift/commit/6ef701409774d2dc4eff5c3186fa6f785b875f55))
-* **test:** measure coverage from current plugin paths ([0a3e6f7](https://github.com/orwa-mahmoud/claude-nightshift/commit/0a3e6f7742ebf1a1342b75e47a1b9b5063a891e1))
+* **state:** align remaining active-shift checks ([7108184](https://github.com/orwa-mahmoud/nightshift/commit/7108184233697097c4f70eabfbfc3999e0dcc593))
+* **workspace:** link tasks to authoritative shift state ([a3a1992](https://github.com/orwa-mahmoud/nightshift/commit/a3a19927bd7fd53371a653df8594d670d31e5423))
+* **workspace:** reject ambiguous link files ([13235d6](https://github.com/orwa-mahmoud/nightshift/commit/13235d6a219ea1b4d373f9b43277c02a070d0b04))
 
-## [0.9.1](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.9.0...v0.9.1) (2026-08-12)
+## [0.9.2](https://github.com/orwa-mahmoud/nightshift/compare/v0.9.1...v0.9.2) (2026-08-12)
 
 
 ### Bug Fixes
 
-* redirect temporary ChatGPT workspaces ([809c906](https://github.com/orwa-mahmoud/claude-nightshift/commit/809c9066288a5f2d5c397d05d88e27c3fce20970))
+* harden Nightshift across Claude Code and Codex ([#53](https://github.com/orwa-mahmoud/nightshift/issues/53)) ([2ebfce5](https://github.com/orwa-mahmoud/nightshift/commit/2ebfce5ceaa2b3daf7f803e2c49a9887b4762ebb))
+* **hardhat:** align active-shift detection across hosts ([0374ac8](https://github.com/orwa-mahmoud/nightshift/commit/0374ac876fb66706da67fa33cd1622ce76f9f67c))
+* **schedule:** safely encode generated cron and launchd paths ([e713d3c](https://github.com/orwa-mahmoud/nightshift/commit/e713d3c1ee8a696d4a7b8ebfaba46410ec433e55))
+* **session:** always record the Claude host in shift identity ([bdfb0aa](https://github.com/orwa-mahmoud/nightshift/commit/bdfb0aaad57369e9f2eceb9be17efef31da0f0af))
+* **setup:** resolve a single repository inside parent workspaces ([20424b1](https://github.com/orwa-mahmoud/nightshift/commit/20424b1432bc55f2e06be75d2c4a4cfbedacb031))
+* **skills:** clarify state-file roles across model workflows ([6ef7014](https://github.com/orwa-mahmoud/nightshift/commit/6ef701409774d2dc4eff5c3186fa6f785b875f55))
+* **test:** measure coverage from current plugin paths ([0a3e6f7](https://github.com/orwa-mahmoud/nightshift/commit/0a3e6f7742ebf1a1342b75e47a1b9b5063a891e1))
 
-## [0.9.0](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.8.1...v0.9.0) (2026-08-12)
+## [0.9.1](https://github.com/orwa-mahmoud/nightshift/compare/v0.9.0...v0.9.1) (2026-08-12)
+
+
+### Bug Fixes
+
+* redirect temporary ChatGPT workspaces ([809c906](https://github.com/orwa-mahmoud/nightshift/commit/809c9066288a5f2d5c397d05d88e27c3fce20970))
+
+## [0.9.0](https://github.com/orwa-mahmoud/nightshift/compare/v0.8.1...v0.9.0) (2026-08-12)
 
 
 ### Features
@@ -48,27 +48,27 @@ version users receive. Dates are release dates; the tags carry the exact trees.
 * add evidence-backed product evolution to the ready-made hunt catalog
 * preserve active opportunity progress across compaction and resumed sessions
 * integrate product research and opportunity tracking with setup, status, and archive
-* make Codex a first-class host alongside Claude Code ([7f62a2d](https://github.com/orwa-mahmoud/claude-nightshift/commit/7f62a2dd1e59f1653b363191c1d9d7d3afad3a12))
+* make Codex a first-class host alongside Claude Code ([7f62a2d](https://github.com/orwa-mahmoud/nightshift/commit/7f62a2dd1e59f1653b363191c1d9d7d3afad3a12))
 
-## [0.8.1](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.8.0...v0.8.1) (2026-08-05)
+## [0.8.1](https://github.com/orwa-mahmoud/nightshift/compare/v0.8.0...v0.8.1) (2026-08-05)
 
 
 ### Bug Fixes
 
-* Codex packaging and host wording catch up to the release ([a1ab3a1](https://github.com/orwa-mahmoud/claude-nightshift/commit/a1ab3a1fb5063c86051f13641d2d5ac9ab1afa93))
+* Codex packaging and host wording catch up to the release ([a1ab3a1](https://github.com/orwa-mahmoud/nightshift/commit/a1ab3a1fb5063c86051f13641d2d5ac9ab1afa93))
 
-## [0.8.0](https://github.com/orwa-mahmoud/claude-nightshift/compare/v0.7.4...v0.8.0) (2026-08-05)
+## [0.8.0](https://github.com/orwa-mahmoud/nightshift/compare/v0.7.4...v0.8.0) (2026-08-05)
 
 nightshift runs on OpenAI Codex. One package, a manifest per host, and the same night either
 way — the gate, the guards, the skills, the scheduler, and the watchman.
 
 ### Features
 
-* the Codex clock-out gate and hardhat enforce the same shift — Claude's decisions behind Codex's own hook wiring, verified in a live session ([2bac060](https://github.com/orwa-mahmoud/claude-nightshift/commit/2bac06066a4a72b2a6ce13e7ab1e89935ab77450))
-* the night watchman works Codex shifts — a killed session is revived into its own conversation and the list is finished with nobody attached, verified with a live SIGKILL mid-shift ([fc3510f](https://github.com/orwa-mahmoud/claude-nightshift/commit/fc3510f2b0ae6437763bb70467f327237b9852cb))
-* the shift record names its host, so each watchman minds only its own shifts ([19d619f](https://github.com/orwa-mahmoud/claude-nightshift/commit/19d619f18f451cd57e90b39d2ef9c9ee637d7f47))
-* the skills speak both hosts — permissions, liveness and the watchman step fork per host, and the schedule generator takes `--agent` so one entry serves either runner ([349bfed](https://github.com/orwa-mahmoud/claude-nightshift/commit/349bfedc775aab94364f92136de75f357428f7e6))
-* Codex install is advertised: the `.agents` marketplace entry and the README's `codex plugin` commands ([e52c18a](https://github.com/orwa-mahmoud/claude-nightshift/commit/e52c18a29b1238f4562eda3ea121bd8cdc2ce598))
+* the Codex clock-out gate and hardhat enforce the same shift — Claude's decisions behind Codex's own hook wiring, verified in a live session ([2bac060](https://github.com/orwa-mahmoud/nightshift/commit/2bac06066a4a72b2a6ce13e7ab1e89935ab77450))
+* the night watchman works Codex shifts — a killed session is revived into its own conversation and the list is finished with nobody attached, verified with a live SIGKILL mid-shift ([fc3510f](https://github.com/orwa-mahmoud/nightshift/commit/fc3510f2b0ae6437763bb70467f327237b9852cb))
+* the shift record names its host, so each watchman minds only its own shifts ([19d619f](https://github.com/orwa-mahmoud/nightshift/commit/19d619f18f451cd57e90b39d2ef9c9ee637d7f47))
+* the skills speak both hosts — permissions, liveness and the watchman step fork per host, and the schedule generator takes `--agent` so one entry serves either runner ([349bfed](https://github.com/orwa-mahmoud/nightshift/commit/349bfedc775aab94364f92136de75f357428f7e6))
+* Codex install is advertised: the `.agents` marketplace entry and the README's `codex plugin` commands ([e52c18a](https://github.com/orwa-mahmoud/nightshift/commit/e52c18a29b1238f4562eda3ea121bd8cdc2ce598))
 
 Unattended Codex runs that commit use the `danger-full-access` sandbox — `workspace-write`
 blocks `git commit`. nightshift's guards hold in every mode. A Codex session alive at an API

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to claude-nightshift
+# Contributing to Nightshift
 
 Thanks for looking under the hood. The plugin is deliberately small — a
 punch-list contract, a stop-gate hook, and skills that hold an agent to both —
@@ -20,7 +20,7 @@ so contributions should keep that shape.
 ## Setup
 
 ```bash
-git clone https://github.com/orwa-mahmoud/claude-nightshift.git
+git clone https://github.com/orwa-mahmoud/nightshift.git
 # install as a local plugin, then run Nightshift: Setup in Codex or
 # /nightshift:setup in Claude Code inside a scratch project
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Overview and FAQ: <https://orwamahmoud.com/nightshift/>
 For local Codex development, the same package can be installed from its marketplace:
 
 ```text
-codex plugin marketplace add orwa-mahmoud/claude-nightshift
+codex plugin marketplace add orwa-mahmoud/nightshift
 codex plugin add nightshift@nightshift
 ```
 
@@ -34,7 +34,7 @@ real repository.
 Two commands inside Claude Code — no npm, no Homebrew, no separate CLI, no API keys, no server:
 
 ```text
-/plugin marketplace add orwa-mahmoud/claude-nightshift
+/plugin marketplace add orwa-mahmoud/nightshift
 /plugin install nightshift
 ```
 
@@ -360,7 +360,7 @@ Read this before you trust it overnight:
 all run on OpenAI Codex from the same package. The one open edge is wedge detection — a Codex
 session alive at an API error is stood by, not revived, until that transcript signature has been
 observed in a real outage — see
-[#41](https://github.com/orwa-mahmoud/claude-nightshift/issues/41).
+[#41](https://github.com/orwa-mahmoud/nightshift/issues/41).
 
 ## Development
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -22,7 +22,7 @@ lie** — clocking out with unticked items, forging receipts, or escaping the
 contract via hook manipulation.
 
 Instead, report privately via GitHub's
-[**Report a vulnerability**](https://github.com/orwa-mahmoud/claude-nightshift/security/advisories/new)
+[**Report a vulnerability**](https://github.com/orwa-mahmoud/nightshift/security/advisories/new)
 flow (Security → Advisories). If that is unavailable, you can open a regular
 issue asking the maintainer to contact you, without disclosing details.
 

--- a/examples/codex-hardening-shift.md
+++ b/examples/codex-hardening-shift.md
@@ -14,31 +14,31 @@ local `.nightshift/` files.
 - **Verification passed before handoff.** The complete Bats suite reported 248 passing tests;
   ShellCheck and strict Claude plugin validation also passed.
 - **Merged and released.** The work landed through
-  [PR #53](https://github.com/orwa-mahmoud/claude-nightshift/pull/53) and shipped in
-  [v0.9.2](https://github.com/orwa-mahmoud/claude-nightshift/releases/tag/v0.9.2).
+  [PR #53](https://github.com/orwa-mahmoud/nightshift/pull/53) and shipped in
+  [v0.9.2](https://github.com/orwa-mahmoud/nightshift/releases/tag/v0.9.2).
 
 ## Item receipts
 
 All timestamps are Dubai time (UTC+04:00) on 2026-08-12. Each line links to the preserved commit:
 
-- `21:17` · [fix(hardhat): align active-shift detection across hosts](https://github.com/orwa-mahmoud/claude-nightshift/commit/0374ac876fb66706da67fa33cd1622ce76f9f67c)
-- `21:19` · [fix(session): always record the Claude host in shift identity](https://github.com/orwa-mahmoud/claude-nightshift/commit/bdfb0aaad57369e9f2eceb9be17efef31da0f0af)
-- `21:22` · [fix(schedule): safely encode generated cron and launchd paths](https://github.com/orwa-mahmoud/claude-nightshift/commit/e713d3c1ee8a696d4a7b8ebfaba46410ec433e55)
-- `21:32` · [fix(test): measure coverage from current plugin paths](https://github.com/orwa-mahmoud/claude-nightshift/commit/0a3e6f7742ebf1a1342b75e47a1b9b5063a891e1)
-- `21:33` · [test(contracts): cover remaining shifts and lifecycle invariants](https://github.com/orwa-mahmoud/claude-nightshift/commit/e32066604cde27c463697aa3d7cb18b99727511b)
-- `21:37` · [docs(github): align templates with dual-host support](https://github.com/orwa-mahmoud/claude-nightshift/commit/884f8caa0464370bc40faa5dac2111bef478c389)
-- `21:39` · [docs(security): clarify runtime and notification side effects](https://github.com/orwa-mahmoud/claude-nightshift/commit/11fa0423434ea2630242c8c56de6025945d7501f)
-- `21:40` · [docs: add unattended first-night checklist](https://github.com/orwa-mahmoud/claude-nightshift/commit/89e01d788e17eaa864c44f2b9bda38358da51d83)
-- `21:48` · [fix(setup): resolve a single repository inside parent workspaces](https://github.com/orwa-mahmoud/claude-nightshift/commit/20424b1432bc55f2e06be75d2c4a4cfbedacb031)
-- `21:52` · [fix(skills): clarify state-file roles across model workflows](https://github.com/orwa-mahmoud/claude-nightshift/commit/6ef701409774d2dc4eff5c3186fa6f785b875f55)
-- `21:56` · [refactor(hooks): share gate and hardhat decision cores across hosts](https://github.com/orwa-mahmoud/claude-nightshift/commit/7c89a474f9aefb414e751066e974c59e78bb8162)
+- `21:17` · [fix(hardhat): align active-shift detection across hosts](https://github.com/orwa-mahmoud/nightshift/commit/0374ac876fb66706da67fa33cd1622ce76f9f67c)
+- `21:19` · [fix(session): always record the Claude host in shift identity](https://github.com/orwa-mahmoud/nightshift/commit/bdfb0aaad57369e9f2eceb9be17efef31da0f0af)
+- `21:22` · [fix(schedule): safely encode generated cron and launchd paths](https://github.com/orwa-mahmoud/nightshift/commit/e713d3c1ee8a696d4a7b8ebfaba46410ec433e55)
+- `21:32` · [fix(test): measure coverage from current plugin paths](https://github.com/orwa-mahmoud/nightshift/commit/0a3e6f7742ebf1a1342b75e47a1b9b5063a891e1)
+- `21:33` · [test(contracts): cover remaining shifts and lifecycle invariants](https://github.com/orwa-mahmoud/nightshift/commit/e32066604cde27c463697aa3d7cb18b99727511b)
+- `21:37` · [docs(github): align templates with dual-host support](https://github.com/orwa-mahmoud/nightshift/commit/884f8caa0464370bc40faa5dac2111bef478c389)
+- `21:39` · [docs(security): clarify runtime and notification side effects](https://github.com/orwa-mahmoud/nightshift/commit/11fa0423434ea2630242c8c56de6025945d7501f)
+- `21:40` · [docs: add unattended first-night checklist](https://github.com/orwa-mahmoud/nightshift/commit/89e01d788e17eaa864c44f2b9bda38358da51d83)
+- `21:48` · [fix(setup): resolve a single repository inside parent workspaces](https://github.com/orwa-mahmoud/nightshift/commit/20424b1432bc55f2e06be75d2c4a4cfbedacb031)
+- `21:52` · [fix(skills): clarify state-file roles across model workflows](https://github.com/orwa-mahmoud/nightshift/commit/6ef701409774d2dc4eff5c3186fa6f785b875f55)
+- `21:56` · [refactor(hooks): share gate and hardhat decision cores across hosts](https://github.com/orwa-mahmoud/nightshift/commit/7c89a474f9aefb414e751066e974c59e78bb8162)
 
 ## Permanent handoff
 
 The item commits were merged without squashing, so the reviewable history survived. The merge is
-[2ebfce5](https://github.com/orwa-mahmoud/claude-nightshift/commit/2ebfce5ceaa2b3daf7f803e2c49a9887b4762ebb),
+[2ebfce5](https://github.com/orwa-mahmoud/nightshift/commit/2ebfce5ceaa2b3daf7f803e2c49a9887b4762ebb),
 and the released tree is pinned by the
-[v0.9.2 tag](https://github.com/orwa-mahmoud/claude-nightshift/tree/v0.9.2).
+[v0.9.2 tag](https://github.com/orwa-mahmoud/nightshift/tree/v0.9.2).
 
 This proves the bounded claim: Nightshift can keep a real Codex maintenance run anchored to an
 explicit punch list and leave a reviewable commit trail. It does not claim that Codex has Claude

--- a/examples/self-build.md
+++ b/examples/self-build.md
@@ -28,25 +28,25 @@ The one-commit-per-item history below is the proof: read it top to bottom and yo
 
 All on 2026-07-13, timestamps local; every line links to its commit:
 
-- `21:57` · [chore: plugin scaffold, manifests, license](https://github.com/orwa-mahmoud/claude-nightshift/commit/07d5927)
-- `21:57` · [ci: shellcheck + test workflow](https://github.com/orwa-mahmoud/claude-nightshift/commit/b41d9cd)
-- `22:03` · [feat(hooks): clock-out gate — punch-list file is the only truth](https://github.com/orwa-mahmoud/claude-nightshift/commit/b8e561a)
-- `22:04` · [feat(hooks): stall red-tag + stop-work order + quitting time — bounded, interruptible runs](https://github.com/orwa-mahmoud/claude-nightshift/commit/11e0ea2)
-- `22:08` · [feat(hooks): hardhat — mechanical safety, zero-config core](https://github.com/orwa-mahmoud/claude-nightshift/commit/60f2380)
-- `22:09` · [feat(hooks): park-don't-ask — a question can't kill the shift](https://github.com/orwa-mahmoud/claude-nightshift/commit/1965b9c)
-- `22:11` · [feat(hooks): morning whistle — optional shift-end ping](https://github.com/orwa-mahmoud/claude-nightshift/commit/5dc7630)
-- `22:27` · [test: bats coverage for gate + hardhat + stall + stop-work + deadline + degradation](https://github.com/orwa-mahmoud/claude-nightshift/commit/41d8d1d)
-- `22:36` · [feat(templates): punch list, parking lot, snag log, walkthrough presets](https://github.com/orwa-mahmoud/claude-nightshift/commit/a8f0c1d)
-- `22:38` · [feat(skill): the nightshift brain](https://github.com/orwa-mahmoud/claude-nightshift/commit/381f01b)
-- `22:42` · [feat(commands): setup, start, status, stop](https://github.com/orwa-mahmoud/claude-nightshift/commit/bd1e2f1)
-- `22:44` · [feat(gates): stack-aware inspections — item gates + site inspections](https://github.com/orwa-mahmoud/claude-nightshift/commit/3a9b647)
-- `22:47` · [feat(adapters): foreman — universal outer loop for any agent cli](https://github.com/orwa-mahmoud/claude-nightshift/commit/46006ff)
-- `22:47` · [test: gates detection + foreman termination paths](https://github.com/orwa-mahmoud/claude-nightshift/commit/763426e)
-- `22:49` · [docs: example shift](https://github.com/orwa-mahmoud/claude-nightshift/commit/1d5e2d3)
-- `22:50` · [docs: readme — story, vocabulary, honest caveats](https://github.com/orwa-mahmoud/claude-nightshift/commit/7a39de0)
+- `21:57` · [chore: plugin scaffold, manifests, license](https://github.com/orwa-mahmoud/nightshift/commit/07d5927)
+- `21:57` · [ci: shellcheck + test workflow](https://github.com/orwa-mahmoud/nightshift/commit/b41d9cd)
+- `22:03` · [feat(hooks): clock-out gate — punch-list file is the only truth](https://github.com/orwa-mahmoud/nightshift/commit/b8e561a)
+- `22:04` · [feat(hooks): stall red-tag + stop-work order + quitting time — bounded, interruptible runs](https://github.com/orwa-mahmoud/nightshift/commit/11e0ea2)
+- `22:08` · [feat(hooks): hardhat — mechanical safety, zero-config core](https://github.com/orwa-mahmoud/nightshift/commit/60f2380)
+- `22:09` · [feat(hooks): park-don't-ask — a question can't kill the shift](https://github.com/orwa-mahmoud/nightshift/commit/1965b9c)
+- `22:11` · [feat(hooks): morning whistle — optional shift-end ping](https://github.com/orwa-mahmoud/nightshift/commit/5dc7630)
+- `22:27` · [test: bats coverage for gate + hardhat + stall + stop-work + deadline + degradation](https://github.com/orwa-mahmoud/nightshift/commit/41d8d1d)
+- `22:36` · [feat(templates): punch list, parking lot, snag log, walkthrough presets](https://github.com/orwa-mahmoud/nightshift/commit/a8f0c1d)
+- `22:38` · [feat(skill): the nightshift brain](https://github.com/orwa-mahmoud/nightshift/commit/381f01b)
+- `22:42` · [feat(commands): setup, start, status, stop](https://github.com/orwa-mahmoud/nightshift/commit/bd1e2f1)
+- `22:44` · [feat(gates): stack-aware inspections — item gates + site inspections](https://github.com/orwa-mahmoud/nightshift/commit/3a9b647)
+- `22:47` · [feat(adapters): foreman — universal outer loop for any agent cli](https://github.com/orwa-mahmoud/nightshift/commit/46006ff)
+- `22:47` · [test: gates detection + foreman termination paths](https://github.com/orwa-mahmoud/nightshift/commit/763426e)
+- `22:49` · [docs: example shift](https://github.com/orwa-mahmoud/nightshift/commit/1d5e2d3)
+- `22:50` · [docs: readme — story, vocabulary, honest caveats](https://github.com/orwa-mahmoud/nightshift/commit/7a39de0)
 
 The shift then closed with
-[docs: nightshift built nightshift — the receipts](https://github.com/orwa-mahmoud/claude-nightshift/commit/12c7031)
+[docs: nightshift built nightshift — the receipts](https://github.com/orwa-mahmoud/nightshift/commit/12c7031)
 (this file) and the SonarQube site inspection. For the live, complete list, run `git log --oneline`
 in this repo.
 

--- a/plugins/nightshift/.claude-plugin/plugin.json
+++ b/plugins/nightshift/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/orwa-mahmoud"
   },
   "homepage": "https://orwamahmoud.com/nightshift/",
-  "repository": "https://github.com/orwa-mahmoud/claude-nightshift",
+  "repository": "https://github.com/orwa-mahmoud/nightshift",
   "license": "MIT",
   "keywords": [
     "claude-code",

--- a/plugins/nightshift/.codex-plugin/plugin.json
+++ b/plugins/nightshift/.codex-plugin/plugin.json
@@ -7,7 +7,7 @@
     "url": "https://github.com/orwa-mahmoud"
   },
   "homepage": "https://orwamahmoud.com/nightshift/",
-  "repository": "https://github.com/orwa-mahmoud/claude-nightshift",
+  "repository": "https://github.com/orwa-mahmoud/nightshift",
   "license": "MIT",
   "skills": "./skills/",
   "hooks": "./hooks/codex/hooks.json",


### PR DESCRIPTION
## What does this PR do?

Completes the repository rename from `orwa-mahmoud/claude-nightshift` to `orwa-mahmoud/nightshift` across install commands, manifests, documentation, security links, changelog links, and public receipts.

The GitHub repository itself is already renamed; stars, issues, releases, and history were preserved. Open issue bodies and the public website were updated separately.

## Verification

- 329 Bats tests pass
- ShellCheck passes for every tracked shell script
- Claude marketplace validation passes in strict mode
- Manifest JSON parses successfully
- No stale old-repository URL remains in the tracked public repository