### PR TITLE
Cursor marketplace manifest for official submit

### DIFF
--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -1,0 +1,45 @@
+{
+  "name": "nightshift",
+  "owner": {
+    "name": "Orwa Mahmoud",
+    "url": "https://github.com/orwa-mahmoud"
+  },
+  "metadata": {
+    "description": "Home of nightshift: accountable engineering shifts with persistent state, enforced boundaries, recovery, and evidence-backed product evolution."
+  },
+  "plugins": [
+    {
+      "name": "nightshift",
+      "source": "./plugins/nightshift",
+      "displayName": "Nightshift",
+      "description": "Accountable, time-bounded engineering shifts with a persistent punch list, mechanical guards, and reviewable receipts.",
+      "category": "productivity",
+      "tags": [
+        "autonomous",
+        "overnight",
+        "unattended",
+        "punch-list",
+        "guardrails",
+        "hooks",
+        "crash-recovery",
+        "agent-harness"
+      ],
+      "keywords": [
+        "agent-harness",
+        "punch-list",
+        "hooks",
+        "overnight",
+        "autonomous-agents",
+        "crash-recovery",
+        "session-resume"
+      ],
+      "author": {
+        "name": "Orwa Mahmoud",
+        "url": "https://github.com/orwa-mahmoud"
+      },
+      "homepage": "https://nightshift.orwamahmoud.com/",
+      "repository": "https://github.com/orwa-mahmoud/nightshift",
+      "license": "MIT"
+    }
+  ]
+}

--- a/.cursor-plugin/marketplace.json
+++ b/.cursor-plugin/marketplace.json
@@ -39,7 +39,8 @@
       },
       "homepage": "https://nightshift.orwamahmoud.com/",
       "repository": "https://github.com/orwa-mahmoud/nightshift",
-      "license": "MIT"
+      "license": "MIT",
+      "logo": "./assets/nightshift-logo.png"
     }
   ]
 }

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -286,7 +286,9 @@ watchman when `watchMinutes` is not `0`. After an IDE death it mints a CLI worke
 tab is denied with the attach command while that worker holds the shift. Other IDE tabs in
 the same project stay outside the gate. Closing the origin tab is not a clean session end
 once a worker is recorded. Do not arm the Claude or Codex watchman from a Cursor session.
-Install locally under `~/.cursor/plugins/local` first; marketplace listing waits on a
+Add the public GitHub repo as a Cursor marketplace source
+(`.cursor-plugin/marketplace.json` at the repo root, same role as the Claude
+marketplace file). Official marketplace listing waits on a
 verified Cursor shift with watchman recovery. The Cursor CLI (`agent`) currently ignores
 marketplace and local plugin hooks and only runs project `.cursor/hooks.json`. Setup can
 copy the shipped Cursor hook file there on an explicit yes; that is a Cursor limitation,

--- a/plugins/nightshift/.cursor-plugin/plugin.json
+++ b/plugins/nightshift/.cursor-plugin/plugin.json
@@ -10,6 +10,7 @@
   "homepage": "https://nightshift.orwamahmoud.com/",
   "repository": "https://github.com/orwa-mahmoud/nightshift",
   "license": "MIT",
+  "logo": "./assets/nightshift-logo.png",
   "keywords": [
     "cursor",
     "agent-harness",

--- a/plugins/nightshift/.cursor-plugin/plugin.json
+++ b/plugins/nightshift/.cursor-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "nightshift",
   "displayName": "Nightshift",
-  "version": "0.15.0",
+  "version": "0.17.0",
   "description": "Accountable, time-bounded engineering shifts with a persistent punch list, mechanical guards, and reviewable receipts.",
   "author": {
     "name": "Orwa Mahmoud",

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -16,6 +16,11 @@
           "type": "json",
           "path": "plugins/nightshift/.codex-plugin/plugin.json",
           "jsonpath": "$.version"
+        },
+        {
+          "type": "json",
+          "path": "plugins/nightshift/.cursor-plugin/plugin.json",
+          "jsonpath": "$.version"
         }
       ]
     }

