### PR TITLE
Expand the ready-made shift catalog and execution modes

### DIFF
--- a/plugins/nightshift/skills/hunt/SKILL.md
+++ b/plugins/nightshift/skills/hunt/SKILL.md
@@ -1,28 +1,47 @@
 ---
 name: hunt
-description: Compose tonight's shift from the ready catalog — pick the jobs, choose how each ends, add your own scope — then park it or start it. Work is composed here; /nightshift:start only executes.
+description: Compose a guided or automatic shift from the ready catalog, then review it first or run it directly under one time budget. Use when the owner wants to choose jobs or let Nightshift find the highest-value applicable work.
 ---
 
-Compose a shift for `$CLAUDE_PROJECT_DIR`. Propose, never impose: nothing is worked without an
-explicit yes. If `.nightshift/` does not exist, stop and point to `/nightshift:setup` first.
+Compose a shift for `$CLAUDE_PROJECT_DIR`. If `.nightshift/` does not exist, stop and point to
+`/nightshift:setup` first.
 
 Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; write
 every `.nightshift/` path to the validated absolute target, otherwise the task root. Never search
 or guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
-## 1. Offer the catalog
+Read `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/execution-modes.md` before composing work.
+It is the shared contract for who selects work, when the clock starts, direct-mode authority, and
+how multiple entries become one shift.
+
+## 1. Ask who selects
 
 Entries live one per file in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/shifts/`. **List
-that directory and read every file in it** — one offer line each, with its ending marked.
-`shift-catalog.md` beside it explains the two endings; it does not list the entries.
+that directory and read every file in it**. `shift-catalog.md` beside it explains the two endings;
+it does not list the entries.
 
+Offer two first-class modes:
+
+- **Guided** — show one offer line per entry, with its ending marked. The owner may choose more
+  than one.
+- **Automatic** — ask for hours, inspect the project, determine which entries apply, deduplicate
+  their findings, and rank them using `execution-modes.md`. Show evidence only in review-first
+  mode; run-direct does not pause.
 **More than one may be chosen** — a night can clear the lint backlog and then hunt coverage until
 the whistle.
 
 Read the directory rather than reciting from memory: entries are added over time, and a job that
 exists in the folder but not in the offer is a job the owner never gets.
 
-## 2. Ask how it ends
+## 2. Ask when execution starts
+
+Ask **review first, or run directly?** This choice is independent from Guided or Automatic.
+
+- In **review first**, all discovery remains read-only and the clock starts only after approval.
+- In **run directly**, start the clock immediately and do not pause after discovery. Follow the
+  direct-mode decision policy in `execution-modes.md`.
+
+## 3. Establish the ending
 
 Per the entry's declared ending:
 
@@ -32,14 +51,16 @@ Per the entry's declared ending:
   is clear, or capped at N hours?* Both are real answers; the work ends when the list is empty
   either way, and hours are only a safeguard against a backlog bigger than the night.
 
-One deadline governs the whole shift. On a mixed selection say so plainly in one line: the finite
+One deadline governs the whole shift. Automatic mode always requires hours. On a mixed selection
+say so plainly in one line: the finite
 work runs first, and the open-ended job soaks up whatever time is left.
 
-## 3. Ask for scope — one question, every entry
+## 4. Ask for guided scope
 
 > Anything specific about scope or approach?
 
-Free text, and skippable. It is where the useful shift is made: *"only `packages/api/`"*, *"use
+Ask this in Guided mode. In Automatic mode infer the safest valuable scope from evidence and the
+time budget. Free text is skippable. It is where the useful shift is made: *"only `packages/api/`"*, *"use
 `getTestInstance()` from the test package"*, *"one module — this becomes a single reviewable PR"*.
 Never edit the entry's own contract to fit it; the owner's words become their own sub-bullet:
 
@@ -51,11 +72,15 @@ The entry's rules stay above it untouched. They are what keeps a shift honest �
 rather than counts, gate green at every commit, never silence instead of fixing — and owner text
 adds constraints rather than replacing them.
 
-## 4. Show the assembled shift, then ask
+## 5. Review or cut
 
-Print the items exactly as they will be written, with the hours and the ending, and ask for one
-approval. This is the last look before anything is armed; a typo, a wrong path, or an instruction
-that contradicts the contract is caught here or not at all.
+In **review first**, print the items exactly as they will be written, with evidence, order, hours,
+and ending, then ask for one approval. This is the last look before anything is armed. Write
+nothing before approval.
+
+In **run directly**, do not ask again: write the order and immediately cut it into the active shift.
+Record significant discovery and selection decisions in `parking-lot.md` as required by the shared
+mode contract.
 
 On approval, append to `.nightshift/work-orders.md` — hunt's own file; the drafting table stays the
 owner's room. Never clobber orders already sitting there — append below them:
@@ -68,11 +93,13 @@ Hours: <N, or "none — finite">
   - **Owner instructions:** <if any>
 ```
 
