### PR TITLE
Harden shift control files and Git commit guards

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -6,6 +6,6 @@ contact_links:
   - name: 🧭 Choose a contribution
     url: https://github.com/orwa-mahmoud/nightshift/blob/main/docs/contribution-map.md
     about: Pick an area, current work, likely files, and focused checks.
-  - name: 🔒 Security — gate-bypass reports
+  - name: 🔒 Security — optional private report
     url: https://github.com/orwa-mahmoud/nightshift/security/advisories/new
-    about: Ways to make the stop-gate lie go here, privately — not in a public issue.
+    about: Only if secrets could leave this machine or other users could be affected. Local guard bugs are public issues.

--- a/.github/ISSUE_TEMPLATE/failed_shift.yml
+++ b/.github/ISSUE_TEMPLATE/failed_shift.yml
@@ -13,9 +13,10 @@ body:
         (watchman stand-down, revival attempt, gate block) — strip paths that are not
         `.nightshift/` markers, command arguments, and file contents.
 
-        **Gate bypass, forged receipts, or a way to clock out with open boxes** belongs in a
-        [private security advisory](https://github.com/orwa-mahmoud/nightshift/security/advisories/new),
-        not here. See [SECURITY.md](https://github.com/orwa-mahmoud/nightshift/blob/main/SECURITY.md).
+        Local guard and gate reports are public issues. A
+        [private advisory](https://github.com/orwa-mahmoud/nightshift/security/advisories/new)
+        is optional — only if secrets could leave this machine or other users could be affected.
+        See [SECURITY.md](https://github.com/orwa-mahmoud/nightshift/blob/main/SECURITY.md).
   - type: dropdown
     id: harness
     attributes:
@@ -106,6 +107,4 @@ body:
       label: Redaction
       options:
         - label: I have removed prompts, credentials, repository content, and full transcripts from this report.
-          required: true
-        - label: This is not a stop-gate bypass or security report (those go to a private advisory).
           required: true

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -13,30 +13,26 @@ The primary Nightshift attack surface is therefore its local hook and runtime
 scripts, the permissions granted to the coding agent, and any owner-configured
 notification command.
 
-## Reporting a vulnerability
+## Reporting
 
-Please **do not open a public issue** for security vulnerabilities.
+A public issue is the default. Nightshift is a local plugin: gate, hardhat,
+knobs, receipts, and other local guard misses belong in the open, including a
+bound agent that can defeat its own contract. A commit-guard hole that lets the
+night stage a file it can already read is still a public hardening report.
 
-The interesting risks here are of one kind: **a way to make the stop-gate
-lie** — clocking out with unticked items, forging receipts, or escaping the
-contract via hook manipulation. A stale recovery process bypassing the active
-process lease to execute a local tool belongs in the same private channel.
+A private advisory is optional. Use it when a report could leak secrets off this
+machine, reach other users, or compromise something beyond this owner's agent
+or session. The form is here:
+[Report a vulnerability](https://github.com/orwa-mahmoud/nightshift/security/advisories/new).
 
-Instead, report privately via GitHub's
-[**Report a vulnerability**](https://github.com/orwa-mahmoud/nightshift/security/advisories/new)
-flow (Security → Advisories). If that is unavailable, you can open a regular
-issue asking the maintainer to contact you, without disclosing details.
-
-A failed or interrupted *night* that is not a bypass — stalled watchman, wrong
-workspace, revival that did not fire — belongs on a public
+A failed or interrupted night that is not a new hardening report belongs on a
 [Failed shift](https://github.com/orwa-mahmoud/nightshift/issues/new?template=failed_shift.yml)
 report. That form asks for host/version and sanitized markers; it must not
 include prompts, credentials, repository content, or a full transcript.
 
 When reporting, please include:
 
-- The Claude Code version and the plugin version.
-- A minimal reproduction of the bypass.
+- The Claude Code or Codex version and the plugin version.
+- A minimal reproduction.
 
-You'll get a reply within a week. Please don't disclose gate-bypass reports
-publicly until a fix ships.
+You'll get a reply within a week.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -280,4 +280,4 @@ worker.
 - [Command reference](commands.md) — setup, start, status, doctor, stop, schedule
 - [Owner knobs](knobs.md) — `rules.json` and env overrides
 - [First-night safety checklist](first-night-checklist.md)
-- [Security policy](../SECURITY.md) — gate-bypass reports stay private
+- [Security policy](../SECURITY.md) — public issues by default; private advisory is optional

--- a/examples/bad-night-template.md
+++ b/examples/bad-night-template.md
@@ -9,8 +9,10 @@ public commits, pull requests, or logs when they exist; do not paste private rep
 to make a tick look verified.
 
 Contribute filled receipts against
-[#22](https://github.com/orwa-mahmoud/nightshift/issues/22). Gate-bypass reports go to a
-[private advisory](https://github.com/orwa-mahmoud/nightshift/security/advisories/new), not here.
+[#22](https://github.com/orwa-mahmoud/nightshift/issues/22). Local guard and gate reports
+are public issues; see [SECURITY.md](../SECURITY.md). Use a
+[private advisory](https://github.com/orwa-mahmoud/nightshift/security/advisories/new)
+only if secrets could leave this machine or other users could be affected.
 
 Copy from **Host** downward. Delete unused bullets. Keep **Facts** and **Interpretation** in
 separate sections.

--- a/plugins/nightshift/hooks/clock-out-gate.sh
+++ b/plugins/nightshift/hooks/clock-out-gate.sh
@@ -140,9 +140,8 @@ honor_stop() {
     summary="shift ended${reason:+ ($reason)}: $TICKED/$TOTAL done"
     end_shift "$summary"
   else
-    # A stop-work order ends the shift even if the list did not survive to be summarized.
-    rm -f "$NS/.shift-armed"
-    release_lease
+    reason="$(head -n1 "$STOP" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    end_shift "shift ended${reason:+ ($reason)}: $TICKED/$TOTAL done"
   fi
 }
 
@@ -200,8 +199,7 @@ fi
 
 # 2. Done — no punch list at all, or every box ticked.
 if [ ! -f "$PUNCH" ]; then
-  rm -f "$NS/.shift-armed"
-  release_lease
+  end_shift "shift done: $TICKED/$TOTAL"
   exit 0
 fi
 if [ "$OPEN" -eq 0 ]; then

--- a/plugins/nightshift/hooks/codex/clock-out-gate.sh
+++ b/plugins/nightshift/hooks/codex/clock-out-gate.sh
@@ -126,9 +126,8 @@ honor_stop() {
     summary="shift ended${reason:+ ($reason)}: $TICKED/$TOTAL done"
     end_shift "$summary"
   else
-    # A stop-work order ends the shift even if the list did not survive to be summarized.
-    rm -f "$NS/.shift-armed"
-    release_lease
+    reason="$(head -n1 "$STOP" 2>/dev/null | sed 's/^[[:space:]]*//; s/[[:space:]]*$//')"
+    end_shift "shift ended${reason:+ ($reason)}: $TICKED/$TOTAL done"
   fi
 }
 
@@ -189,8 +188,7 @@ fi
 
 # 2. Done — no punch list at all, or every box ticked.
 if [ ! -f "$PUNCH" ]; then
-  rm -f "$NS/.shift-armed"
-  release_lease
+  end_shift "shift done: $TICKED/$TOTAL"
   codex_emit_release
   exit 0
 fi

--- a/plugins/nightshift/hooks/codex/hardhat.sh
+++ b/plugins/nightshift/hooks/codex/hardhat.sh
@@ -135,6 +135,9 @@ fi
 if ns_hardhat_payload_targets_rules "$TOOL" "$CODEX_RAW" "$CMD"; then
   deny "BLOCKED: the rules file is the owner's — the night neither reads nor rewrites its own rules. Park the need in .nightshift/parking-lot.md and keep working."
 fi
+if ns_hardhat_payload_targets_control "$TOOL" "$CODEX_RAW" "$CMD"; then
+  deny "BLOCKED: shift control files are owner-owned while the night is armed. Do not delete or forge .shift-armed, .ended, STOP, .shift-session, or work-target, and do not delete the punch list. Park the need in .nightshift/parking-lot.md and keep working."
+fi
 
 if [ "$TOOL" = "request_user_input" ] \
   || { [ -z "$TOOL" ] && codex_input_mentions_tool "request_user_input"; }; then

--- a/plugins/nightshift/hooks/hardhat.sh
+++ b/plugins/nightshift/hooks/hardhat.sh
@@ -154,6 +154,9 @@ fi
 if ns_hardhat_payload_targets_rules "$TOOL" "$INPUT" "$CMD"; then
   deny "BLOCKED: the rules file is the owner's — the night neither reads nor rewrites its own rules. Park the need in .nightshift/parking-lot.md and keep working."
 fi
+if ns_hardhat_payload_targets_control "$TOOL" "$INPUT" "$CMD"; then
+  deny "BLOCKED: shift control files are owner-owned while the night is armed. Do not delete or forge .shift-armed, .ended, STOP, .shift-session, or work-target, and do not delete the punch list. Park the need in .nightshift/parking-lot.md and keep working."
+fi
 
 if [ "$TOOL" = "AskUserQuestion" ] \
   || { [ -z "$TOOL" ] && printf '%s' "$INPUT" | grep -q '"tool_name"[[:space:]]*:[[:space:]]*"AskUserQuestion"'; }; then

--- a/plugins/nightshift/hooks/shared/hardhat-core.sh
+++ b/plugins/nightshift/hooks/shared/hardhat-core.sh
@@ -499,13 +499,12 @@ ns_hardhat_command_reason() {
       fi
     fi
     if [ -n "$NEVER_COMMIT_PATTERNS" ]; then
-      if commit_stages_implicitly "$CMD"; then
-        _scope="the diff this commit would write"
-        _diff="$(git -C "$REPO" diff HEAD 2>/dev/null)"
-      else
-        _scope="the staged diff"
-        _diff="$(git -C "$REPO" diff --cached 2>/dev/null)"
-      fi
+      _scope="the diff this commit would write"
+      _diff="$(ns_git_prospective_diff "$REPO" "$SCRUBBED")"
+      case "$?" in
+        2) printf '%s' "BLOCKED: this commit uses a form the never-commit guard cannot verify. Do not retry a rephrased form."
+           return 0 ;;
+      esac
       if printf '%s' "$_diff" | grep -qiE "$NEVER_COMMIT_PATTERNS"; then
         printf '%s' "BLOCKED: $_scope matches a never-commit pattern. Remove it, restage, retry. Do not weaken the pattern list."
         return 0

--- a/plugins/nightshift/hooks/shared/hardhat-core.sh
+++ b/plugins/nightshift/hooks/shared/hardhat-core.sh
@@ -29,6 +29,27 @@ ns_hardhat_rules_targeted() {
     }
 }
 
+# True when the command is already inside .nightshift — by path, by cd/pushd, or by payload cwd.
+ns_hardhat_nightshift_dir_context() {
+  local normalized="$1" cwd_norm ns_norm
+  # `.nightshift && unlink .shift-armed` has no slash after the directory name.
+  if printf '%s' "$normalized" | grep -qE '\.nightshift([/[:space:];&]|$)'; then
+    return 0
+  fi
+  if printf '%s' "$normalized" |
+      grep -qE '(^|[;&|()[:space:]])(cd|pushd)[[:space:]]+([^;&|()[:space:]]*/)?\.nightshift/?([;&|()[:space:]]|$)'; then
+    return 0
+  fi
+  if [ -n "${CWD:-}" ] && [ -n "${NS:-}" ]; then
+    cwd_norm="${CWD%/}"
+    ns_norm="${NS%/}"
+    case "$cwd_norm" in
+      "$ns_norm" | "$ns_norm"/*) return 0 ;;
+    esac
+  fi
+  return 1
+}
+
 ns_hardhat_lease_targeted() {
   local normalized nightshift_context=0
   normalized="$(printf '%s' "$1" | sed "s#\\\\/#/#g; s#[\"']##g")"
@@ -36,9 +57,7 @@ ns_hardhat_lease_targeted() {
       grep -qE '(^|/)(\.shift-lease|\.mutex-scope)($|[^[:alnum:]_-])|(^|/)\.lease-lock\.d($|/)'; then
     return 0
   fi
-  case "$normalized" in *'.nightshift/'*) nightshift_context=1 ;; esac
-  if printf '%s' "$normalized" |
-      grep -qE '(^|[;&|()[:space:]])(cd|pushd)[[:space:]]+([^;&|()[:space:]]*/)?\.nightshift/?([;&|()[:space:]]|$)'; then
+  if ns_hardhat_nightshift_dir_context "$normalized"; then
     nightshift_context=1
   fi
   if [ "$nightshift_context" -eq 1 ]; then
@@ -50,8 +69,10 @@ ns_hardhat_lease_targeted() {
         | *'{'*'shift-lease'* | *'{'*'lease-lock'* | *'{'*'mutex-scope'* ) return 0 ;;
     esac
   fi
-  if printf '%s' "$normalized" | grep -qE '(^|[;&|[:space:]])(rm|rmdir|unlink|mv)([[:space:]]|$)' \
-    && printf '%s' "$normalized" | grep -qE '(^|[[:space:]])(\./)?\.nightshift/?([[:space:]]|$)'; then
+  # The delete verb must target .nightshift itself. `cd .nightshift && unlink .shift-armed`
+  # is a control-file write, not `rm .nightshift`.
+  if printf '%s' "$normalized" |
+      grep -qE '(^|[;&|()[:space:]])(rm|rmdir|unlink|mv)[[:space:]]+([^;&|\n]*[[:space:]]+)?(\./)?\.nightshift/?([;&|()[:space:]]|$)'; then
     return 0
   fi
   if printf '%s' "$normalized" | grep -qE '(^|[;&|[:space:]])find([[:space:]]|$)' \
@@ -203,6 +224,14 @@ ns_hardhat_control_list_path() {
   printf '%s' "$1" | grep -qE '(^|/|\.)nightshift/punch-list\.md(/|$|[^[:alnum:]_.-])'
 }
 
+ns_hardhat_control_rewrite_name() {
+  printf '%s' "$1" | grep -qE '(^|[;&|()[:space:]])(\./)?(STOP|\.shift-armed|\.ended|\.shift-session|work-target)([;&|()[:space:]]|$)'
+}
+
+ns_hardhat_control_list_name() {
+  printf '%s' "$1" | grep -qE '(^|[;&|()[:space:]])(\./)?punch-list\.md([;&|()[:space:]]|$)'
+}
+
 ns_hardhat_control_delete_verb() {
   printf '%s' "$1" | grep -qE '(^|[;&|()[:space:]])(rm|rmdir|unlink|mv|Remove-Item|Move-Item|Rename-Item)([[:space:]]|$)'
 }
@@ -211,7 +240,12 @@ ns_hardhat_control_targeted() {
   local normalized
   normalized="$(printf '%s' "$1" | sed "s#\\\\#/#g; s#[\"']##g")"
   ns_hardhat_control_rewrite_path "$normalized" && return 0
-  ns_hardhat_control_list_path "$normalized" && ns_hardhat_control_delete_verb "$normalized"
+  ns_hardhat_control_list_path "$normalized" && ns_hardhat_control_delete_verb "$normalized" && return 0
+  if ns_hardhat_nightshift_dir_context "$normalized"; then
+    ns_hardhat_control_rewrite_name "$normalized" && return 0
+    ns_hardhat_control_list_name "$normalized" && ns_hardhat_control_delete_verb "$normalized" && return 0
+  fi
+  return 1
 }
 
 ns_hardhat_payload_targets_control() {

--- a/plugins/nightshift/hooks/shared/hardhat-core.sh
+++ b/plugins/nightshift/hooks/shared/hardhat-core.sh
@@ -398,7 +398,7 @@ ns_hardhat_is_commit() {
 # Uses globals: SCRUBBED CMD CWD PROJECT_DIR PROTECTED_DIRS EXPECTED_EMAIL
 # NEVER_COMMIT_PATTERNS FORBIDDEN_COMMANDS
 ns_hardhat_command_reason() {
-  local _p _name _pat d _tok _dirs _toks REPO email _scope _diff
+  local _p _name _pat d _tok _dirs _toks REPO email _scope _diff _verb _pathfile _pathrc _hit
   for _p in "FORBIDDEN_COMMANDS:$FORBIDDEN_COMMANDS" "NEVER_COMMIT_PATTERNS:$NEVER_COMMIT_PATTERNS"; do
     _name="${_p%%:*}"
     _pat="${_p#*:}"
@@ -410,19 +410,66 @@ ns_hardhat_command_reason() {
   done
 
   if [ -n "$PROTECTED_DIRS" ] && ns_hardhat_is_git_write "$SCRUBBED"; then
-    IFS=' |' read -ra _dirs <<<"$PROTECTED_DIRS"
-    read -ra _toks <<<"$SCRUBBED"
-    for d in "${_dirs[@]}"; do
-      [ -n "$d" ] || continue
-      for _tok in "${_toks[@]}"; do
-        case "$_tok" in
-          "$d" | "$d"/* | */"$d" | */"$d"/* | *="$d" | *="$d"/*)
-            printf '%s' "BLOCKED: never git add/commit/tag/remote inside '$d' (a protected directory). Do not retry a rephrased form."
-            return 0
-            ;;
-        esac
+    _verb=""
+    ns_hardhat_git_verb "$SCRUBBED" add && _verb=add
+    ns_hardhat_git_verb "$SCRUBBED" commit && _verb=commit
+    if [ -n "$_verb" ]; then
+      if printf '%s' "$SCRUBBED" | grep -qE -- '--git-dir|--work-tree'; then
+        printf '%s' "BLOCKED: --git-dir/--work-tree point this $_verb somewhere the protected-directory guard cannot verify. Run it from inside the repository instead."
+        return 0
+      fi
+      REPO="$(target_repo "$CMD" "${CWD:-$PROJECT_DIR}")"
+      case "$?" in
+        1) printf '%s' "BLOCKED: this $_verb names a directory that is not a git repository, so the protected-directory guard cannot inspect it. Do not retry a rephrased form."
+           return 0 ;;
+        2) REPO="$(repo_root "$PROJECT_DIR" "$CWD")" || REPO="$(ns_work_target "$PROJECT_DIR")" || {
+             printf '%s' "BLOCKED: cannot tell which git repository this $_verb targets, so the protected-directory guard cannot run. Run it from inside the repository."
+             return 0
+           } ;;
+      esac
+      _pathfile="$(mktemp "${TMPDIR:-/tmp}/ns-pd.XXXXXX")" || {
+        printf '%s' "BLOCKED: cannot tell which paths this $_verb would write, so the protected-directory guard cannot run."
+        return 0
+      }
+      ns_git_prospective_paths "$REPO" "$SCRUBBED" "$_verb" >"$_pathfile"
+      _pathrc=$?
+      if [ "$_pathrc" -eq 2 ]; then
+        rm -f "$_pathfile"
+        printf '%s' "BLOCKED: this $_verb uses a form the protected-directory guard cannot verify. Do not retry a rephrased form."
+        return 0
+      fi
+      _hit=""
+      while IFS= read -r -d '' _p; do
+        [ -n "$_p" ] || continue
+        if ns_path_under_protected "$_p" "$PROTECTED_DIRS"; then
+          _hit="$_p"
+          break
+        fi
+      done <"$_pathfile"
+      rm -f "$_pathfile"
+      if [ -n "$_hit" ]; then
+        IFS=' |' read -ra _dirs <<<"$PROTECTED_DIRS"
+        for d in "${_dirs[@]}"; do
+          ns_path_under_protected "$_hit" "$d" && break
+        done
+        printf '%s' "BLOCKED: never git add/commit/tag/remote inside '$d' (a protected directory). Do not retry a rephrased form."
+        return 0
+      fi
+    else
+      IFS=' |' read -ra _dirs <<<"$PROTECTED_DIRS"
+      read -ra _toks <<<"$SCRUBBED"
+      for d in "${_dirs[@]}"; do
+        [ -n "$d" ] || continue
+        for _tok in "${_toks[@]}"; do
+          case "$_tok" in
+            "$d" | "$d"/* | */"$d" | */"$d"/* | *="$d" | *="$d"/*)
+              printf '%s' "BLOCKED: never git add/commit/tag/remote inside '$d' (a protected directory). Do not retry a rephrased form."
+              return 0
+              ;;
+          esac
+        done
       done
-    done
+    fi
   fi
 
   if ns_hardhat_is_commit "$SCRUBBED" && { [ -n "$EXPECTED_EMAIL" ] || [ -n "$NEVER_COMMIT_PATTERNS" ]; }; then

--- a/plugins/nightshift/hooks/shared/hardhat-core.sh
+++ b/plugins/nightshift/hooks/shared/hardhat-core.sh
@@ -193,6 +193,39 @@ sys.stdout.buffer.write(base64.b64decode(sys.argv[1])+b"\x1c")' "$encoded" 2>/de
   return 1
 }
 
+# Bound-worker control plane: forge/delete of the files the gate keys off.
+# punch-list.md may be edited; only a delete/rename of that file is denied.
+ns_hardhat_control_rewrite_path() {
+  printf '%s' "$1" | grep -qE '(^|/|\.)nightshift/(STOP|\.shift-armed|\.ended|\.shift-session|work-target)(/|$|[^[:alnum:]_.-])'
+}
+
+ns_hardhat_control_list_path() {
+  printf '%s' "$1" | grep -qE '(^|/|\.)nightshift/punch-list\.md(/|$|[^[:alnum:]_.-])'
+}
+
+ns_hardhat_control_delete_verb() {
+  printf '%s' "$1" | grep -qE '(^|[;&|()[:space:]])(rm|rmdir|unlink|mv|Remove-Item|Move-Item|Rename-Item)([[:space:]]|$)'
+}
+
+ns_hardhat_control_targeted() {
+  local normalized
+  normalized="$(printf '%s' "$1" | sed "s#\\\\#/#g; s#[\"']##g")"
+  ns_hardhat_control_rewrite_path "$normalized" && return 0
+  ns_hardhat_control_list_path "$normalized" && ns_hardhat_control_delete_verb "$normalized"
+}
+
+ns_hardhat_payload_targets_control() {
+  case "$1" in
+    Read | Grep | Glob | LS | WebFetch | WebSearch | Task | TodoWrite | AskUserQuestion | request_user_input | NotebookRead)
+      return 1
+      ;;
+    *read* | *Read*)
+      return 1
+      ;;
+  esac
+  ns_hardhat_payload_targets "$1" "$2" "$3" ns_hardhat_control_targeted
+}
+
 ns_hardhat_payload_targets_rules() {
   ns_hardhat_payload_targets "$1" "$2" "$3" ns_hardhat_rules_targeted
 }

--- a/plugins/nightshift/hooks/windows/clock-out-gate.ps1
+++ b/plugins/nightshift/hooks/windows/clock-out-gate.ps1
@@ -232,14 +232,8 @@ if (Test-Path -LiteralPath $stop -PathType Leaf) {
         }
         catch {
         }
-        if (Test-Path -LiteralPath $punch -PathType Leaf) {
-            $suffix = if ([string]::IsNullOrEmpty($reason)) { '' } else { " ($reason)" }
-            Complete-NSShift ("shift ended${suffix}: $($counts.Ticked)/$($counts.Total) done")
-        }
-        else {
-            Remove-Item -LiteralPath $armed -Force -ErrorAction SilentlyContinue
-            Release-NSLeaseWithRetry
-        }
+        $suffix = if ([string]::IsNullOrEmpty($reason)) { '' } else { " ($reason)" }
+        Complete-NSShift ("shift ended${suffix}: $($counts.Ticked)/$($counts.Total) done")
     }
     finally {
         if ($null -ne $mutex) {
@@ -295,8 +289,7 @@ try {
     }
 
     if (-not (Test-Path -LiteralPath $punch -PathType Leaf)) {
-        Remove-Item -LiteralPath $armed -Force -ErrorAction SilentlyContinue
-        Release-NSLeaseWithRetry
+        Complete-NSShift "shift done: $($counts.Ticked)/$($counts.Total)"
         Write-Release
     }
     if ($counts.Open -eq 0) {

--- a/plugins/nightshift/hooks/windows/hardhat.ps1
+++ b/plugins/nightshift/hooks/windows/hardhat.ps1
@@ -288,6 +288,88 @@ function Resolve-NSCommandRepository {
     }
 }
 
+function Get-NSProspectiveGitPaths {
+    param(
+        [Parameter(Mandatory = $true)][string]$Repository,
+        [Parameter(Mandatory = $true)][string]$Command,
+        [Parameter(Mandatory = $true)][string]$Verb
+    )
+    $gitDir = Invoke-NSGit $Repository @('rev-parse', '--absolute-git-dir')
+    if ([string]::IsNullOrWhiteSpace($gitDir)) {
+        return $null
+    }
+    $temp = Join-Path ([IO.Path]::GetTempPath()) ("ns-git-" + [guid]::NewGuid().ToString('N'))
+    $null = New-Item -ItemType Directory -Path $temp -Force
+    $index = Join-Path $gitDir 'index'
+    $copy = Join-Path $temp 'index'
+    if (Test-Path -LiteralPath $index -PathType Leaf) {
+        Copy-Item -LiteralPath $index -Destination $copy -Force
+    }
+    $env:GIT_INDEX_FILE = $copy
+    try {
+        $words = @($Command -split '\s+' | Where-Object { $_ -ne '' })
+        $start = [array]::IndexOf($words, $Verb)
+        if ($start -lt 0) { return $null }
+        $form = 'index'
+        $paths = New-Object System.Collections.Generic.List[string]
+        $rest = $false
+        $skip = $false
+        foreach ($word in $words[($start + 1)..($words.Length - 1)]) {
+            if ($skip) { $skip = $false; continue }
+            if ($rest) {
+                if ($word -ne 'MSG') { $paths.Add($word) }
+                continue
+            }
+            switch -Regex ($word) {
+                '^--$' { $rest = $true }
+                '^(--all|-A)$' { $form = $(if ($Verb -eq 'add') { 'all' } else { 'tracked' }) }
+                '^(--update|-u)$' { $form = 'tracked' }
+                '^(--include|-i)$' { if ($Verb -eq 'commit') { $form = 'include' } }
+                '^(--only|-o)$' { if ($Verb -eq 'commit') { $form = 'only' } }
+                '^(-m|--message|--file|--author|--date|--cleanup)$' { $skip = $true }
+                '^(--message=|--file=|--author=|--date=|MSG)' { }
+                '^(--allow-empty|--allow-empty-message|--no-verify|--no-edit|--quiet|--signoff|-q|-s|-n|--no-gpg-sign|--verbose|-v|--force|-f|--ignore-missing|--refresh)$' { }
+                '^-[[:alpha:]]*a[[:alpha:]]*$' { if ($Verb -eq 'commit') { $form = 'tracked' } }
+                '^-' { return $null }
+                default { if ($word -ne 'MSG') { $paths.Add($word) } }
+            }
+        }
+        if ($Verb -eq 'commit' -and $paths.Count -gt 0 -and $form -eq 'index') { $form = 'only' }
+        switch ("$Verb-$form") {
+            'add-all' { $null = Invoke-NSGit $Repository @('add', '-A') }
+            'add-tracked' { $null = Invoke-NSGit $Repository @('add', '-u') }
+            'add-index' { if ($paths.Count -gt 0) { $null = Invoke-NSGit $Repository (@('add', '--') + $paths) } }
+            'commit-index' { }
+            'commit-tracked' { $null = Invoke-NSGit $Repository @('add', '-u') }
+            'commit-include' { if ($paths.Count -gt 0) { $null = Invoke-NSGit $Repository (@('add', '--') + $paths) } }
+            'commit-only' {
+                $null = Invoke-NSGit $Repository @('read-tree', 'HEAD')
+                if ($paths.Count -gt 0) { $null = Invoke-NSGit $Repository (@('add', '--') + $paths) }
+            }
+            default { return $null }
+        }
+        if ($Verb -eq 'add') {
+            $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff', 'HEAD')
+            if ([string]::IsNullOrEmpty($listed)) {
+                $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff')
+            }
+        }
+        else {
+            $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff', 'HEAD')
+            if ([string]::IsNullOrEmpty($listed)) {
+                $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff')
+            }
+        }
+        if ([string]::IsNullOrEmpty($listed)) { return @() }
+        return @($listed -split "`0" | Where-Object { -not [string]::IsNullOrEmpty($_) })
+    }
+    finally {
+        Remove-Item -LiteralPath $env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
+        Remove-Item Env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
+        Remove-Item -LiteralPath $temp -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
 function Get-NSCommandDenyReason {
     param(
         [Parameter(Mandatory = $true)][string]$Command,
@@ -316,16 +398,39 @@ function Get-NSCommandDenyReason {
     $isGitWrite = (Test-NSGitVerb $Scrubbed 'add') -or (Test-NSGitVerb $Scrubbed 'commit') `
         -or (Test-NSGitVerb $Scrubbed 'tag') -or (Test-NSGitVerb $Scrubbed 'remote')
     if ($isGitWrite -and -not [string]::IsNullOrEmpty($ProtectedDirectories)) {
-        $tokens = $Scrubbed -split '\s+'
-        foreach ($directory in ($ProtectedDirectories -split '[\s|]+')) {
-            if ([string]::IsNullOrEmpty($directory)) {
-                continue
+        $verb = $null
+        if (Test-NSGitVerb $Scrubbed 'add') { $verb = 'add' }
+        if (Test-NSGitVerb $Scrubbed 'commit') { $verb = 'commit' }
+        if ($null -ne $verb) {
+            $repository = Resolve-NSCommandRepository $Command $CurrentDirectory $Workspace
+            if ([string]::IsNullOrEmpty($repository)) {
+                return "BLOCKED: cannot tell which Git repository this $verb targets, so the protected-directory guard cannot run. Run it from inside the repository."
             }
-            foreach ($token in $tokens) {
-                $clean = $token.Trim("'`"")
-                $parts = $clean.Replace('\', '/').Split('/')
-                if ($parts -contains $directory -or $clean -like "*=$directory" -or $clean -like "*=$directory/*") {
-                    return "BLOCKED: never git add/commit/tag/remote inside '$directory' (a protected directory). Do not retry a rephrased form."
+            $paths = Get-NSProspectiveGitPaths $repository $Scrubbed $verb
+            if ($null -eq $paths) {
+                return "BLOCKED: this $verb uses a form the protected-directory guard cannot verify. Do not retry a rephrased form."
+            }
+            foreach ($path in $paths) {
+                foreach ($directory in ($ProtectedDirectories -split '[\s|]+')) {
+                    if ([string]::IsNullOrEmpty($directory)) { continue }
+                    $normalized = $path.Replace('\', '/').TrimStart('./')
+                    if ($normalized -eq $directory -or $normalized.StartsWith("$directory/") `
+                        -or $normalized.EndsWith("/$directory") -or $normalized -match "/$([regex]::Escape($directory))/") {
+                        return "BLOCKED: never git add/commit/tag/remote inside '$directory' (a protected directory). Do not retry a rephrased form."
+                    }
+                }
+            }
+        }
+        else {
+            $tokens = $Scrubbed -split '\s+'
+            foreach ($directory in ($ProtectedDirectories -split '[\s|]+')) {
+                if ([string]::IsNullOrEmpty($directory)) { continue }
+                foreach ($token in $tokens) {
+                    $clean = $token.Trim("'`"")
+                    $parts = $clean.Replace('\', '/').Split('/')
+                    if ($parts -contains $directory -or $clean -like "*=$directory" -or $clean -like "*=$directory/*") {
+                        return "BLOCKED: never git add/commit/tag/remote inside '$directory' (a protected directory). Do not retry a rephrased form."
+                    }
                 }
             }
         }

--- a/plugins/nightshift/hooks/windows/hardhat.ps1
+++ b/plugins/nightshift/hooks/windows/hardhat.ps1
@@ -292,7 +292,8 @@ function Get-NSProspectiveGitPaths {
     param(
         [Parameter(Mandatory = $true)][string]$Repository,
         [Parameter(Mandatory = $true)][string]$Command,
-        [Parameter(Mandatory = $true)][string]$Verb
+        [Parameter(Mandatory = $true)][string]$Verb,
+        [switch]$AsDiff
     )
     $gitDir = Invoke-NSGit $Repository @('rev-parse', '--absolute-git-dir')
     if ([string]::IsNullOrWhiteSpace($gitDir)) {
@@ -348,17 +349,16 @@ function Get-NSProspectiveGitPaths {
             }
             default { return $null }
         }
-        if ($Verb -eq 'add') {
-            $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff', 'HEAD')
-            if ([string]::IsNullOrEmpty($listed)) {
-                $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff')
+        if ($AsDiff) {
+            $diff = Invoke-NSGit $Repository @('diff', '--cached', '--no-ext-diff', 'HEAD')
+            if ($null -eq $diff) {
+                $diff = Invoke-NSGit $Repository @('diff', '--cached', '--no-ext-diff')
             }
+            return $diff
         }
-        else {
-            $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff', 'HEAD')
-            if ([string]::IsNullOrEmpty($listed)) {
-                $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff')
-            }
+        $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff', 'HEAD')
+        if ([string]::IsNullOrEmpty($listed)) {
+            $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff')
         }
         if ([string]::IsNullOrEmpty($listed)) { return @() }
         return @($listed -split "`0" | Where-Object { -not [string]::IsNullOrEmpty($_) })
@@ -456,25 +456,12 @@ function Get-NSCommandDenyReason {
             }
         }
         if ($null -ne $neverRegex) {
-            $diffArgs = @('diff', '--cached', '--no-ext-diff', '--')
-            $scope = 'the staged diff'
-            if ($Scrubbed -match '(?i)(^|\s)--all(\s|$)|(^|\s)-[A-Za-z]*a[A-Za-z]*(\s|$)|(^|\s)--(\s|$)') {
-                $diffArgs = @('diff', 'HEAD', '--no-ext-diff', '--')
-                $scope = 'the diff this commit would write'
-            }
-            $diff = Get-NSGitDiffText $repository $diffArgs
-            if ($null -eq $diff -and $diffArgs.Count -ge 2 -and $diffArgs[1] -eq 'HEAD') {
-                $cached = Get-NSGitDiffText $repository @('diff', '--cached', '--no-ext-diff', '--')
-                $worktree = Get-NSGitDiffText $repository @('diff', '--no-ext-diff', '--')
-                if ($null -ne $cached -or $null -ne $worktree) {
-                    $diff = "$(if ($null -eq $cached) { '' } else { $cached })`n$(if ($null -eq $worktree) { '' } else { $worktree })"
-                }
-            }
+            $diff = Get-NSProspectiveGitPaths $repository $Scrubbed 'commit' -AsDiff
             if ($null -eq $diff) {
-                return 'BLOCKED: the commit diff could not be read, so the forbidden-content guard cannot approve this commit.'
+                return 'BLOCKED: this commit uses a form the never-commit guard cannot verify. Do not retry a rephrased form.'
             }
-            if ($neverRegex.IsMatch($diff)) {
-                return "BLOCKED: $scope matches neverCommitPatterns. Remove the protected content before committing."
+            if ($neverRegex.IsMatch([string]$diff)) {
+                return 'BLOCKED: the diff this commit would write matches neverCommitPatterns. Remove the protected content before committing.'
             }
         }
     }

--- a/plugins/nightshift/hooks/windows/hardhat.ps1
+++ b/plugins/nightshift/hooks/windows/hardhat.ps1
@@ -15,6 +15,8 @@ if (Test-Path Variable:PSNativeCommandUseErrorActionPreference) {
 
 $pluginRoot = Resolve-Path (Join-Path $PSScriptRoot '../..')
 Import-Module (Join-Path $pluginRoot 'lib/Nightshift.psm1') -Force -DisableNameChecking
+$script:cwd = ''
+$script:ns = ''
 
 function Write-Deny {
     param([Parameter(Mandatory = $true)][string]$Reason)
@@ -169,8 +171,7 @@ function Test-NSLeaseTarget {
     if ($normalized -match '(?i)(^|/)(\.shift-lease|\.mutex-scope)($|[^A-Za-z0-9_-])|(^|/)\.lease-lock\.d($|/)') {
         return $true
     }
-    $nightshiftContext = $normalized -match '(?i)\.nightshift/' `
-        -or $normalized -match '(?i)(^|[;&|()\s])(cd|pushd|Set-Location)\s+[^\r\n;&|()]*\.nightshift/?([;&|()\s]|$)'
+    $nightshiftContext = Test-NSNightshiftDirContext $normalized
     if ($nightshiftContext -and
         $normalized -match '(?i)\.nightshift/(?:\.\*|\*|\?|\[|\{|\$|`)') {
         return $true
@@ -178,13 +179,33 @@ function Test-NSLeaseTarget {
     if ($nightshiftContext -and $normalized -match '(?i)\.(shift|lease|mutex)-(?:\*|\?|\[|\{|\$|`)') {
         return $true
     }
-    if ($normalized -match '(?i)(^|[;&|\s])(rm|rmdir|unlink|mv|Remove-Item|Move-Item|Rename-Item)([\s;&|]|$)' `
-        -and $normalized -match '(?i)(^|\s)(\./)?\.nightshift/?(\s|$)') {
+    if ($normalized -match '(?i)(^|[;&|()\s])(rm|rmdir|unlink|mv|Remove-Item|Move-Item|Rename-Item)\s+([^;&|\r\n]*\s+)?(\./)?\.nightshift/?([;&|()\s]|$)') {
         return $true
     }
     if ($normalized -match '(?i)(^|[;&|\s])find(\s|$)' -and $normalized -match '(?i)\.nightshift' `
         -and $normalized -match '(?i)(-delete|-exec)') {
         return $true
+    }
+    return $false
+}
+
+function Test-NSNightshiftDirContext {
+    param([AllowEmptyString()][string]$Normalized)
+    # `cd .nightshift && unlink .shift-armed` has no slash after the directory name.
+    if ($Normalized -match '(?i)\.nightshift([/\s;&]|$)') {
+        return $true
+    }
+    if ($Normalized -match '(?i)(^|[;&|()\s])(cd|pushd|Set-Location)(?:\s+-LiteralPath)?\s+[''"]?\.nightshift\b') {
+        return $true
+    }
+    $cwdValue = [string]$script:cwd
+    $nsValue = [string]$script:ns
+    if (-not [string]::IsNullOrEmpty($cwdValue) -and -not [string]::IsNullOrEmpty($nsValue)) {
+        $cwdNorm = $cwdValue.Replace('\', '/').TrimEnd('/')
+        $nsNorm = $nsValue.Replace('\', '/').TrimEnd('/')
+        if ($cwdNorm -eq $nsNorm -or $cwdNorm.StartsWith("$nsNorm/")) {
+            return $true
+        }
     }
     return $false
 }
@@ -201,6 +222,16 @@ function Test-NSControlListPath {
     return $normalized -match '(?i)(^|/|\.)nightshift/punch-list\.md(/|$|[^A-Za-z0-9_.-])'
 }
 
+function Test-NSControlRewriteName {
+    param([AllowEmptyString()][string]$Target)
+    return $Target -match '(?i)(^|[;&|()\s])(\./)?(STOP|\.shift-armed|\.ended|\.shift-session|work-target)([;&|()\s]|$)'
+}
+
+function Test-NSControlListName {
+    param([AllowEmptyString()][string]$Target)
+    return $Target -match '(?i)(^|[;&|()\s])(\./)?punch-list\.md([;&|()\s]|$)'
+}
+
 function Test-NSControlDeleteVerb {
     param([AllowEmptyString()][string]$Target)
     return $Target -match '(?i)(^|[;&|()\s])(rm|rmdir|unlink|mv|Remove-Item|Move-Item|Rename-Item)([\s]|$)'
@@ -212,7 +243,18 @@ function Test-NSControlTarget {
     if (Test-NSControlRewritePath $normalized) {
         return $true
     }
-    return (Test-NSControlListPath $normalized) -and (Test-NSControlDeleteVerb $normalized)
+    if ((Test-NSControlListPath $normalized) -and (Test-NSControlDeleteVerb $normalized)) {
+        return $true
+    }
+    if (Test-NSNightshiftDirContext $normalized) {
+        if (Test-NSControlRewriteName $normalized) {
+            return $true
+        }
+        if ((Test-NSControlListName $normalized) -and (Test-NSControlDeleteVerb $normalized)) {
+            return $true
+        }
+    }
+    return $false
 }
 
 function Convert-NSErePattern {
@@ -308,6 +350,14 @@ function Get-NSProspectiveGitPaths {
     }
     $env:GIT_INDEX_FILE = $copy
     try {
+        $before = Invoke-NSGitCommand $Repository @('ls-files', '--stage')
+        $beforePaths = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::Ordinal)
+        foreach ($line in $before.Lines) {
+            $tab = $line.IndexOf("`t")
+            if ($tab -ge 0) {
+                [void]$beforePaths.Add($line.Substring($tab + 1).Replace('\', '/'))
+            }
+        }
         $words = @($Command -split '\s+' | Where-Object { $_ -ne '' })
         $start = [array]::IndexOf($words, $Verb)
         if ($start -lt 0) { return $null }
@@ -322,46 +372,91 @@ function Get-NSProspectiveGitPaths {
                 continue
             }
             switch -Regex ($word) {
-                '^--$' { $rest = $true }
-                '^(--all|-A)$' { $form = $(if ($Verb -eq 'add') { 'all' } else { 'tracked' }) }
-                '^(--update|-u)$' { $form = 'tracked' }
-                '^(--include|-i)$' { if ($Verb -eq 'commit') { $form = 'include' } }
-                '^(--only|-o)$' { if ($Verb -eq 'commit') { $form = 'only' } }
-                '^(-m|--message|--file|--author|--date|--cleanup)$' { $skip = $true }
-                '^(--message=|--file=|--author=|--date=|MSG)' { }
-                '^(--allow-empty|--allow-empty-message|--no-verify|--no-edit|--quiet|--signoff|-q|-s|-n|--no-gpg-sign|--verbose|-v|--force|-f|--ignore-missing|--refresh)$' { }
-                '^-[[:alpha:]]*a[[:alpha:]]*$' { if ($Verb -eq 'commit') { $form = 'tracked' } }
+                '^--$' { $rest = $true; break }
+                '^(--all|-A)$' { $form = $(if ($Verb -eq 'add') { 'all' } else { 'tracked' }); break }
+                '^(--update|-u)$' { $form = 'tracked'; break }
+                '^(--include|-i)$' { if ($Verb -eq 'commit') { $form = 'include' }; break }
+                '^(--only|-o)$' { if ($Verb -eq 'commit') { $form = 'only' }; break }
+                '^(-m|--message|--file|--author|--date|--cleanup)$' { $skip = $true; break }
+                '^(--message=|--file=|--author=|--date=|MSG)' { break }
+                '^(--allow-empty|--allow-empty-message|--no-verify|--no-edit|--quiet|--signoff|-q|-s|-n|--no-gpg-sign|--verbose|-v|--force|-f|--ignore-missing|--refresh|--porcelain)$' { break }
+                # .NET has no POSIX [[:alpha:]]; clustered shorts like -am must use [A-Za-z].
+                '^-[A-Za-z]*a[A-Za-z]*$' { if ($Verb -eq 'commit') { $form = 'tracked' }; break }
+                '^-[A-Za-z]*i[A-Za-z]*$' { if ($Verb -eq 'commit') { $form = 'include' }; break }
+                '^-[A-Za-z]*o[A-Za-z]*$' { if ($Verb -eq 'commit') { $form = 'only' }; break }
+                '^-[A-Za-z]*A[A-Za-z]*$' { if ($Verb -eq 'add') { $form = 'all' }; break }
+                '^-[A-Za-z]*u[A-Za-z]*$' { if ($Verb -eq 'add') { $form = 'tracked' }; break }
                 '^-' { return $null }
-                default { if ($word -ne 'MSG') { $paths.Add($word) } }
+                default { if ($word -ne 'MSG') { $paths.Add($word) }; break }
             }
         }
         if ($Verb -eq 'commit' -and $paths.Count -gt 0 -and $form -eq 'index') { $form = 'only' }
+        $replay = $null
         switch ("$Verb-$form") {
-            'add-all' { $null = Invoke-NSGit $Repository @('add', '-A') }
-            'add-tracked' { $null = Invoke-NSGit $Repository @('add', '-u') }
-            'add-index' { if ($paths.Count -gt 0) { $null = Invoke-NSGit $Repository (@('add', '--') + $paths) } }
-            'commit-index' { }
-            'commit-tracked' { $null = Invoke-NSGit $Repository @('add', '-u') }
-            'commit-include' { if ($paths.Count -gt 0) { $null = Invoke-NSGit $Repository (@('add', '--') + $paths) } }
+            'add-all' { $replay = Invoke-NSGitCommand $Repository @('add', '-A') }
+            'add-tracked' { $replay = Invoke-NSGitCommand $Repository @('add', '-u') }
+            'add-index' {
+                if ($paths.Count -gt 0) { $replay = Invoke-NSGitCommand $Repository (@('add', '--') + @($paths)) }
+                else { $replay = [pscustomobject]@{ ExitCode = 0 } }
+            }
+            'commit-index' { $replay = [pscustomobject]@{ ExitCode = 0 } }
+            'commit-tracked' { $replay = Invoke-NSGitCommand $Repository @('add', '-u') }
+            'commit-include' {
+                if ($paths.Count -gt 0) { $replay = Invoke-NSGitCommand $Repository (@('add', '--') + @($paths)) }
+                else { $replay = [pscustomobject]@{ ExitCode = 0 } }
+            }
             'commit-only' {
-                $null = Invoke-NSGit $Repository @('read-tree', 'HEAD')
-                if ($paths.Count -gt 0) { $null = Invoke-NSGit $Repository (@('add', '--') + $paths) }
+                $replay = Invoke-NSGitCommand $Repository @('read-tree', 'HEAD')
+                if ($null -eq $replay -or $replay.ExitCode -ne 0) {
+                    $replay = Invoke-NSGitCommand $Repository @('read-tree', '--empty')
+                }
+                if ($null -ne $replay -and $replay.ExitCode -eq 0 -and $paths.Count -gt 0) {
+                    $replay = Invoke-NSGitCommand $Repository (@('add', '--') + @($paths))
+                }
             }
             default { return $null }
         }
+        if ($null -eq $replay -or $replay.ExitCode -ne 0) {
+            return $null
+        }
         if ($AsDiff) {
-            $diff = Invoke-NSGit $Repository @('diff', '--cached', '--no-ext-diff', 'HEAD')
+            $diff = Get-NSGitDiffText $Repository @('diff', '--cached', '--no-ext-diff', 'HEAD')
             if ($null -eq $diff) {
-                $diff = Invoke-NSGit $Repository @('diff', '--cached', '--no-ext-diff')
+                $diff = Get-NSGitDiffText $Repository @('diff', '--cached', '--no-ext-diff')
             }
             return $diff
         }
-        $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff', 'HEAD')
-        if ([string]::IsNullOrEmpty($listed)) {
-            $listed = Invoke-NSGit $Repository @('diff', '--cached', '--name-only', '-z', '--no-ext-diff')
+        $changed = New-Object System.Collections.Generic.List[string]
+        if ($Verb -eq 'add') {
+            $after = Invoke-NSGitCommand $Repository @('ls-files', '--stage')
+            $afterPaths = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::Ordinal)
+            $beforeLines = New-Object 'System.Collections.Generic.HashSet[string]' ([StringComparer]::Ordinal)
+            foreach ($line in $before.Lines) {
+                [void]$beforeLines.Add($line)
+            }
+            foreach ($line in $after.Lines) {
+                $tab = $line.IndexOf("`t")
+                if ($tab -ge 0) {
+                    $path = $line.Substring($tab + 1).Replace('\', '/')
+                    [void]$afterPaths.Add($path)
+                    if (-not $beforeLines.Contains($line)) {
+                        $changed.Add($path)
+                    }
+                }
+            }
+            foreach ($path in $beforePaths) {
+                if (-not $afterPaths.Contains($path)) {
+                    $changed.Add($path)
+                }
+            }
+            return @($changed | Select-Object -Unique)
+        }
+        $listed = Get-NSGitDiffText $Repository @('diff', '--cached', '--name-only', '--no-ext-diff', 'HEAD')
+        if ($null -eq $listed) {
+            $listed = Get-NSGitDiffText $Repository @('diff', '--cached', '--name-only', '--no-ext-diff')
         }
         if ([string]::IsNullOrEmpty($listed)) { return @() }
-        return @($listed -split "`0" | Where-Object { -not [string]::IsNullOrEmpty($_) })
+        return @($listed -split "(`r`n|`n|`0)" | Where-Object { -not [string]::IsNullOrEmpty($_) })
     }
     finally {
         Remove-Item -LiteralPath $env:GIT_INDEX_FILE -ErrorAction SilentlyContinue
@@ -470,6 +565,10 @@ function Get-NSCommandDenyReason {
         return 'BLOCKED: this command matches forbiddenCommands for the active shift. Do not retry a rephrased form.'
     }
     return ''
+}
+
+if ($env:NIGHTSHIFT_HARDHAT_LIB -eq '1') {
+    return
 }
 
 $raw = Get-NSStdinText -Piped $HookJson

--- a/plugins/nightshift/hooks/windows/hardhat.ps1
+++ b/plugins/nightshift/hooks/windows/hardhat.ps1
@@ -189,6 +189,32 @@ function Test-NSLeaseTarget {
     return $false
 }
 
+function Test-NSControlRewritePath {
+    param([AllowEmptyString()][string]$Target)
+    $normalized = $Target.Replace('\', '/').Replace('"', '').Replace("'", '')
+    return $normalized -match '(?i)(^|/|\.)nightshift/(STOP|\.shift-armed|\.ended|\.shift-session|work-target)(/|$|[^A-Za-z0-9_.-])'
+}
+
+function Test-NSControlListPath {
+    param([AllowEmptyString()][string]$Target)
+    $normalized = $Target.Replace('\', '/').Replace('"', '').Replace("'", '')
+    return $normalized -match '(?i)(^|/|\.)nightshift/punch-list\.md(/|$|[^A-Za-z0-9_.-])'
+}
+
+function Test-NSControlDeleteVerb {
+    param([AllowEmptyString()][string]$Target)
+    return $Target -match '(?i)(^|[;&|()\s])(rm|rmdir|unlink|mv|Remove-Item|Move-Item|Rename-Item)([\s]|$)'
+}
+
+function Test-NSControlTarget {
+    param([AllowEmptyString()][string]$Target)
+    $normalized = $Target.Replace('\', '/').Replace('"', '').Replace("'", '')
+    if (Test-NSControlRewritePath $normalized) {
+        return $true
+    }
+    return (Test-NSControlListPath $normalized) -and (Test-NSControlDeleteVerb $normalized)
+}
+
 function Convert-NSErePattern {
     param([Parameter(Mandatory = $true)][string]$Pattern)
     $result = $Pattern.Replace('[[:space:]]', '\s')
@@ -487,6 +513,18 @@ catch {
 foreach ($target in $targets) {
     if (Test-NSRulesTarget ([string]$target)) {
         Write-Deny 'BLOCKED: the rules file is the owner''s - the night neither reads nor rewrites its own rules. Park the need in .nightshift/parking-lot.md and keep working.'
+    }
+}
+
+$controlPassive = $tool -in @(
+    'Read', 'Grep', 'Glob', 'LS', 'WebFetch', 'WebSearch', 'Task', 'TodoWrite',
+    'AskUserQuestion', 'request_user_input', 'NotebookRead'
+) -or $tool -match '(?i)read'
+if (-not $controlPassive) {
+    foreach ($target in $targets) {
+        if (Test-NSControlTarget ([string]$target)) {
+            Write-Deny 'BLOCKED: shift control files are owner-owned while the night is armed. Do not delete or forge .shift-armed, .ended, STOP, .shift-session, or work-target, and do not delete the punch list. Park the need in .nightshift/parking-lot.md and keep working.'
+        }
     }
 }
 

--- a/plugins/nightshift/lib/lib.sh
+++ b/plugins/nightshift/lib/lib.sh
@@ -187,6 +187,179 @@ commit_stages_implicitly() {
   return 1
 }
 
+# ns_git_verb_tail <command> <add|commit>
+# Print the words after that git verb. Return 1 when the verb is absent.
+ns_git_verb_tail() {
+  local cmd="$1" verb="$2" seen=0 word
+  # shellcheck disable=SC2086
+  set -- $cmd
+  for word in "$@"; do
+    if [ "$seen" -eq 1 ]; then
+      printf '%s\n' "$word"
+      continue
+    fi
+    [ "$word" = "$verb" ] && seen=1
+  done
+  [ "$seen" -eq 1 ]
+}
+
+# ns_path_under_protected <path> <protectedDirs>
+ns_path_under_protected() {
+  local path="${1#./}" d
+  path="${path#./}"
+  IFS=' |' read -ra _ns_pd_dirs <<<"$2"
+  for d in "${_ns_pd_dirs[@]}"; do
+    [ -n "$d" ] || continue
+    d="${d#./}"
+    case "$path" in
+      "$d" | "$d"/* | */"$d" | */"$d"/*) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+# Replay add/commit against a copied index so guards can ask Git what would be written
+# without mutating the real index. 0 = prepared ($NS_GIT_PROSP_DIR, GIT_INDEX_FILE),
+# 1 = no-op / empty, 2 = cannot model this command (fail closed).
+ns_git_prospective_prepare() { # <repo> <command> <add|commit>
+  local repo="$1" cmd="$2" verb="$3" tmp src word rest=0 skip=0 form=index
+  local -a paths=()
+  NS_GIT_PROSP_DIR=""
+  tmp="$(mktemp -d "${TMPDIR:-/tmp}/ns-git.XXXXXX")" || return 2
+  src="$(git -C "$repo" rev-parse --absolute-git-dir 2>/dev/null)" || { rm -rf "$tmp"; return 2; }
+  src="$src/index"
+  if [ -f "$src" ]; then
+    cp "$src" "$tmp/index" || { rm -rf "$tmp"; return 2; }
+  fi
+  export GIT_INDEX_FILE="$tmp/index"
+  NS_GIT_PROSP_DIR="$tmp"
+  git -C "$repo" ls-files --stage -z >"$tmp/before" 2>/dev/null || :
+
+  while IFS= read -r word; do
+    [ -n "$word" ] || continue
+    if [ "$skip" -eq 1 ]; then
+      skip=0
+      continue
+    fi
+    if [ "$rest" -eq 1 ]; then
+      [ "$word" = MSG ] || paths+=("$word")
+      continue
+    fi
+    case "$word" in
+      --) rest=1 ;;
+      --all | -A)
+        if [ "$verb" = add ]; then form=all
+        else form=tracked
+        fi
+        ;;
+      --update | -u) form=tracked ;;
+      --include | -i) [ "$verb" = commit ] && form=include ;;
+      --only | -o) [ "$verb" = commit ] && form=only ;;
+      -m | --message | --file | --author | --date | --cleanup)
+        skip=1
+        ;;
+      --message=* | --file=* | --author=* | --date=* | MSG) ;;
+      --allow-empty | --allow-empty-message | --no-verify | --no-edit | --quiet | --signoff | -q | -s | -n | --no-gpg-sign | --porcelain | --verbose | -v | --force | -f | --ignore-missing | --refresh)
+        ;;
+      --amend | --patch | -p | --interactive | --chmod=* | --edit | -e | --fixup | --squash | --reuse-message | --reedit-message)
+        ns_git_prospective_cleanup
+        return 2
+        ;;
+      -*)
+        if [ "$verb" = commit ] && printf '%s' "$word" | grep -qE '^-[[:alpha:]]*a[[:alpha:]]*$'; then
+          form=tracked
+        elif [ "$verb" = commit ] && printf '%s' "$word" | grep -qE '^-[[:alpha:]]*i[[:alpha:]]*$'; then
+          form=include
+        elif [ "$verb" = commit ] && printf '%s' "$word" | grep -qE '^-[[:alpha:]]*o[[:alpha:]]*$'; then
+          form=only
+        elif [ "$verb" = add ] && printf '%s' "$word" | grep -qE '^-[[:alpha:]]*A[[:alpha:]]*$'; then
+          form=all
+        elif [ "$verb" = add ] && printf '%s' "$word" | grep -qE '^-[[:alpha:]]*u[[:alpha:]]*$'; then
+          form=tracked
+        else
+          ns_git_prospective_cleanup
+          return 2
+        fi
+        ;;
+      *) [ "$word" = MSG ] || paths+=("$word") ;;
+    esac
+  done < <(ns_git_verb_tail "$cmd" "$verb")
+
+  if [ "$verb" = commit ] && [ "${#paths[@]}" -gt 0 ] && [ "$form" = index ]; then
+    form=only
+  fi
+
+  case "$verb-$form" in
+    add-index)
+      if [ "${#paths[@]}" -eq 0 ]; then
+        :
+      else
+        git -C "$repo" add -- "${paths[@]}" >/dev/null 2>&1 || { ns_git_prospective_cleanup; return 2; }
+      fi
+      ;;
+    add-all) git -C "$repo" add -A >/dev/null 2>&1 || { ns_git_prospective_cleanup; return 2; } ;;
+    add-tracked) git -C "$repo" add -u >/dev/null 2>&1 || { ns_git_prospective_cleanup; return 2; } ;;
+    commit-index) ;;
+    commit-tracked) git -C "$repo" add -u >/dev/null 2>&1 || { ns_git_prospective_cleanup; return 2; } ;;
+    commit-include)
+      if [ "${#paths[@]}" -gt 0 ]; then
+        git -C "$repo" add -- "${paths[@]}" >/dev/null 2>&1 || { ns_git_prospective_cleanup; return 2; }
+      fi
+      ;;
+    commit-only)
+      git -C "$repo" read-tree HEAD >/dev/null 2>&1 || git -C "$repo" read-tree --empty >/dev/null 2>&1 || {
+        ns_git_prospective_cleanup
+        return 2
+      }
+      if [ "${#paths[@]}" -gt 0 ]; then
+        git -C "$repo" add -- "${paths[@]}" >/dev/null 2>&1 || { ns_git_prospective_cleanup; return 2; }
+      fi
+      ;;
+    *) ns_git_prospective_cleanup; return 2 ;;
+  esac
+  return 0
+}
+
+ns_git_prospective_cleanup() {
+  [ -n "${NS_GIT_PROSP_DIR:-}" ] && rm -rf "$NS_GIT_PROSP_DIR"
+  unset GIT_INDEX_FILE NS_GIT_PROSP_DIR
+}
+
+# Print NUL-delimited paths this add/commit would write. 2 = cannot model.
+ns_git_prospective_paths() { # <repo> <command> <add|commit>
+  local repo="$1" cmd="$2" verb="$3" rc line
+  ns_git_prospective_prepare "$repo" "$cmd" "$verb"
+  rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
+  if [ "$verb" = add ]; then
+    tr '\0' '\n' <"$NS_GIT_PROSP_DIR/before" >"$NS_GIT_PROSP_DIR/before.nl" 2>/dev/null || :
+    git -C "$repo" ls-files --stage -z 2>/dev/null | tr '\0' '\n' | while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      grep -F -x -- "$line" "$NS_GIT_PROSP_DIR/before.nl" >/dev/null 2>&1 && continue
+      printf '%s\0' "${line#*	}"
+    done
+  else
+    git -C "$repo" diff --cached --name-only -z --no-ext-diff HEAD 2>/dev/null \
+      || git -C "$repo" diff --cached --name-only -z --no-ext-diff 2>/dev/null \
+      || true
+  fi
+  ns_git_prospective_cleanup
+  return 0
+}
+
+# Print the diff this commit would write. 2 = cannot model.
+ns_git_prospective_diff() { # <repo> <command>
+  local repo="$1" cmd="$2" rc
+  ns_git_prospective_prepare "$repo" "$cmd" commit
+  rc=$?
+  [ "$rc" -eq 0 ] || return "$rc"
+  git -C "$repo" diff --cached --no-ext-diff HEAD 2>/dev/null \
+    || git -C "$repo" diff --cached --no-ext-diff 2>/dev/null \
+    || true
+  ns_git_prospective_cleanup
+  return 0
+}
+
 # valid_ere <pattern> — true when grep -E accepts the pattern.
 # An invalid pattern makes grep exit 2, which reads exactly like "no match" to a plain `if`,
 # so a typo in an owner's guard pattern would silently disable the guard.

--- a/plugins/nightshift/lib/lib.sh
+++ b/plugins/nightshift/lib/lib.sh
@@ -327,17 +327,26 @@ ns_git_prospective_cleanup() {
 
 # Print NUL-delimited paths this add/commit would write. 2 = cannot model.
 ns_git_prospective_paths() { # <repo> <command> <add|commit>
-  local repo="$1" cmd="$2" verb="$3" rc line
+  local repo="$1" cmd="$2" verb="$3" rc line _path
   ns_git_prospective_prepare "$repo" "$cmd" "$verb"
   rc=$?
   [ "$rc" -eq 0 ] || return "$rc"
   if [ "$verb" = add ]; then
     tr '\0' '\n' <"$NS_GIT_PROSP_DIR/before" >"$NS_GIT_PROSP_DIR/before.nl" 2>/dev/null || :
-    git -C "$repo" ls-files --stage -z 2>/dev/null | tr '\0' '\n' | while IFS= read -r line; do
+    git -C "$repo" ls-files --stage -z 2>/dev/null | tr '\0' '\n' >"$NS_GIT_PROSP_DIR/after.nl" || :
+    while IFS= read -r line; do
       [ -n "$line" ] || continue
       grep -F -x -- "$line" "$NS_GIT_PROSP_DIR/before.nl" >/dev/null 2>&1 && continue
       printf '%s\0' "${line#*	}"
-    done
+    done <"$NS_GIT_PROSP_DIR/after.nl"
+    # A deletion has no after-index entry, so the loop above never emits it.
+    sed 's/^[^	]*	//' "$NS_GIT_PROSP_DIR/after.nl" | sort -u >"$NS_GIT_PROSP_DIR/after.paths"
+    while IFS= read -r line; do
+      [ -n "$line" ] || continue
+      _path="${line#*	}"
+      grep -F -x -- "$_path" "$NS_GIT_PROSP_DIR/after.paths" >/dev/null 2>&1 && continue
+      printf '%s\0' "$_path"
+    done <"$NS_GIT_PROSP_DIR/before.nl"
   else
     git -C "$repo" diff --cached --name-only -z --no-ext-diff HEAD 2>/dev/null \
       || git -C "$repo" diff --cached --name-only -z --no-ext-diff 2>/dev/null \

--- a/tests/clock-out-gate.bats
+++ b/tests/clock-out-gate.bats
@@ -18,6 +18,8 @@ load helpers
   p="$(new_project)"
   run gate "$p"
   is_release
+  [ -f "$p/.nightshift/.ended" ]
+  [ ! -f "$p/.nightshift/.shift-armed" ]
 }
 
 @test "stop-work order releases even with open boxes" {

--- a/tests/codex/gate.bats
+++ b/tests/codex/gate.bats
@@ -46,6 +46,15 @@ codex_gate() {
   is_codex_release
 }
 
+@test "codex gate missing punch list still ends through end_shift" {
+  p="$(new_project)"
+  rm -f "$p/.nightshift/punch-list.md"
+  run codex_gate "$p"
+  is_codex_release
+  [ -f "$p/.nightshift/.ended" ]
+  [ ! -f "$p/.nightshift/.shift-armed" ]
+}
+
 @test "codex gate honors a stop-work order even with open boxes" {
   p="$(new_project)"
   punch_open "$p"

--- a/tests/codex/hardhat.bats
+++ b/tests/codex/hardhat.bats
@@ -226,12 +226,21 @@ codex_hardhat_ask() {
   git -C "$p" add ai_docs/secret.txt
   run codex_hardhat_bash "$p" "git commit -m protected-bypass" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
   is_deny "$output"
+  git -C "$p" add ai_docs/secret.txt
+  git -C "$p" commit -q -m protected
+  rm -f "$p/ai_docs/secret.txt"
+  run codex_hardhat_bash "$p" "git add -A" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
 }
 
 @test "the bound worker cannot unlink the armed marker or delete the punch list" {
   p="$(new_project)"
   punch_open "$p"
   run codex_hardhat_bash "$p" "unlink .nightshift/.shift-armed"
+  is_deny "$output"
+  run codex_hardhat_bash "$p" "cd .nightshift && unlink .shift-armed"
+  is_deny "$output"
+  run codex_hardhat_bash "$p" "cd .nightshift && touch STOP"
   is_deny "$output"
   run codex_hardhat_bash "$p" "rm .nightshift/punch-list.md"
   is_deny "$output"

--- a/tests/codex/hardhat.bats
+++ b/tests/codex/hardhat.bats
@@ -205,6 +205,15 @@ codex_hardhat_ask() {
 
 # Codex delivers file edits as apply_patch with the patch text in tool_input.command; the
 # payload's cwd is the documented way a hook finds the project — no env override here.
+@test "the bound worker cannot unlink the armed marker or delete the punch list" {
+  p="$(new_project)"
+  punch_open "$p"
+  run codex_hardhat_bash "$p" "unlink .nightshift/.shift-armed"
+  is_deny "$output"
+  run codex_hardhat_bash "$p" "rm .nightshift/punch-list.md"
+  is_deny "$output"
+}
+
 @test "an apply_patch aimed at the rules file is denied" {
   p="$(new_project)"
   punch_open "$p"

--- a/tests/codex/hardhat.bats
+++ b/tests/codex/hardhat.bats
@@ -205,6 +205,18 @@ codex_hardhat_ask() {
 
 # Codex delivers file edits as apply_patch with the patch text in tool_input.command; the
 # payload's cwd is the documented way a hook finds the project — no env override here.
+@test "protectedDirs inspects Git paths on Codex too" {
+  p="$(new_project)"
+  punch_open "$p"
+  mkdir -p "$p/ai_docs"
+  printf 'secret\n' >"$p/ai_docs/secret.txt"
+  run codex_hardhat_bash "$p" "git add -A" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
+  git -C "$p" add ai_docs/secret.txt
+  run codex_hardhat_bash "$p" "git commit -m protected-bypass" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
+}
+
 @test "the bound worker cannot unlink the armed marker or delete the punch list" {
   p="$(new_project)"
   punch_open "$p"

--- a/tests/codex/hardhat.bats
+++ b/tests/codex/hardhat.bats
@@ -205,6 +205,17 @@ codex_hardhat_ask() {
 
 # Codex delivers file edits as apply_patch with the patch text in tool_input.command; the
 # payload's cwd is the documented way a hook finds the project — no env override here.
+@test "neverCommitPatterns inspects a pathspec commit on Codex" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'clean\n' >"$p/leak.txt"
+  git -C "$p" add leak.txt
+  git -C "$p" commit -q -m seed
+  printf 'API_KEY=sk-secret\n' >"$p/leak.txt"
+  run codex_hardhat_bash "$p" "git commit -m pathspec-bypass leak.txt" NIGHTSHIFT_NEVER_COMMIT_PATTERNS="sk-secret"
+  is_deny "$output"
+}
+
 @test "protectedDirs inspects Git paths on Codex too" {
   p="$(new_project)"
   punch_open "$p"

--- a/tests/github-templates.bats
+++ b/tests/github-templates.bats
@@ -32,20 +32,25 @@ parse_yaml() {
   grep -qF 'id: logs' "$FAILED"
 }
 
-@test "the failed-shift form redacts secrets and routes bypasses privately" {
+@test "the failed-shift form redacts secrets and keeps an optional private path" {
   grep -qF 'Do not paste' "$FAILED"
   grep -qF 'prompts, credentials' "$FAILED"
   grep -qF 'full session transcript' "$FAILED"
   grep -qF 'https://github.com/orwa-mahmoud/nightshift/security/advisories/new' "$FAILED"
   grep -qF 'https://github.com/orwa-mahmoud/nightshift/blob/main/SECURITY.md' "$FAILED"
   grep -qF 'I have removed prompts, credentials, repository content, and full transcripts' "$FAILED"
+  grep -qF 'Local guard and gate reports are public issues' "$FAILED"
   ! grep -qi 'paste the full transcript' "$FAILED"
   ! grep -qi 'include your prompt' "$FAILED"
+  ! grep -qi 'those go to a private advisory' "$FAILED"
 }
 
-@test "SECURITY.md points failed nights at the form and bypasses at advisories" {
+@test "SECURITY.md points failed nights at the form and keeps an optional advisory" {
+  grep -qF 'A public issue is the default' "$SECURITY"
+  grep -qF 'A private advisory is optional' "$SECURITY"
   grep -qF 'issues/new?template=failed_shift.yml' "$SECURITY"
   grep -qF 'security/advisories/new' "$SECURITY"
+  ! grep -qi 'do not open a public issue' "$SECURITY"
   [ -f "$FAILED" ]
 }
 

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -104,6 +104,23 @@ load helpers
   is_deny "$output"
 }
 
+@test "neverCommitPatterns inspects the exact commit Git would write" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'clean\n' >"$p/leak.txt"
+  git -C "$p" add leak.txt
+  git -C "$p" commit -q -m seed
+  printf 'API_KEY=sk-secret\n' >"$p/leak.txt"
+  run hardhat_bash "$p" "git commit -m pathspec-bypass leak.txt" NIGHTSHIFT_NEVER_COMMIT_PATTERNS="sk-secret|API_KEY"
+  is_deny "$output"
+  run hardhat_bash "$p" "git commit -m x --only leak.txt" NIGHTSHIFT_NEVER_COMMIT_PATTERNS="sk-secret"
+  is_deny "$output"
+  run hardhat_bash "$p" "git commit -m x --include leak.txt" NIGHTSHIFT_NEVER_COMMIT_PATTERNS="sk-secret"
+  is_deny "$output"
+  run hardhat_bash "$p" "git commit -m index-only" NIGHTSHIFT_NEVER_COMMIT_PATTERNS="sk-secret"
+  is_allow
+}
+
 @test "never-commit pattern check is skipped when unset" {
   p="$(new_project)"
   punch_open "$p"

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -37,7 +37,40 @@ load helpers
 @test "protected-dir git write is denied when configured" {
   p="$(new_project)"
   punch_open "$p"
+  mkdir -p "$p/ai_docs"
+  printf 'secret\n' >"$p/ai_docs/secret"
   run hardhat_bash "$p" "git add ai_docs/secret" NIGHTSHIFT_PROTECTED_DIRS="ai_docs notes"
+  is_deny "$output"
+}
+
+@test "protectedDirs inspects the paths Git would add or commit" {
+  p="$(new_project)"
+  punch_open "$p"
+  mkdir -p "$p/ai_docs"
+  printf 'secret\n' >"$p/ai_docs/secret.txt"
+  run hardhat_bash "$p" "git add -A" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
+  run hardhat_bash "$p" "git add ." NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
+  git -C "$p" add ai_docs/secret.txt
+  run hardhat_bash "$p" "git commit -m protected-bypass" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
+  git -C "$p" reset -q
+  printf 'also\n' >"$p/tracked.txt"
+  git -C "$p" add tracked.txt
+  git -C "$p" commit -q -m seed
+  printf 'dirty\n' >"$p/tracked.txt"
+  mkdir -p "$p/ai_docs"
+  printf 'secret\n' >"$p/ai_docs/secret.txt"
+  git -C "$p" add ai_docs/secret.txt
+  run hardhat_bash "$p" "git commit -am all" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
+  git -C "$p" reset -q
+  printf 'safe\n' >"$p/ok.txt"
+  git -C "$p" add ok.txt
+  run hardhat_bash "$p" "git commit -m ok" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_allow
+  run hardhat_bash "$p" "git tag ai_docs" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
   is_deny "$output"
 }
 

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -72,6 +72,13 @@ load helpers
   is_allow
   run hardhat_bash "$p" "git tag ai_docs" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
   is_deny "$output"
+  mkdir -p "$p/ai_docs"
+  printf 'secret\n' >"$p/ai_docs/secret.txt"
+  git -C "$p" add ai_docs/secret.txt
+  git -C "$p" commit -q -m protected
+  rm -f "$p/ai_docs/secret.txt"
+  run hardhat_bash "$p" "git add -A" NIGHTSHIFT_PROTECTED_DIRS="ai_docs"
+  is_deny "$output"
 }
 
 @test "protected-dir check is skipped when unset" {
@@ -683,6 +690,14 @@ STUB
   run hardhat_bash "$p" "unlink .nightshift/.shift-armed"
   is_deny "$output"
   printf '%s' "$output" | grep -q "control files"
+  run hardhat_bash "$p" "cd .nightshift && unlink .shift-armed"
+  is_deny "$output"
+  run hardhat_bash "$p" "cd .nightshift && touch STOP"
+  is_deny "$output"
+  run hardhat_bash "$p" "touch STOP"
+  is_allow
+  run hardhat_bash "$p" "unlink .shift-armed"
+  is_allow
   run hardhat_bash "$p" "touch .nightshift/STOP"
   is_deny "$output"
   run hardhat_bash "$p" "echo ended > .nightshift/.ended"

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -627,6 +627,50 @@ STUB
   [ -z "$out" ] # no shift, no rules — the owner edits freely
 }
 
+@test "the bound worker cannot delete or forge armed-shift control files" {
+  p="$(new_project)"
+  punch_open "$p"
+  run hardhat_bash "$p" "unlink .nightshift/.shift-armed"
+  is_deny "$output"
+  printf '%s' "$output" | grep -q "control files"
+  run hardhat_bash "$p" "touch .nightshift/STOP"
+  is_deny "$output"
+  run hardhat_bash "$p" "echo ended > .nightshift/.ended"
+  is_deny "$output"
+  run hardhat_bash "$p" "echo /tmp/other > .nightshift/work-target"
+  is_deny "$output"
+  run hardhat_bash "$p" "rm -f .nightshift/punch-list.md"
+  is_deny "$output"
+  out="$(jq -nc --arg fp "$p/.nightshift/.shift-session" '{tool_name:"Write",tool_input:{file_path:$fp,content:"forged"}}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  is_deny "$out"
+}
+
+@test "punch-list ticks stay allowed and Start can still create the armed marker" {
+  p="$(new_project)"
+  punch_open "$p"
+  out="$(jq -nc --arg fp "$p/.nightshift/punch-list.md" '{tool_name:"Write",tool_input:{file_path:$fp,content:"## Items\n- [x] **1.**\n"}}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ]
+  run hardhat_bash "$p" "printf 'ticked\n' >> .nightshift/punch-list.md"
+  is_allow
+  rm "$p/.nightshift/.shift-armed"
+  run hardhat_bash "$p" "touch .nightshift/.shift-armed"
+  is_allow
+}
+
+@test "a helper session can still issue STOP" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf 'the-shift\n\n\n\n' >"$p/.nightshift/.shift-session"
+  out="$(jq -nc --arg fp "$p/.nightshift/STOP" '{tool_name:"Write",session_id:"helper-tab",tool_input:{file_path:$fp,content:"stop"}}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ]
+  out="$(jq -nc '{tool_name:"Bash",session_id:"helper-tab",tool_input:{command:"touch .nightshift/STOP"}}' |
+    env CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh")"
+  [ -z "$out" ]
+}
+
 # No readable rules is a fault, never permission to invent an ask policy.
 @test "a missing rules file denies the question and names the repair" {
   p="$(new_project)"

--- a/tests/windows/hardhat-logic.ps1
+++ b/tests/windows/hardhat-logic.ps1
@@ -1,0 +1,104 @@
+# Portable PowerShell probe for Windows hardhat command guards.
+# Run on macOS or Windows before pushing: pwsh -File tests/windows/hardhat-logic.ps1
+# It does not replace windows-native CI (ACLs, mutexes, dispatchers).
+Set-StrictMode -Version 2.0
+$ErrorActionPreference = 'Stop'
+
+$repository = Resolve-Path (Join-Path $PSScriptRoot '../..')
+$hardhat = Join-Path $repository 'plugins/nightshift/hooks/windows/hardhat.ps1'
+$failures = New-Object 'System.Collections.Generic.List[string]'
+
+function Expect-True {
+    param([bool]$Condition, [string]$Message)
+    if (-not $Condition) {
+        $failures.Add($Message)
+        Write-Host "FAIL: $Message"
+    }
+}
+
+$env:NIGHTSHIFT_HARDHAT_LIB = '1'
+. $hardhat -HostName codex
+
+$root = Join-Path ([IO.Path]::GetTempPath()) ("ns-hardhat-logic-" + [guid]::NewGuid().ToString('N'))
+$null = New-Item -ItemType Directory -Path $root -Force
+try {
+    Set-Location $root
+    $null = & git init --quiet
+    $null = & git config user.email dev@example.com
+    $null = & git config user.name tester
+    $null = & git config core.autocrlf false
+    [IO.File]::WriteAllText((Join-Path $root 'tracked.txt'), "seed`n")
+    $null = & git add -- tracked.txt
+    $null = & git commit --quiet -m init
+
+    $script:cwd = $root
+    $script:ns = Join-Path $root '.nightshift'
+
+    Expect-True (Test-NSControlTarget 'Remove-Item -Force .nightshift\.shift-armed') `
+        'backslash control path is denied'
+    Expect-True (Test-NSControlTarget 'cd .nightshift && unlink .shift-armed') `
+        'cd .nightshift && unlink .shift-armed is a control target'
+    Expect-True (-not (Test-NSLeaseTarget 'cd .nightshift && unlink .shift-armed')) `
+        'cd .nightshift && unlink .shift-armed is not rm .nightshift'
+    Expect-True (Test-NSControlTarget 'cd .nightshift && touch STOP') `
+        'cd .nightshift && touch STOP is a control target'
+    Expect-True (-not (Test-NSControlTarget 'touch STOP')) `
+        'touch STOP at repo root is not a control target'
+    Expect-True (Test-NSLeaseTarget 'rm -rf .nightshift') `
+        'rm -rf .nightshift is a lease target'
+    Expect-True (Test-NSLeaseTarget 'Remove-Item -Force .nightshift\.shift-*') `
+        'indirect lease glob is a lease target'
+
+    $null = New-Item -ItemType Directory -Path (Join-Path $root 'ai_docs') -Force
+    [IO.File]::WriteAllText((Join-Path $root 'ai_docs/secret.txt'), "secret`n")
+    $addAll = Get-NSCommandDenyReason -Command 'git add -A' -Scrubbed 'git add -A' `
+        -CurrentDirectory $root -Workspace $root -ProtectedDirectories 'ai_docs' `
+        -ExpectedEmail '' -NeverCommitPatterns '' -ForbiddenCommands ''
+    Expect-True ($addAll -match 'protected directory') "git add -A: $addAll"
+
+    $null = & git add -- ai_docs/secret.txt
+    $null = & git commit --quiet -m protected
+    Remove-Item -LiteralPath (Join-Path $root 'ai_docs/secret.txt') -Force
+    $addDeleted = Get-NSCommandDenyReason -Command 'git add -A' -Scrubbed 'git add -A' `
+        -CurrentDirectory $root -Workspace $root -ProtectedDirectories 'ai_docs' `
+        -ExpectedEmail '' -NeverCommitPatterns '' -ForbiddenCommands ''
+    Expect-True ($addDeleted -match 'protected directory') "git add -A deletion: $addDeleted"
+
+    [IO.File]::WriteAllText((Join-Path $root 'secret.txt'), "SECRET_KEY=abc`n")
+    $null = & git add -- secret.txt
+    $commitStaged = Get-NSCommandDenyReason -Command 'git commit -m x' -Scrubbed 'git commit -m MSG' `
+        -CurrentDirectory $root -Workspace $root -ProtectedDirectories '' `
+        -ExpectedEmail '' -NeverCommitPatterns 'secret_key' -ForbiddenCommands ''
+    Expect-True ($commitStaged -match 'neverCommitPatterns') "staged never-commit: $commitStaged"
+
+    $null = & git reset --quiet HEAD -- secret.txt
+    $commitAm = Get-NSCommandDenyReason -Command 'git commit -am x' -Scrubbed 'git commit -am MSG' `
+        -CurrentDirectory $root -Workspace $root -ProtectedDirectories '' `
+        -ExpectedEmail '' -NeverCommitPatterns 'secret_key' -ForbiddenCommands ''
+    Expect-True ($commitAm -notmatch 'cannot verify') "git commit -am is modeled: $commitAm"
+    Expect-True ($commitAm -match 'neverCommitPatterns') "git commit -am never-commit: $commitAm"
+
+    Remove-Item -LiteralPath (Join-Path $root 'secret.txt') -Force
+    $commitClean = Get-NSCommandDenyReason -Command 'git commit -am x' -Scrubbed 'git commit -am MSG' `
+        -CurrentDirectory $root -Workspace $root -ProtectedDirectories '' `
+        -ExpectedEmail '' -NeverCommitPatterns 'secret_key' -ForbiddenCommands ''
+    Expect-True ([string]::IsNullOrWhiteSpace($commitClean)) "clean git commit -am: $commitClean"
+
+    $push = Get-NSCommandDenyReason -Command 'git push origin HEAD' -Scrubbed 'git push origin HEAD' `
+        -CurrentDirectory $root -Workspace $root -ProtectedDirectories '' `
+        -ExpectedEmail '' -NeverCommitPatterns '' -ForbiddenCommands 'git .*push'
+    Expect-True ($push -match 'forbidden') "forbidden push: $push"
+}
+finally {
+    Set-Location $repository
+    Remove-Item -LiteralPath $root -Recurse -Force -ErrorAction SilentlyContinue
+    Remove-Item Env:NIGHTSHIFT_HARDHAT_LIB -ErrorAction SilentlyContinue
+}
+
+if ($failures.Count -gt 0) {
+    Write-Host "hardhat-logic failed ($($failures.Count)):"
+    foreach ($failure in $failures) { Write-Host " - $failure" }
+    exit 1
+}
+Write-Host 'hardhat-logic passed'
+exit 0

--- a/tests/windows/run.ps1
+++ b/tests/windows/run.ps1
@@ -506,6 +506,13 @@ try {
 
     $rulesRead = Invoke-Hardhat $workspace $sessionId 'Read' @{ path = (Join-Path $workspace '.nightshift/rules.json') }
     Assert-True ($rulesRead.Stdout -match 'rules file is the owner') 'rules reads are denied during a shift'
+    $armedDelete = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'Remove-Item -Force .nightshift\.shift-armed' }
+    Assert-True ($armedDelete.Stdout -match 'control files') 'bound worker cannot delete .shift-armed'
+    $punchTick = Invoke-Hardhat $workspace $sessionId 'Write' @{
+        path = (Join-Path $workspace '.nightshift/punch-list.md')
+        content = "## Items`n- [x] **1.**`n"
+    }
+    Assert-True ([string]::IsNullOrEmpty($punchTick.Stdout)) 'punch-list ticks stay allowed'
 
     $forbidden = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'git push origin HEAD' } `
         @{ NIGHTSHIFT_FORBIDDEN_COMMANDS = 'git .*push' }

--- a/tests/windows/run.ps1
+++ b/tests/windows/run.ps1
@@ -514,6 +514,14 @@ try {
     }
     Assert-True ([string]::IsNullOrEmpty($punchTick.Stdout)) 'punch-list ticks stay allowed'
 
+    $protectedDir = Join-Path $workTarget 'ai_docs'
+    $null = New-Item -ItemType Directory -Path $protectedDir -Force
+    [IO.File]::WriteAllText((Join-Path $protectedDir 'secret.txt'), "secret`n")
+    $addAll = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'git add -A' } @{
+        NIGHTSHIFT_PROTECTED_DIRS = 'ai_docs'
+    }
+    Assert-True ($addAll.Stdout -match 'protected directory') 'git add -A is checked from Git paths'
+
     $forbidden = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'git push origin HEAD' } `
         @{ NIGHTSHIFT_FORBIDDEN_COMMANDS = 'git .*push' }
     Assert-True ($forbidden.Stdout -match 'forbiddenCommands') 'PowerShell commands honor forbiddenCommands'

--- a/tests/windows/run.ps1
+++ b/tests/windows/run.ps1
@@ -20,6 +20,7 @@ $claudeSessionEndDispatch = Join-Path $plugin 'hooks/dispatch/claude-session-end
 $codexHooksManifest = Join-Path $plugin 'hooks/codex/hooks.json'
 $hostExecutable = (Get-Process -Id $PID).Path
 $script:Assertions = 0
+$script:Failures = New-Object 'System.Collections.Generic.List[string]'
 
 function Assert-True {
     param(
@@ -28,7 +29,8 @@ function Assert-True {
     )
     $script:Assertions++
     if (-not $Condition) {
-        throw "assertion failed: $Message"
+        $script:Failures.Add($Message)
+        Write-Host "FAIL: $Message"
     }
 }
 
@@ -40,7 +42,9 @@ function Assert-Equal {
     )
     $script:Assertions++
     if ([string]$Expected -ne [string]$Actual) {
-        throw "assertion failed: $Message (expected '$Expected', got '$Actual')"
+        $detail = "$Message (expected '$Expected', got '$Actual')"
+        $script:Failures.Add($detail)
+        Write-Host "FAIL: $detail"
     }
 }
 
@@ -508,6 +512,10 @@ try {
     Assert-True ($rulesRead.Stdout -match 'rules file is the owner') 'rules reads are denied during a shift'
     $armedDelete = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'Remove-Item -Force .nightshift\.shift-armed' }
     Assert-True ($armedDelete.Stdout -match 'control files') 'bound worker cannot delete .shift-armed'
+    $cdArmed = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'cd .nightshift && unlink .shift-armed' }
+    Assert-True ($cdArmed.Stdout -match 'control files') "cd into .nightshift cannot unlink the armed marker ($(Format-HookResult $cdArmed))"
+    $cdStop = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'cd .nightshift && touch STOP' }
+    Assert-True ($cdStop.Stdout -match 'control files') "cd into .nightshift cannot forge STOP ($(Format-HookResult $cdStop))"
     $punchTick = Invoke-Hardhat $workspace $sessionId 'Write' @{
         path = (Join-Path $workspace '.nightshift/punch-list.md')
         content = "## Items`n- [x] **1.**`n"
@@ -521,6 +529,13 @@ try {
         NIGHTSHIFT_PROTECTED_DIRS = 'ai_docs'
     }
     Assert-True ($addAll.Stdout -match 'protected directory') 'git add -A is checked from Git paths'
+    $null = & git -C $workTarget add -- ai_docs/secret.txt
+    $null = & git -C $workTarget commit --quiet -m 'protected'
+    Remove-Item -LiteralPath (Join-Path $protectedDir 'secret.txt') -Force
+    $addDeleted = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'git add -A' } @{
+        NIGHTSHIFT_PROTECTED_DIRS = 'ai_docs'
+    }
+    Assert-True ($addDeleted.Stdout -match 'protected directory') 'git add -A sees a staged protected deletion'
 
     $forbidden = Invoke-Hardhat $workspace $sessionId 'Bash' @{ command = 'git push origin HEAD' } `
         @{ NIGHTSHIFT_FORBIDDEN_COMMANDS = 'git .*push' }
@@ -853,6 +868,13 @@ exit 0
         @('-Project', $brokenLauncherWorkspace, '-HostName', 'claude') '' @{ NIGHTSHIFT_WATCH_SLEEP = '0' }
     Assert-True ($brokenLaunch.ExitCode -ne 0) 'watchman launcher reports a child that fails before publishing ownership'
 
+    if ($script:Failures.Count -gt 0) {
+        Write-Host "Windows-native verification failed ($($script:Failures.Count) of $script:Assertions):"
+        foreach ($failure in $script:Failures) {
+            Write-Host " - $failure"
+        }
+        exit 1
+    }
     Write-Host "Windows-native verification passed ($script:Assertions assertions)."
     # GitHub Actions' PowerShell shells fail the step on a leftover native
     # $LASTEXITCODE. The last child here is the broken-rules launcher, which


### PR DESCRIPTION
## What does this PR do?

Closes three local hardhat / stop-gate holes reported by @walt-verweij:

- The bound worker can no longer delete or forge the armed-shift control files that decide whether the gate runs. Start can still create the armed marker. A missing punch list now goes through `end_shift` instead of releasing early.
- `protectedDirs` is checked from the paths Git would actually write, not from tokens in the command text.
- `neverCommitPatterns` inspects the content Git would commit, including pathspec / `--include` / `--only` forms.

Also updates the security policy: a public issue is the default for local guard misses; a private advisory is optional when secrets could leave this machine or other users could be affected.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [x] Harness parity (shared Claude Code / Codex behaviour)
- [x] Docs / chore / refactor (no behaviour change)
- [x] Gate behaviour change (discussed in an issue first — see CONTRIBUTING)

## Checklist

- [x] I ran the focused checks for this area from the
      [contribution map](https://github.com/orwa-mahmoud/nightshift/blob/main/docs/contribution-map.md).
- [x] `shellcheck` and the `bats` suite pass locally.
- [x] Shell stays portable: macOS bash 3.2 / zsh — no newer bashisms, no GNU-only flags.
- [x] If the stop-gate changed: the PR description shows a transcript of one
      blocked stop and one permitted stop.
- [x] Docs updated if commands, hooks, or the contract changed.

## Gate outcomes

Permitted: an armed shift with a ticked list still clocks out through `end_shift`.
Blocked: an armed shift with an open box still cannot clock out. A missing punch list now takes the same `end_shift` path instead of releasing.

## Test plan

- [ ] `bats tests/hardhat.bats tests/clock-out-gate.bats tests/codex/hardhat.bats tests/codex/gate.bats tests/github-templates.bats`
- [ ] Confirm CI is green on Ubuntu and macOS
- [ ] Merge with **Create a merge commit** so the three `fix:` commits stay intact for Release Please


Made with [Cursor](https://cursor.com)