--- a/tests/cursor/honesty.bats
+++ b/tests/cursor/honesty.bats
@@ -7,6 +7,7 @@ START="$ROOT/plugins/nightshift/skills/start/SKILL.md"
 README="$ROOT/README.md"
 MARKET="$ROOT/.claude-plugin/marketplace.json"
 CODEX_MARKET="$ROOT/.agents/plugins/marketplace.json"
+CURSOR_MARKET="$ROOT/.cursor-plugin/marketplace.json"
 
 @test "docs name the Cursor IDE and CLI store split" {
   grep -qF '~/.cursor/projects/' "$HOW"
@@ -34,4 +35,18 @@ CODEX_MARKET="$ROOT/.agents/plugins/marketplace.json"
   grep -qF 'marketplace listing waits' "$HOW"
   ! grep -qi cursor "$MARKET"
   ! grep -qi cursor "$CODEX_MARKET"
+}
+
+@test "the Cursor marketplace file points at the shipped plugin" {
+  [ -f "$CURSOR_MARKET" ]
+  [ "$(jq -r '.plugins[0].name' "$CURSOR_MARKET")" = "nightshift" ]
+  [ "$(jq -r '.plugins[0].source' "$CURSOR_MARKET")" = "./plugins/nightshift" ]
+  [ -f "$ROOT/plugins/nightshift/.cursor-plugin/plugin.json" ]
+}
+
+@test "Release Please bumps the Cursor host manifest with the others" {
+  cfg="$ROOT/release-please-config.json"
+  jq -e '.packages["."]."extra-files" | map(.path) | index("plugins/nightshift/.claude-plugin/plugin.json")' "$cfg" >/dev/null
+  jq -e '.packages["."]."extra-files" | map(.path) | index("plugins/nightshift/.codex-plugin/plugin.json")' "$cfg" >/dev/null
+  jq -e '.packages["."]."extra-files" | map(.path) | index("plugins/nightshift/.cursor-plugin/plugin.json")' "$cfg" >/dev/null
 }

--- a/tests/cursor/honesty.bats
+++ b/tests/cursor/honesty.bats
@@ -44,6 +44,14 @@ CURSOR_MARKET="$ROOT/.cursor-plugin/marketplace.json"
   [ -f "$ROOT/plugins/nightshift/.cursor-plugin/plugin.json" ]
 }
 
+@test "Cursor listing uses the same in-repo logo as Codex" {
+  logo="$ROOT/plugins/nightshift/assets/nightshift-logo.png"
+  [ -f "$logo" ]
+  [ "$(jq -r '.logo' "$ROOT/plugins/nightshift/.cursor-plugin/plugin.json")" = "./assets/nightshift-logo.png" ]
+  [ "$(jq -r '.plugins[0].logo' "$CURSOR_MARKET")" = "./assets/nightshift-logo.png" ]
+  [ "$(jq -r '.interface.logo' "$ROOT/plugins/nightshift/.codex-plugin/plugin.json")" = "./assets/nightshift-logo.png" ]
+}
+
 @test "Release Please bumps the Cursor host manifest with the others" {
   cfg="$ROOT/release-please-config.json"
   jq -e '.packages["."]."extra-files" | map(.path) | index("plugins/nightshift/.claude-plugin/plugin.json")' "$cfg" >/dev/null


### PR DESCRIPTION
## Summary
- Adds the repo-root `.cursor-plugin/marketplace.json` Cursor needs to import or list this GitHub repo, pointing at `./plugins/nightshift`.
- Release Please now bumps the Cursor host manifest with Claude and Codex; the Cursor version is caught up to 0.17.0.
- Public README still does not claim Cursor.

## Test plan
- [ ] `bats tests/cursor/honesty.bats`
- [ ] `claude plugin validate . --strict`
- [ ] After merge, Cursor Dashboard → Plugins → Import from Repo on `https://github.com/orwa-mahmoud/nightshift` lists nightshift


Made with [Cursor](https://cursor.com)