-The hours are inert while the order sits here — the clock starts only at the cut.
+The hours are inert while a review-first order sits here — the clock starts only at the cut, after
+approval. In run-direct mode the order is cut immediately, so its clock starts now.
 
-## 5. Start now?
+## 6. Start or park after review
 
-One question: **start now, or park it for later?**
+After review-first approval, ask **start now, or park it for later?** Run-direct skips this question
+and always starts now; choosing it was already explicit authorization.
 
 On **now** — start the shift yourself, here, without making the owner type another command. Follow
 `/nightshift:start` exactly: clear the stale markers, **move** the item out of `work-orders.md` and

--- a/plugins/nightshift/skills/nightshift/SKILL.md
+++ b/plugins/nightshift/skills/nightshift/SKILL.md
@@ -63,6 +63,14 @@ it anyway. Instead: choose the most sensible production-grade default, record th
 reasoning in `parking-lot.md` in plain language, and keep working. The owner reviews it over coffee.
 Known later work is not a decision: stage it in `drafting-table.md`.
 
+When the owner selected **run directly**, that is explicit authority to choose and implement
+reasonable, reversible production defaults within the stated scope and time. Do not turn ordinary
+code, API, design, localization, or cleanup judgments into blockers merely because alternatives
+exist. Preserve compatibility or provide migration and rollback, verify the result, and record the
+choice, evidence, alternatives, shipped result, and rollback in `parking-lot.md`. Stop only for
+publishing, merging, deploying, real-data deletion, secrets exposure, spending, or legal/licensing
+decisions outside the coding-work authorization.
+
 ## Snag log discipline
 
 Before reporting findings in a review or walkthrough, read `snag-log.md` and dedupe against ALL seen

--- a/plugins/nightshift/skills/nightshift/references/execution-modes.md
+++ b/plugins/nightshift/skills/nightshift/references/execution-modes.md
@@ -1,0 +1,58 @@
+# Selection and launch modes
+
+Hunt and Quality use two independent choices. Never infer one from the other.
+
+## Selection
+
+- **Guided** — the owner chooses one or more catalog entries, then may add scope or approach.
+- **Automatic** — the owner supplies a time budget; inspect the repository and choose the
+  applicable catalog entries that offer the strongest evidenced user value in that time.
+
+Automatic selection is not a generic brainstorm. Read every entry in `shifts/`, then inspect the
+project's tooling, tests, documentation, issue references available in the workspace, and recent
+git history. For each applicable entry record one sentence of evidence. Rank by:
+
+1. user or production impact;
+2. strength of repository evidence;
+3. ability to finish and verify inside the remaining time;
+4. risk and reversibility.
+
+Remove overlaps: one finding belongs to one entry. Run finite entries first. If useful time remains,
+choose at most one open-ended entry — coverage, defect hunting, or product evolution — to use it.
+One deadline governs the whole automatic shift, and automatic mode always requires hours.
+
+## Launch
+
+- **Review first** — discovery is read-only. Show the evidence, selected entries, order, scope,
+  endings, and hours. Write and arm nothing until the owner approves. The clock starts only after
+  that approval.
+- **Run directly** — the owner's choice is explicit authority to discover, select, implement, and
+  verify within the stated scope and time. Start the clock immediately, assemble and cut one work
+  order, arm one shift, and continue selecting applicable work until quitting time.
+
+Guided + run directly still performs the selected entry's discovery, but it does not pause after
+showing the findings. Guided + review first does pause. Choosing a category is not by itself approval
+to implement; the launch choice decides that.
+
+## Direct-mode decisions
+
+Run directly means make progress, not avoid judgment:
+
+- choose the strongest production-quality default;
+- make reasonable, reversible decisions on the isolated branch;
+- preserve compatibility or include migration and rollback where a breaking change is justified;
+- implement and verify the decision;
+- record every significant choice, evidence, alternatives, shipped result, and rollback in
+  `parking-lot.md`; then continue.
+
+Stop for the owner only when the action is outside the granted coding-work boundary: publishing,
+merging, deploying, deleting real data, exposing secrets, spending money, or changing legal or licensing policy.
+A difficult or potentially breaking code change is not automatically outside the
+boundary when it is isolated, tested, reviewable, and reversible.
+
+## One shift contract
+
+Any combination becomes one ordered work order, one punch list, one branch, one deadline where
+required, and one set of receipts. Never arm a separate shift per entry. The catalog entry remains
+the definition of done; selection and launch modes decide who chooses it and whether discovery
+pauses for approval.

