### PR TITLE
docs: align receipt contribution guidance

### DIFF
--- a/examples/bad-night-template.md
+++ b/examples/bad-night-template.md
@@ -1,9 +1,8 @@
 # Bad-night receipt template
 
 Use this when a shift was interrupted, stalled, owner-stopped, revived incorrectly, or ended with
-work that did not match the punch list. Successful nights belong in a filled example (see
-[`adapttable-overnight.md`](adapttable-overnight.md) and
-[`codex-hardening-shift.md`](codex-hardening-shift.md)).
+work that did not match the punch list. Successful nights belong in a filled example; use the
+[receipt library](README.md) to see how those are structured and evidenced.
 
 A ticked box is the agent's own claim that the item is done. It is not independent proof. Link
 public commits, pull requests, or logs when they exist; do not paste private repository content

--- a/tests/bad-night-template.bats
+++ b/tests/bad-night-template.bats
@@ -17,6 +17,7 @@ SECURITY="$BATS_TEST_DIRNAME/../SECURITY.md"
 }
 
 @test "the template separates facts from interpretation and refuses tick-as-proof" {
+  grep -qF '[receipt library](README.md)' "$T"
   grep -qF '## Facts (observed)' "$T"
   grep -qF '## Interpretation (yours, not the agent' "$T"
   grep -qi 'not independent proof' "$T"


### PR DESCRIPTION
## Summary

- point successful receipt authors to the scalable receipt library
- keep the bad-night template focused on its own reporting contract
- enforce the library link in the receipt-template test

## Verification

- `bats tests/bad-night-template.bats`
- `claude plugin validate . --strict`
- `git diff --check`