### PR TITLE
Record the session host from its transcript path

### DIFF
--- a/plugins/nightshift/hooks/clock-out-gate.sh
+++ b/plugins/nightshift/hooks/clock-out-gate.sh
@@ -174,7 +174,7 @@ if [ "$own_rc" -eq 2 ]; then
   exit 0
 fi
 if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
-  ns_session_claim "$NS" "$SID" "${TPATH:-}" "$CURRENT_PID" "$CURRENT_START" claude || true
+  ns_session_claim "$NS" "$SID" "${TPATH:-}" "$CURRENT_PID" "$CURRENT_START" "$(ns_claude_session_host "${TPATH:-}")" || true
 fi
 ns_shift_ownership claude "$CURRENT_PID" "$CURRENT_START" gate
 own_rc=$?

--- a/plugins/nightshift/hooks/hardhat.sh
+++ b/plugins/nightshift/hooks/hardhat.sh
@@ -113,7 +113,7 @@ own_rc=$?
 if [ ! -f "$NS/.shift-session" ] && [ -n "${SID:-}" ]; then
   case "$TOOL" in
     Bash | AskUserQuestion | Edit | Write | MultiEdit | NotebookEdit)
-      ns_session_claim "$NS" "$SID" "${TPATH:-}" "$CURRENT_PID" "$CURRENT_START" claude || true
+      ns_session_claim "$NS" "$SID" "${TPATH:-}" "$CURRENT_PID" "$CURRENT_START" "$(ns_claude_session_host "${TPATH:-}")" || true
       ;;
   esac
 fi

--- a/plugins/nightshift/lib/ownership.sh
+++ b/plugins/nightshift/lib/ownership.sh
@@ -62,7 +62,7 @@ ns_session_write() { # <ns> <sid> <transcript> <pid> <start> <host> <tmp>; valid
   ns_lease_safe_line "$sid" && ns_lease_safe_line "$transcript" \
     && ns_lease_safe_line "$pid" && ns_lease_safe_line "$start" || return 1
   case "$pid" in *[!0-9]*) return 1 ;; esac
-  case "$host" in claude | codex) ;; *) return 1 ;; esac
+  case "$host" in claude | codex | cursor) ;; *) return 1 ;; esac
   (umask 077; printf '%s\n%s\n%s\n%s\n%s\n' \
     "$sid" "$transcript" "$pid" "$start" "$host" >"$tmp") || {
     rm -f "$tmp"
@@ -152,7 +152,7 @@ ns_lease_valid() { ns_lease_load "$1"; }
 ns_lease_write_unlocked() { # <ns> <sid> <host> <generation> <nonce> <pid> <start>
   local ns="$1" sid="$2" host="$3" generation="$4" nonce="$5" pid="$6" start="$7" tmp
   ns_lease_safe_line "$sid" && ns_lease_safe_line "$start" || return 1
-  case "$host" in claude | codex) ;; *) return 1 ;; esac
+  case "$host" in claude | codex | cursor) ;; *) return 1 ;; esac
   case "$generation" in '' | *[!0-9]*) return 1 ;; esac
   [ "$generation" -gt 0 ] 2>/dev/null || return 1
   case "$nonce" in *[!A-Za-z0-9._-]*) return 1 ;; esac
@@ -544,6 +544,18 @@ ns_lease_reset_stale() { # $1 = .nightshift; caller has proved no process or wat
   rc=$?
   ns_lease_unlock "$ns"
   return "$rc"
+}
+
+# Every tool that speaks Claude Code's plugin interface executes these same hooks, so a hook
+# cannot assume Claude is the host it runs in. The transcript path names the writer: Cursor
+# keeps its conversations under ~/.cursor, and a record claimed from one belongs to Cursor —
+# Claude's watchman must stand down from it rather than fire `claude --resume` at a
+# conversation it can never reach. Paths without a known foreign marker stay claude.
+ns_claude_session_host() { # <transcript-path>
+  case "$1" in
+    */.cursor/*) printf 'cursor' ;;
+    *) printf 'claude' ;;
+  esac
 }
 
 # Which host owns this shift. Absent means a record written before hosts were distinguished,

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -409,6 +409,26 @@ load helpers
   [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "first-tab" ]
 }
 
+# Cursor runs Claude Code's plugin interface, so these hooks execute there too. The record
+# must name the real host: Claude's watchman stands down from a cursor-owned shift instead of
+# firing `claude --resume` at a conversation it can never reach.
+@test "a session working from a cursor transcript records the cursor host" {
+  p="$(new_project)"
+  punch_open "$p"
+  jq -nc '{tool_name:"Bash",session_id:"cursor-tab",transcript_path:"/Users/o/.cursor/projects/x/agent-transcripts/u/u.jsonl",tool_input:{command:"echo hi"}}' |
+    CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "cursor-tab" ]
+  [ "$(sed -n 5p "$p/.nightshift/.shift-session")" = "cursor" ]
+}
+
+@test "a claude transcript keeps recording the claude host" {
+  p="$(new_project)"
+  punch_open "$p"
+  jq -nc '{tool_name:"Bash",session_id:"claude-tab",transcript_path:"/Users/o/.claude/projects/x/u.jsonl",tool_input:{command:"echo hi"}}' |
+    CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
+  [ "$(sed -n 5p "$p/.nightshift/.shift-session")" = "claude" ]
+}
+
 @test "no active shift means no session record" {
   p="$(new_project)"
   punch_done "$p"

--- a/tests/watchman.bats
+++ b/tests/watchman.bats
@@ -833,6 +833,14 @@ STUB
   grep -q 'owned by codex' "$P/.nightshift/shift-log.md"
 }
 
+@test "the watchman stands down on a cursor-owned shift" {
+  printf 'sid\n/Users/o/.cursor/projects/x/u.jsonl\n99999\nstart\ncursor\n' >"$P/.nightshift/.shift-session"
+  run watch --agent "bash $BIN/tick.sh" --max-wakes 1
+  [ "$status" -eq 0 ]
+  [ "$(calls)" -eq 0 ]
+  grep -q 'owned by cursor' "$P/.nightshift/shift-log.md"
+}
+
 # A record written before hosts were named can only be Claude's — nothing else could write one.
 @test "a record with no host is treated as claude" {
   printf 'sid\n/tmp/t.jsonl\n99999\nstart\n' >"$P/.nightshift/.shift-session"


### PR DESCRIPTION
The session claim in the Claude hooks names the host from where the transcript lives instead of assuming claude: conversations under ~/.cursor record cursor, and the watchman's wrong-host stand-down then keeps claude from firing resume attempts at a conversation it cannot reach. Paths without a known foreign marker keep recording claude, and the session-record whitelist accepts the new host name.

Covered by hook-wrapper tests: a cursor transcript records the cursor host, a claude transcript still records claude, and the watchman stands down on a cursor-owned shift. Full suite passes (634 bats tests) and shellcheck is clean on the changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)