--- a/plugins/nightshift/skills/nightshift/references/shifts/accessibility-repair.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/accessibility-repair.md
@@ -1,0 +1,28 @@
+# Accessibility repair — finite — objective violations from checks the project already runs
+
+Accessibility violations reported by the repository's configured linter, test suite, or scanner.
+The shift repairs concrete findings without redesigning the interface or claiming compliance.
+
+Supported on projects that already configure accessibility lint rules or automated accessibility
+tests. Detect those commands from package scripts, test configuration, or the item gate. If the
+project has no established accessibility check, this shift is unsupported and must not start.
+
+```text
+- [ ] **Accessibility repair — fix objective violations reported by existing project checks.**
+  - Discovery: detect and run the repository's configured accessibility linter, component tests,
+    or automated scanner. Record the command and objective reported violations; dedupe against
+    snag-log.md (ALL seen — fixed and rejected). Do not add a scanner silently.
+  - Repair one related cluster at a time using the product's existing design system and semantic
+    patterns. Preserve intended behaviour and appearance, rerun the accessibility check and item
+    gate, commit.
+  - Park findings that require visual design, product copy, legal interpretation, assistive-
+    technology judgment, or an owner tradeoff; include the rule, affected surface, and evidence.
+  - Never perform an unrelated visual redesign or rewrite product copy to satisfy a scanner.
+  - Never suppress a rule, hide an element from assistive technology, or weaken a test merely to
+    clear the report.
+  - Never claim WCAG, legal, or full accessibility compliance from automated checks alone.
+  - Ends when the same configured checks report no actionable objective violations, and every
+    judgment-dependent finding is parked with its evidence and required decision.
+  - Verify: the item gate is green at every commit; rerun the project's configured accessibility
+    checks after each cluster and once more over the complete affected surface.
+```

--- a/plugins/nightshift/skills/nightshift/references/shifts/api-contract-drift.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/api-contract-drift.md
@@ -1,0 +1,31 @@
+# API contract drift — finite — checked-in server, schema, and client contracts brought back into agreement
+
+Objective mismatches between routes, schemas, generated clients, fixtures, or checked-in contracts,
+found using API tooling the repository already configures. Breaking choices remain with the owner.
+
+Supported on projects with an established contract source and comparison command: OpenAPI or
+GraphQL generation/checks, protobuf or schema compilation, consumer-contract tests, generated SDK
+checks, or an equivalent repository-owned gate. Without both, this shift must not start.
+
+```text
+- [ ] **API contract drift — align existing API artifacts without silently changing the public API.**
+  - Discovery: identify the repository's authoritative API source and run its configured generation,
+    diff, schema, compatibility, or consumer-contract command. Compare server routes, checked-in
+    schemas, generated clients, fixtures, and contract tests as applicable. Dedupe findings against
+    snag-log.md (ALL seen — fixed and rejected).
+  - Classify each mismatch before editing: non-breaking artifact drift with an authoritative source,
+    or a potentially breaking change involving removal, narrowing, renaming, required fields,
+    status codes, or compatibility policy.
+  - Repair non-breaking artifact drift one coherent cluster at a time from the established source
+    of truth. Run the contract command and item gate, commit.
+  - Park every potentially breaking change in drafting-table.md with affected consumers, evidence,
+    compatibility question, and rollback path. Do not choose the public contract unattended.
+  - Never silently change a public API, invent a compatibility or versioning policy, or regenerate
+    from a source whose authority is unclear.
+  - Never add contract tooling, accept a generated diff blindly, or update snapshots merely to
+    make the comparison pass without reviewing the semantic change.
+  - Ends when configured contract checks report no actionable non-breaking drift, and every
+    potentially breaking mismatch is staged for owner review with evidence.
+  - Verify: the item gate is green at every commit; the repository's existing generation or
+    contract-comparison command is clean and relevant server/client tests pass.
+```

--- a/plugins/nightshift/skills/nightshift/references/shifts/dead-code-cleanup.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/dead-code-cleanup.md
@@ -1,0 +1,28 @@
+# Dead-code cleanup — finite — code proven unused by tooling the repository already trusts
+
+Unused exports, files, branches, or dependencies reported by analyzers and build tools already in
+the project. Each deletion carries evidence; dynamic or uncertain references stay untouched.
+
+Use only when the repository already has a dead-code, unused-export, dependency, compiler, or
+coverage tool capable of producing findings. Supported stacks are whatever that configured tool
+supports. If no such tool is configured, this shift is unsupported and must not start.
+
+```text
+- [ ] **Dead-code cleanup — remove only code the project's existing tooling proves unused.**
+  - Discovery: detect and run the repository's configured unused-code tooling, compiler checks, or
+    dependency analyzer. Record its exact command and findings; dedupe against snag-log.md (ALL
+    seen — fixed and rejected). Do not introduce a new analyzer without owner approval.
+  - Take one coherent finding at a time. Confirm it is not reached through reflection, dynamic
+    imports, registration, configuration, generated code, public exports, or external consumers.
+    Remove it, run the item gate and the original analyzer, commit.
+  - Park uncertain findings in snag-log.md with the analyzer evidence and the reference that could
+    not be ruled out. Uncertainty is not permission to delete.
+  - Never infer dead code from intuition, naming, low coverage, or a text search alone.
+  - Never delete a public API, migration, plugin entry point, compatibility shim, or generated
+    artifact merely because the local analyzer cannot see its consumer.
+  - Never add ignore rules or weaken the analyzer to make its report clean.
+  - Ends when the original analyzer reports no actionable findings, and every uncertain or
+    externally consumed finding is parked with its evidence and reason.
+  - Verify: the item gate is green at every commit; the existing dead-code analyzer is rerun after
+    every deletion and the final repository build or package check succeeds.
+```

