### PR TITLE
docs: add the flagship continuity showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,32 +224,13 @@ If you can write it as a checklist, you can hand it to the night.
 
 ## Receipts
 
-**What the contract can scale to.** One Nightshift contract ran for 45 elapsed hours on AdaptTable,
-survived a Claude Code → Cursor handoff, and finished as a human-reviewed 67-commit PR spanning six
-roadmap phases and 57 closed issues. The public timeline, handoff, checks and permanent links are in
-[`examples/adapttable-continuity.md`](examples/adapttable-continuity.md).
+**Start with the receipts, not the promise.** The evidence library leads with a 45-hour AdaptTable
+contract that survived a Claude Code → Cursor handoff and became a human-reviewed 67-commit PR
+covering six roadmap phases and 57 closed issues. It also includes a smaller four-hour first night,
+Nightshift's self-build, a Codex hardening shift and a template for reporting bad nights honestly.
 
-**nightshift was built by nightshift.** An enforced punch list guarded every build session of this
-repo, and the hooks refused every early clock-out. Each item landed as its own conventional commit
-— `git log --oneline` reads like the shift log — and the final punch list + shift log are in
-[`examples/self-build.md`](examples/self-build.md).
-
-**Your first night.** One small list, one night, on the same published library: 9 items — a
-CSV export button, 7 new locales, a Tailwind starter, inline cell editing and row grouping across
-every adapter — landed as unsquashed per-item commits, closed 4 issues on merge, and shipped as
-v1.2.0 on npm the same day. Public links:
-[`examples/adapttable-overnight.md`](examples/adapttable-overnight.md).
-
-**Codex hardened Nightshift itself.** An 11-item maintenance shift kept the work on one branch,
-landed each item as a separate reviewable commit, passed 248 tests plus ShellCheck and strict plugin
-validation, and shipped as v0.9.2. The permanent PR, release, and item links are in
-[`examples/codex-hardening-shift.md`](examples/codex-hardening-shift.md).
-
-**Bad nights are evidence too.** Interrupted, stalled, owner-stopped, or incorrectly completed
-runs can be filed from
-[`examples/bad-night-template.md`](examples/bad-night-template.md) — facts separated from
-interpretation, public links only when they exist, ticks never treated as proof. Open them on
-[#22](https://github.com/orwa-mahmoud/nightshift/issues/22).
+Browse the timelines, checks and permanent links in
+[`examples/`](examples/README.md).
 
 The live `.nightshift/` state stays out of this repo — the same default nightshift sets for your
 projects: your run history is yours, ignored by your repo, and versioned in its own local

--- a/README.md
+++ b/README.md
@@ -224,12 +224,17 @@ If you can write it as a checklist, you can hand it to the night.
 
 ## Receipts
 
+**What the contract can scale to.** One Nightshift contract ran for 45 elapsed hours on AdaptTable,
+survived a Claude Code → Cursor handoff, and finished as a human-reviewed 67-commit PR spanning six
+roadmap phases and 57 closed issues. The public timeline, handoff, checks and permanent links are in
+[`examples/adapttable-continuity.md`](examples/adapttable-continuity.md).
+
 **nightshift was built by nightshift.** An enforced punch list guarded every build session of this
 repo, and the hooks refused every early clock-out. Each item landed as its own conventional commit
 — `git log --oneline` reads like the shift log — and the final punch list + shift log are in
 [`examples/self-build.md`](examples/self-build.md).
 
-**And it ran a real production night.** One list, one night, on a published library: 9 items — a
+**Your first night.** One small list, one night, on the same published library: 9 items — a
 CSV export button, 7 new locales, a Tailwind starter, inline cell editing and row grouping across
 every adapter — landed as unsquashed per-item commits, closed 4 issues on merge, and shipped as
 v1.2.0 on npm the same day. Public links:

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,44 @@
+# Nightshift receipts
+
+Real runs with public evidence. These are not benchmarks and ticks are not treated as proof; each
+receipt separates the agent's work from the owner's review and links to the permanent result.
+
+## Flagship — continuity at scale
+
+### [One contract, two coding agents, 57 issues](adapttable-continuity.md)
+
+One AdaptTable contract ran for 45 elapsed hours, survived a Claude Code → Cursor handoff, and
+finished as a human-reviewed 67-commit PR spanning six roadmap phases and 57 closed issues.
+
+Use this receipt to understand what durable on-disk state makes possible when a shift outlives one
+conversation, one allowance and one coding agent.
+
+## Start here — a reproducible first night
+
+### [A real overnight run on a production library](adapttable-overnight.md)
+
+Nine focused items landed in four hours as unsquashed per-item commits, closed four issues on merge,
+and shipped AdaptTable v1.2.0 to npm the same day.
+
+Use this receipt as the smaller model for a first attended or overnight shift.
+
+## Nightshift building Nightshift
+
+### [Nightshift's self-build](self-build.md)
+
+The plugin's own build sessions used an enforced punch list, conventional item commits and the same
+stop gate it gives users.
+
+### [Codex hardening shift](codex-hardening-shift.md)
+
+An 11-item Codex maintenance shift stayed on one branch, passed the repository gates and became
+Nightshift v0.9.2.
+
+## Contribute a receipt
+
+Use the [bad-night template](bad-night-template.md) for an interrupted, stalled, owner-stopped or
+incorrectly completed run. Good and bad nights are both useful when facts, interpretation and public
+evidence remain separate.
+
+Share a public receipt on
+[#22](https://github.com/orwa-mahmoud/nightshift/issues/22).

--- a/examples/adapttable-continuity.md
+++ b/examples/adapttable-continuity.md
@@ -10,9 +10,6 @@ The result was [PR #353](https://github.com/orwa-mahmoud/adapttable/pull/353): *
 changed files, six roadmap phases, and 57 issues closed** after owner review. The full GitHub check
 suite passed before merge.
 
-This is the scale example. For a small first run that is easier to reproduce, see
-[`adapttable-overnight.md`](adapttable-overnight.md).
-
 ## The durable handoff
 
 Nightshift's files, not either conversation, held the authority:

--- a/examples/adapttable-continuity.md
+++ b/examples/adapttable-continuity.md
@@ -1,0 +1,84 @@
+# Flagship example — one contract, two coding agents, 57 issues
+
+From 2026-08-12 to 2026-08-14, one Nightshift contract drove six roadmap phases on
+[AdaptTable](https://github.com/orwa-mahmoud/adapttable), a production React data-table library.
+Claude Code began the shift. When the owner's Claude allowance ran out, the owner issued a
+Nightshift stop-work order and handed the same on-disk punch list to Cursor. Cursor resumed ten
+minutes later instead of reconstructing the plan from chat.
+
+The result was [PR #353](https://github.com/orwa-mahmoud/adapttable/pull/353): **67 commits, 700
+changed files, six roadmap phases, and 57 issues closed** after owner review. The full GitHub check
+suite passed before merge.
+
+This is the scale example. For a small first run that is easier to reproduce, see
+[`adapttable-overnight.md`](adapttable-overnight.md).
+
+## The durable handoff
+
+Nightshift's files, not either conversation, held the authority:
+
+- one branch: `night/2026-08-12`;
+- eight top-level punch-list items covering the six roadmap phases;
+- one definition of done across nine adapters, 17 locales, documentation, changesets, tests,
+  browser verification and Sonar;
+- one parking lot for owner decisions and one snag log for failures;
+- one conventional commit per issue, kept local until morning review.
+
+The recorded sequence is public or preserved in the archived Nightshift receipt:
+
+| UTC | Event |
+| --- | --- |
+| 2026-08-12 17:20 | Nightshift armed the eight-item contract with Claude Code. |
+| 2026-08-13 17:12 | The owner stopped that session when the Claude allowance ran out. |
+| 2026-08-13 17:22 | Cursor resumed the same branch, punch list and definition of done. |
+| 2026-08-14 14:27 | All eight items were ticked after the final Sonar pass: 0 issues, 0 hotspots. |
+| 2026-08-14 19:26 | Owner review, additional fixes and CI completed; PR #353 merged. |
+
+That is **45 hours 7 minutes of elapsed shift continuity** and **50 hours 6 minutes from arming to
+merge**. Commit timestamps prove the agent sequence and handoff; they are not presented as a meter
+of uninterrupted token-processing time. Claude Code returned during the final review-and-fix pass,
+which is also visible in the commit authorship.
+
+## What shipped
+
+The eight contract items produced six coherent roadmap phases:
+
+1. **Data engine** — nested grouping, group footers, group-aware sorting and filtering,
+   controlled expansion, server grouping, hierarchical tree data and nested tables.
+2. **Spreadsheet interactions** — drag and column selection, clipboard copy/cut/paste, fill
+   handle, selection statistics, undo/redo and find-in-table.
+3. **Virtualization and sizing** — column virtualization, virtualized row detail, content sizing
+   and flex-to-container columns.
+4. **Editing 2.0** — validation, typed and custom editors, optimistic saves with rollback, dirty
+   state, row and batch editing, row mutation helpers, lifecycle events and conflict handling.
+5. **Rows and columns** — reordering, pinning, spanning, full-width rows, conditional styling,
+   collapsible column groups, advanced menus, custom chrome and sparkline columns.
+6. **Advanced filtering** — typed operators, relative dates, AND/OR trees and builder,
+   Excel-style checklists, facet counts, header filters and a public filter registry.
+
+## What the owner reviewed
+
+Nightshift did not merge, publish or pretend that ticks proved correctness. The owner reviewed the
+branch, ran additional checks, fixed findings and merged the PR. The final evidence included:
+
+- all GitHub checks green, including tests with coverage, CodeQL, packaging, consumer harness,
+  performance smoke, three React compatibility jobs and a 16-minute Playwright showcase run;
+- core coverage reported by the PR at 96.58% statements, 99.43% lines and 99.03% functions;
+- SonarQube at 0 issues and 0 hotspots;
+- browser verification across all eight UI adapters;
+- new labels in all 17 locales and every new public export documented;
+- zero lint suppressions and zero skipped tests.
+
+## Proof
+
+- [Merged flagship PR #353](https://github.com/orwa-mahmoud/adapttable/pull/353)
+- [First commit in the public
+  sequence](https://github.com/orwa-mahmoud/adapttable/commit/b419e6623bf1bf9a3d8ad9331b918d3a0ae2b171)
+- [First Cursor handoff
+  commit](https://github.com/orwa-mahmoud/adapttable/commit/9bccc0b1350784bdf99518c11d5cd1cbef4cc027)
+- [Last review-and-fix
+  commit](https://github.com/orwa-mahmoud/adapttable/commit/e6d5d283706dd96119fccef5c04839642088f40d)
+
+The point is not that every shift should be this large. It is that the work contract survived the
+thing that normally breaks a long agent run: time, compaction, a stopped session and a change of
+agent. The next agent inherited explicit state and continued shipping against the same standard.

--- a/tests/bad-night-template.bats
+++ b/tests/bad-night-template.bats
@@ -1,10 +1,19 @@
 README="$BATS_TEST_DIRNAME/../README.md"
+INDEX="$BATS_TEST_DIRNAME/../examples/README.md"
 T="$BATS_TEST_DIRNAME/../examples/bad-night-template.md"
 SECURITY="$BATS_TEST_DIRNAME/../SECURITY.md"
 
-@test "README points at the bad-night template beside real receipts" {
-  grep -qF '[`examples/bad-night-template.md`](examples/bad-night-template.md)' "$README"
-  grep -qF 'orwa-mahmoud/nightshift/issues/22' "$README"
+@test "README points at the receipt index" {
+  grep -qF '[`examples/`](examples/README.md)' "$README"
+}
+
+@test "receipt index organizes real runs and the bad-night template" {
+  grep -qF '(adapttable-continuity.md)' "$INDEX"
+  grep -qF '(adapttable-overnight.md)' "$INDEX"
+  grep -qF '(self-build.md)' "$INDEX"
+  grep -qF '(codex-hardening-shift.md)' "$INDEX"
+  grep -qF '(bad-night-template.md)' "$INDEX"
+  grep -qF 'orwa-mahmoud/nightshift/issues/22' "$INDEX"
 }
 
 @test "the template separates facts from interpretation and refuses tick-as-proof" {


### PR DESCRIPTION
## Summary

- make AdaptTable PR #353 the flagship scale-and-continuity receipt
- document the Claude Code to Cursor handoff with verifiable timestamps and permanent links
- keep PR #75 as the smaller, reproducible first-night example

## Verification

- `bats tests/bad-night-template.bats tests/first-night-checklist.bats tests/skill-paths.bats`
- `claude plugin validate . --strict`
- `git diff --check`