--- a/plugins/nightshift/skills/nightshift/references/shifts/flaky-test-repair.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/flaky-test-repair.md
@@ -1,0 +1,29 @@
+# Flaky-test repair — finite — unstable tests reproduced and repaired without weakening coverage
+
+Tests that sometimes pass and sometimes fail under the repository's existing test runner. The
+shift spends a declared repetition budget reproducing each suspect, fixes only demonstrated
+causes, and leaves an honest record when the failure cannot be reproduced.
+
+Use only when the project already has a test command and evidence of instability: repeated local
+failure, CI history, or a named suspect test. Supported on any stack whose existing test runner can
+repeat a test or suite. Do not add a new flake service or test framework.
+
+```text
+- [ ] **Flaky-test repair — reproduce unstable tests and fix their demonstrated causes.**
+  - Discovery: collect tests with existing flake evidence from CI logs, failure artifacts, or an
+    owner-provided list. Dedupe against snag-log.md (ALL seen — fixed and rejected). Before work,
+    declare a repetition budget for each suspect using the project's existing runner.
+  - Reproduce one suspect within its budget. If it fails, isolate the deterministic cause (shared
+    state, ordering, time, randomness, concurrency, environment, or leaked resources), fix that
+    cause, run the item gate, commit, then repeat the repaired test for the same budget.
+  - If it never fails within the budget, do not claim a repair. Record the commands, run count, and
+    outcome in snag-log.md as unreproduced, then move on.
+  - Never delete, skip, quarantine, mute, or weaken a test merely to make CI green.
+  - Never replace a meaningful assertion with a looser one, add retries as the fix, or hide a race
+    by increasing a timeout without evidence that the timeout is the contract.
+  - Never exceed the declared repetition budget chasing an unreproduced failure.
+  - Ends when every discovered suspect is either repaired and stable for its declared budget or
+    recorded honestly as unreproduced with its evidence and commands.
+  - Verify: the item gate is green at every commit; each repaired test passes for its full declared
+    repetition budget and its containing suite passes once normally.
+```

--- a/plugins/nightshift/skills/nightshift/references/shifts/localization-parity.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/localization-parity.md
@@ -1,0 +1,31 @@
+# Localization parity — finite — objective key drift in an existing localization system
+
+Missing, unused, or structurally inconsistent localization keys reported by tooling or proved by
+comparison inside a localization system the repository already uses. Language judgment remains
+with a human.
+
+Supported only when the project already has locale catalogs plus an established checker, generator,
+type system, or canonical source locale. If localization is absent or no source of truth can be
+identified, this shift is unsupported and must not start.
+
+```text
+- [ ] **Localization parity — repair objective key drift without inventing translations.**
+  - Discovery: detect the repository's locale catalogs, canonical source locale, and configured
+    localization check, generator, or typed-key command. Use those established sources to find
+    missing, unused, duplicate, or structurally inconsistent keys. Dedupe against snag-log.md
+    (ALL seen — fixed and rejected).
+  - Fix objective structure one cluster at a time: restore a key from an existing canonical value,
+    align placeholders and plural forms that tooling defines, or remove an unused key only after
+    project tooling and a repository-wide reference check agree. Run the item gate, commit.
+  - Park every missing translation that requires language judgment in drafting-table.md with the
+    locale, source text, key, and decision needed. Do not copy machine output into the catalog.
+  - Never invent or machine-generate translations, rewrite product copy, or choose regional tone.
+  - Never introduce localization to a project that lacks it or add new localization tooling
+    without owner approval.
+  - Never delete a key based on text search alone; dynamic lookup and external consumers must be
+    ruled out by the project's established tooling.
+  - Ends when existing localization checks report no actionable structural drift, and every
+    language-dependent gap is staged with its key and source text.
+  - Verify: the item gate is green at every commit; rerun the existing localization checker or
+    generator and its relevant application tests after each cluster.
+```

--- a/plugins/nightshift/skills/nightshift/references/shifts/todo-fixme-debt.md
+++ b/plugins/nightshift/skills/nightshift/references/shifts/todo-fixme-debt.md
@@ -1,0 +1,28 @@
+# TODO and FIXME debt — finite — actionable code comments resolved without inventing product decisions
+
+Tracked TODO, FIXME, HACK, and XXX comments in repository-owned source. The shift separates work
+that the current code and tests define from comments that require an owner's product decision.
+
+Supported on repositories where these markers live in tracked, human-authored source or tests.
+Generated files, vendored code, dependencies, build output, and archived receipts are excluded.
+
+```text
+- [ ] **TODO and FIXME debt — resolve actionable comments and stage ambiguous decisions.**
+  - Discovery: search tracked, human-authored source and tests for TODO, FIXME, HACK, and XXX
+    markers. Exclude generated, vendored, dependency, build, and archive paths. Dedupe against
+    snag-log.md (ALL seen — fixed and rejected), then inventory the marker, path, and nearby
+    contract for each finding.
+  - Classify each finding before editing. Actionable means existing behaviour, tests, issue links,
+    or an explicit comment defines the required result. Ambiguous means product intent, UX,
+    compatibility, or scope still needs an owner decision.
+  - Resolve one actionable cluster at a time, including the underlying work—not only the comment.
+    Run the item gate, commit. Remove or update the marker only when its underlying debt is gone.
+  - Stage ambiguous findings in drafting-table.md with the decision needed, evidence, source path,
+    and next action. Do not put them in the live punch list and do not guess the answer.
+  - Never invent a feature, requirement, or compatibility policy from a vague comment.
+  - Never delete or reword a marker merely to make the inventory smaller.
+  - Ends when every discovered marker is either resolved with verified underlying work or staged
+    in drafting-table.md with a concrete owner decision and source reference.
+  - Verify: the item gate is green at every commit; a final scoped search finds no unresolved
+    actionable markers and every remaining ambiguous marker has a drafting-table entry.
+```

--- a/plugins/nightshift/skills/quality/SKILL.md
+++ b/plugins/nightshift/skills/quality/SKILL.md
@@ -1,52 +1,79 @@
 ---
 name: quality
-description: Survey the project's quality debt — lint, types, tests — then fix it now, draft it for later, or drop it. The scan is read-only; nothing is written or started without an explicit answer.
+description: Find and work the project's applicable quality debt across tests, code, accessibility, contracts, documentation, dependencies, and security. Supports guided or automatic selection and review-first or run-direct execution.
 ---
 
-Survey this project's existing quality debt and turn what matters into proposed punch-list items.
-The scan is read-only: run checks in report mode, fix nothing, write nothing without an explicit
-yes. Work in `$CLAUDE_PROJECT_DIR`.
+Quality is the broad entry point for this project's quality work. It uses the same selection and
+launch modes as Hunt. Work in `$CLAUDE_PROJECT_DIR`.
 
 Resolve `${CLAUDE_PROJECT_DIR:-$PWD}` through its explicit `.nightshift-link` when present; use the
 validated absolute target for every `.nightshift/` path, otherwise the task root. Never search or
 guess. The shell's working directory persists between Bash calls, so never use a bare path.
 
-## 1. Detect and scan
+Read these before scanning:
 
-Detect the stack from the table in `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/gates-catalog.md`
-(monorepo-aware), then run the matching item-gate commands in report-only mode — no fix flags, no
-writes. Skip any tool that is not installed; never install anything. If `.nightshift/` does not
-exist yet, scan anyway and note that `/nightshift:setup` is the next step before a shift can run.
+- `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/execution-modes.md`
+- every applicable entry under `${CLAUDE_PLUGIN_ROOT}/skills/nightshift/references/shifts/`
 
-## 2. Report in plain numbers
+Quality includes: lint, types, tests, flaky tests, coverage, dead code, TODO/FIXME debt,
+accessibility, localization, API contract drift, documentation drift, CI warnings, direct
+dependencies, and vulnerability advisories. `clear-quality-debt.md` remains the generic finite
+core-tooling entry; specialized entries retain their own safety rules and definitions of done.
 
-Summarize what came back per tool and per top-level directory — counts, not lectures. A finding is
-information, not a demand: the owner may know about it and not care.
+## 1. Choose selection and launch
 
-## 3. Offer the work — three answers, one of them starts it
+Ask two independent choices:
 
-Draft one punch-list item per meaningful cluster (e.g. "clear the 12 shellcheck findings under
-`scripts/`", "add mypy and fix what it reports"), each in the standard item shape with its own
-Verify and Commit lines. Show the drafts, then ask — with three first-class answers:
+1. **Guided** (the owner chooses quality areas) or **Automatic** (Nightshift selects every
+   applicable high-value area that fits the hours).
+2. **Review first** or **Run directly**.
 
-- **fix now** — write the items straight under `## Items` in `.nightshift/punch-list.md` and start
-  the shift here, following `/nightshift:start`: clear the stale markers, **arm the gate** with
-  `touch "$NIGHTSHIFT_WORKSPACE/.nightshift/.shift-armed"`, log the start, arm the watchman. The
-  marker is what starts the shift; the items alone hold nothing. These are finite items, so no
-  deadline is required; offer an optional hours cap in one line and write `.nightshift/deadline`
-  only if the owner names a number. From that second the gate holds this session until every box
-  is ticked.
+Automatic mode requires hours. Guided mode asks for scope and requires hours only when an
+open-ended entry is selected. In review-first mode scanning is read-only and the clock starts only
+after approval. In run-direct mode the clock begins immediately and findings are implemented
+without another pause under the decision policy in `execution-modes.md`.
+
+## 2. Detect and scan
+
+Detect the stack from the gates catalog (monorepo-aware), inspect repository-owned tooling and
+evidence, then apply the discovery rules from every relevant quality entry. Never install a tool
+merely to manufacture findings. In review-first mode use report-only commands: no fix flags and no
+writes. If `.nightshift/` does not exist, review-first may report, but any run-direct request must
+stop and point to `/nightshift:setup` before work can be armed.
+
+## 3. Rank and deduplicate
+
+Map each finding to one catalog entry so work is never duplicated. In Automatic mode rank using
+the shared mode contract, run finite entries first, and use at most one open-ended entry for useful
+remaining time. In Guided mode keep only the areas and scope the owner selected.
+
+## 4. Review first
+
+When review first was chosen, summarize evidence per catalog entry and top-level directory in plain
+numbers, then show the exact ordered work order. Offer three answers:
+
+- **fix now** — compose one work order from the selected catalog entries and start it here through
+  the Hunt cut and `/nightshift:start` lifecycle. Preserve every entry's contract. Apply the one
+  deadline chosen for the combined shift.
 - **draft for later** — append them to `.nightshift/drafting-table.md` and arm nothing. The
   drafting table is staging: it is never read by the gate, which is exactly why proposals can wait
   there safely. Tell the owner they can promote what they want into the punch list and run
-  `/nightshift:start`, or pick *clear quality debt* from `/nightshift:hunt` to work the whole
-  backlog in one shift.
+  `/nightshift:start` after promotion, or compose it later through Hunt.
 - **ignore** — write nothing at all; fully respected. A finding the owner does not care about is
   not a defect.
 
-Never write to the punch list on anything but an explicit **fix now**. Items there are the shift
+Never write to the punch list on anything but an explicit **fix now** in review-first mode. Items there are the shift
 the next start will work, so writing them on a survey puts work in front of the owner that nobody
 agreed to — the box and the start belong together, or neither happens.
+
+## 5. Run directly
+
+When run directly was chosen, do not present the three-answer review menu. Compose one ordered work
+order, cut it immediately, and arm one shift with
+`touch "$NIGHTSHIFT_WORKSPACE/.nightshift/.shift-armed"`; log the start and arm the watchman exactly
+as `/nightshift:start` requires. Implement and verify the selected entry contracts, and continue
+until the finite work is clear or the shared deadline ends. Record significant decisions and
+rollback instructions in `parking-lot.md`; never create a second shift per quality area.
 
 If the stack no longer matches the current `## Gates` block, say so in one line and point to
 `/nightshift:setup` — gates belong to setup, not to this command.

--- a/tests/shifts/accessibility-repair.bats
+++ b/tests/shifts/accessibility-repair.bats
@@ -1,0 +1,25 @@
+E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/accessibility-repair.md"
+
+@test "accessibility repair requires existing configured checks" {
+  grep -qi 'already configure' "$E"
+  grep -qi 'must not start' "$E"
+  grep -qi 'Do not add a scanner silently' "$E"
+}
+
+@test "accessibility repair limits work to objective violations" {
+  grep -qi 'objective reported violations' "$E"
+  grep -qi 'existing design system' "$E"
+  grep -qi 'judgment-dependent' "$E"
+}
+
+@test "accessibility repair refuses redesign suppression and compliance claims" {
+  grep -qi 'Never perform an unrelated visual redesign' "$E"
+  grep -qi 'Never suppress a rule' "$E"
+  grep -qi 'Never claim WCAG' "$E"
+}
+
+@test "accessibility repair reruns project checks to finish" {
+  grep -qi 'Ends when the same configured checks' "$E"
+  grep -qi 'item gate is green at every commit' "$E"
+  grep -qi 'complete affected surface' "$E"
+}

--- a/tests/shifts/api-contract-drift.bats
+++ b/tests/shifts/api-contract-drift.bats
@@ -1,0 +1,26 @@
+E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/api-contract-drift.md"
+
+@test "API drift requires an authoritative source and existing comparison" {
+  grep -qi 'authoritative API source' "$E"
+  grep -qi 'configured generation' "$E"
+  grep -qi 'must not start' "$E"
+}
+
+@test "API drift distinguishes non-breaking and potentially breaking changes" {
+  grep -qi 'non-breaking artifact drift' "$E"
+  grep -qi 'potentially breaking change' "$E"
+  grep -qi 'affected consumers' "$E"
+}
+
+@test "API drift parks breaking decisions and refuses silent API changes" {
+  grep -qi 'drafting-table.md' "$E"
+  grep -qi 'Never silently change a public API' "$E"
+  grep -qi 'Never add contract tooling' "$E"
+  grep -qi 'accept a generated diff blindly' "$E"
+}
+
+@test "API drift ends with clean existing contract checks" {
+  grep -qi 'Ends when configured contract checks' "$E"
+  grep -qi 'item gate is green at every commit' "$E"
+  grep -qi 'relevant server/client tests pass' "$E"
+}

--- a/tests/shifts/dead-code-cleanup.bats
+++ b/tests/shifts/dead-code-cleanup.bats
@@ -1,0 +1,25 @@
+E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/dead-code-cleanup.md"
+
+@test "dead-code cleanup requires existing repository tooling" {
+  grep -qi "repository already has" "$E"
+  grep -qi 'must not start' "$E"
+  grep -qi 'Do not introduce a new analyzer' "$E"
+}
+
+@test "dead-code cleanup checks dynamic and external references" {
+  grep -qi 'reflection, dynamic' "$E"
+  grep -qi 'public exports' "$E"
+  grep -qi 'external consumers' "$E"
+}
+
+@test "dead-code cleanup parks uncertainty instead of deleting" {
+  grep -qi 'Park uncertain findings' "$E"
+  grep -qi 'Uncertainty is not permission to delete' "$E"
+  grep -qi 'Never infer dead code from intuition' "$E"
+}
+
+@test "dead-code cleanup verifies every deletion and its ending" {
+  grep -qi 'Ends when the original analyzer reports' "$E"
+  grep -qi 'item gate is green at every commit' "$E"
+  grep -qi 'every deletion and the final repository' "$E"
+}

--- a/tests/shifts/flaky-test-repair.bats
+++ b/tests/shifts/flaky-test-repair.bats
@@ -1,0 +1,25 @@
+E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/flaky-test-repair.md"
+
+@test "flaky-test repair declares evidence and a repetition budget" {
+  grep -qi 'existing flake evidence' "$E"
+  grep -qi 'declare a repetition budget' "$E"
+  grep -qi 'Never exceed the declared repetition budget' "$E"
+}
+
+@test "flaky-test repair records unreproduced suspects honestly" {
+  grep -qi 'do not claim a repair' "$E"
+  grep -qi 'unreproduced' "$E"
+  grep -qi 'snag-log.md' "$E"
+}
+
+@test "flaky-test repair refuses weaker tests and cosmetic stability" {
+  grep -qi 'Never delete, skip, quarantine' "$E"
+  grep -qi 'Never replace a meaningful assertion' "$E"
+  grep -qi 'add retries as the fix' "$E"
+}
+
+@test "flaky-test repair has a finite verified ending" {
+  grep -qi 'Ends when every discovered suspect' "$E"
+  grep -qi 'item gate is green at every commit' "$E"
+  grep -qi 'repetition budget and its containing suite' "$E"
+}

--- a/tests/shifts/localization-parity.bats
+++ b/tests/shifts/localization-parity.bats
@@ -1,0 +1,25 @@
+E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/localization-parity.md"
+
+@test "localization parity refuses unsupported projects" {
+  grep -qi 'Supported only when' "$E"
+  grep -qi 'must not start' "$E"
+  grep -qi 'Never introduce localization' "$E"
+}
+
+@test "localization parity uses established sources and tooling" {
+  grep -qi 'canonical source locale' "$E"
+  grep -qi 'localization check, generator' "$E"
+  grep -qi 'repository-wide reference check' "$E"
+}
+
+@test "localization parity parks language judgment and refuses invention" {
+  grep -qi 'requires language judgment' "$E"
+  grep -qi 'drafting-table.md' "$E"
+  grep -qi 'Never invent or machine-generate translations' "$E"
+}
+
+@test "localization parity verifies objective drift is gone" {
+  grep -qi 'Ends when existing localization checks' "$E"
+  grep -qi 'item gate is green at every commit' "$E"
+  grep -qi 'relevant application tests' "$E"
+}

--- a/tests/shifts/todo-fixme-debt.bats
+++ b/tests/shifts/todo-fixme-debt.bats
@@ -1,0 +1,26 @@
+E="$BATS_TEST_DIRNAME/../../plugins/nightshift/skills/nightshift/references/shifts/todo-fixme-debt.md"
+
+@test "TODO debt inventories tracked human-authored markers" {
+  grep -qi 'tracked, human-authored' "$E"
+  grep -qi 'TODO, FIXME, HACK, and XXX' "$E"
+  grep -qi 'generated, vendored' "$E"
+}
+
+@test "TODO debt distinguishes actionable work from decisions" {
+  grep -qi 'Actionable means' "$E"
+  grep -qi 'Ambiguous means' "$E"
+  grep -qi 'underlying work' "$E"
+}
+
+@test "TODO debt stages ambiguity and refuses invented features" {
+  grep -qi 'drafting-table.md' "$E"
+  grep -qi 'do not guess the answer' "$E"
+  grep -qi 'Never invent a feature' "$E"
+  grep -qi 'Never delete or reword a marker' "$E"
+}
+
+@test "TODO debt has a verifiable finite ending" {
+  grep -qi 'Ends when every discovered marker' "$E"
+  grep -qi 'item gate is green at every commit' "$E"
+  grep -qi 'final scoped search' "$E"
+}

--- a/tests/templates.bats
+++ b/tests/templates.bats
@@ -98,6 +98,19 @@ OPEN_BOX='^[[:space:]]*-[[:space:]]*\[[[:space:]]\]'
   grep -qi 'or neither happens' "$q"
 }
 
+@test "quality covers the full catalog and shares hunt execution modes" {
+  q="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/quality/SKILL.md"
+  grep -qF 'execution-modes.md' "$q"
+  grep -qi 'Guided' "$q"
+  grep -qi 'Automatic' "$q"
+  grep -qi 'Review first' "$q"
+  grep -qi 'Run directly' "$q"
+  for area in 'flaky tests' coverage 'dead code' 'TODO/FIXME' accessibility localization \
+    'API contract drift' 'documentation drift' 'CI warnings' dependencies 'vulnerability advisories'; do
+    grep -qi "$area" "$q" || { echo "quality omits $area"; return 1; }
+  done
+}
+
 # The install copies plugins/nightshift/ alone, and MIT asks for the notice to travel with every copy — so the
 # licence exists twice on purpose. Two copies drift; this fails the moment they do.
 @test "the shipped licence is the repository's licence" {

--- a/tests/walkthroughs.bats
+++ b/tests/walkthroughs.bats
@@ -107,6 +107,39 @@ START="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/start/SKILL.md"
   grep -qi 'park it for later' "$HUNT"
 }
 
+@test "hunt separates selection mode from launch mode" {
+  grep -qi 'Guided' "$HUNT"
+  grep -qi 'Automatic' "$HUNT"
+  grep -qi 'review first, or run directly' "$HUNT"
+  grep -qi 'independent from Guided or Automatic' "$HUNT"
+}
+
+@test "automatic hunt ranks evidence and uses one combined clock" {
+  mode="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/nightshift/references/execution-modes.md"
+  grep -qi 'inspect the repository' "$mode"
+  grep -qi 'user or production impact' "$mode"
+  grep -qi 'Remove overlaps' "$mode"
+  grep -qi 'Run finite entries first' "$mode"
+  grep -qi 'at most one open-ended entry' "$mode"
+  grep -qi 'one deadline governs' "$mode"
+}
+
+@test "review-first and run-direct clocks begin at different boundaries" {
+  mode="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/nightshift/references/execution-modes.md"
+  grep -qi 'clock starts only after' "$mode"
+  grep -qi 'Start the clock immediately' "$mode"
+  grep -qi 'Guided + run directly' "$mode"
+}
+
+@test "run-direct has a bounded decision policy and leaves receipts" {
+  mode="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/nightshift/references/execution-modes.md"
+  grep -qi 'production-quality default' "$mode"
+  grep -qi 'parking-lot.md' "$mode"
+  grep -qi 'rollback' "$mode"
+  grep -qi 'publishing' "$mode"
+  grep -qi 'legal or licensing policy' "$mode"
+}
+
 # The archive files finished paperwork only — the contract and open work are untouchable.
 @test "the archive skill moves only finished records, never the contract or open items" {
   s="$BATS_TEST_DIRNAME/../plugins/nightshift/skills/archive/SKILL.md"


### PR DESCRIPTION
## What does this PR do?

Expands Nightshift in two connected ways.

### Ready-made shifts

Adds six finite, safety-bounded catalog entries:

- flaky-test repair with explicit repetition budgets and honest unreproduced outcomes
- dead-code cleanup limited to findings proven by existing repository tooling
- TODO/FIXME debt resolution that stages ambiguous product decisions
- accessibility repair limited to objective violations from configured checks
- localization parity without invented or machine-generated translations
- API contract-drift repair with compatibility, migration, and rollback discipline

Each entry has its own contract tests for discovery, refusals, verification, and its finite ending condition.

### Guided and automatic execution

Separates two independent choices across Hunt and Quality:

- selection: Guided or Automatic
- launch: Review first or Run directly

Automatic mode inspects repository evidence, ranks applicable catalog work by impact, evidence, risk, and available time, removes overlaps, runs finite work first, and uses at most one open-ended shift for useful remaining time. Review-first discovery remains read-only and starts the clock only after approval. Run-direct starts immediately under a bounded authority policy, records significant decisions and rollback instructions, and leaves publishing, merging, deployment, real-data deletion, secrets, spending, and legal policy to the owner.

Quality now covers the complete applicable catalog rather than only lint, types, and tests. All selected work remains one ordered shift with one branch, one deadline where required, and one set of receipts. The shared execution contract serves both Claude Code and Codex.

## Verification

- `bats tests/` — 348 tests passed
- `git ls-files "*.sh" | xargs shellcheck -x`
- `claude plugin validate . --strict`
- Hunt, Quality, and Nightshift skill validation
- `git diff --check`

Closes #68
Closes #69
Closes #70
Closes #71
Closes #73
Closes #75