### PR TITLE
Keep Claude marketplace hooks off Cursor leases

### DIFF
--- a/plugins/nightshift/hooks/clock-out-gate.sh
+++ b/plugins/nightshift/hooks/clock-out-gate.sh
@@ -169,6 +169,11 @@ if [ -f "$STOP" ]; then
   exit 0
 fi
 
+# Cursor IDE also runs this Claude gate; leave Cursor's gate as the only clock-out owner.
+if ns_claude_foreign_cursor_surface "$NS" "${TPATH:-}"; then
+  exit 0
+fi
+
 LEASE_NONCE="${NIGHTSHIFT_LEASE_NONCE:-}"
 LEASE_GENERATION="${NIGHTSHIFT_LEASE_GENERATION:-}"
 ns_shift_unbound claude gate

--- a/plugins/nightshift/hooks/hardhat.sh
+++ b/plugins/nightshift/hooks/hardhat.sh
@@ -106,6 +106,12 @@ if ns_hardhat_is_command_tool "$TOOL"; then
   fi
 fi
 
+# Cursor IDE loads this Claude marketplace plugin beside the Cursor host plugin. Do not claim
+# or fence a Cursor conversation — Cursor hardhat owns that surface.
+if ns_claude_foreign_cursor_surface "$NS" "${TPATH:-}"; then
+  exit 0
+fi
+
 # The conversation record preserves continuity; the lease names the process generation allowed
 # to act on it. Initial work uses the Claude ancestor's pid + start time. Every watchman spawn
 # instead carries a unique nonce and generation, so an old IDE process with the same session id

--- a/plugins/nightshift/hooks/windows/clock-out-gate.ps1
+++ b/plugins/nightshift/hooks/windows/clock-out-gate.ps1
@@ -248,6 +248,11 @@ if (Test-Path -LiteralPath $stop -PathType Leaf) {
     Write-Release
 }
 
+# Cursor IDE also runs this Claude gate; leave Cursor's gate as the only clock-out owner.
+if ($HostName -eq 'claude' -and (Test-NSClaudeForeignCursorSurface -NightshiftDir $ns -Transcript $transcript)) {
+    Write-Release
+}
+
 if ($null -eq $payload) {
     Write-Block 'DO NOT STOP - the hook payload is unreadable while a shift is active. Retry after the host can provide valid hook JSON.'
 }

--- a/plugins/nightshift/hooks/windows/hardhat.ps1
+++ b/plugins/nightshift/hooks/windows/hardhat.ps1
@@ -668,6 +668,11 @@ if ($tool -in @('Bash', 'PowerShell')) {
     }
 }
 
+# Cursor IDE loads the Claude marketplace plugin beside the Cursor host plugin.
+if ($HostName -eq 'claude' -and (Test-NSClaudeForeignCursorSurface -NightshiftDir $ns -Transcript $transcript)) {
+    exit 0
+}
+
 $unbound = Resolve-NSShiftUnbound -NightshiftDir $ns -HostName $HostName `
     -Nonce $nonce -Generation $generation -Revival $revival -Mode hardhat
 if ($unbound.Status -eq 'Pass') { exit 0 }

--- a/plugins/nightshift/lib/Nightshift.psm1
+++ b/plugins/nightshift/lib/Nightshift.psm1
@@ -1131,6 +1131,18 @@ function Read-NSSession {
     }
 }
 
+function Test-NSClaudeForeignCursorSurface {
+    param(
+        [Parameter(Mandatory = $true)][string]$NightshiftDir,
+        [AllowEmptyString()][string]$Transcript = ''
+    )
+    if ($Transcript -match '[/\\]\.cursor([/\\]|$)') {
+        return $true
+    }
+    $session = Read-NSSession $NightshiftDir
+    return ($null -ne $session -and $session.HostName -eq 'cursor')
+}
+
 function Write-NSSession {
     param(
         [Parameter(Mandatory = $true)][string]$NightshiftDir,
@@ -1958,6 +1970,21 @@ function Resolve-NSShiftAuthorize {
             return New-NSShiftDecision -Status Fail -Session $Session -Message 'BLOCKED: the shift process lease could not be created. Issue STOP from another session, then run Start again.'
         }
         return New-NSShiftDecision -Status Fail -Session $Session -Message 'DO NOT STOP - the shift process lease is unreadable. Issue STOP from another session, then run Start again.'
+    }
+    elseif ($HostName -eq 'cursor') {
+        $contaminated = Read-NSLease $NightshiftDir
+        if ($null -ne $contaminated `
+            -and $contaminated.HostName -eq 'claude' `
+            -and $contaminated.SessionId -eq $Session.SessionId `
+            -and [string]::IsNullOrEmpty($contaminated.Nonce) `
+            -and [string]::IsNullOrEmpty($Nonce)) {
+            if (-not (Write-NSLease $NightshiftDir $Session.SessionId 'cursor' 1 '' $ProcessId $ProcessStart)) {
+                if ($Mode -eq 'hardhat') {
+                    return New-NSShiftDecision -Status Fail -Session $Session -Message 'BLOCKED: the shift process lease could not be reclaimed for Cursor. Issue STOP from another session, then run Start again.'
+                }
+                return New-NSShiftDecision -Status Fail -Session $Session -Message 'DO NOT STOP - the shift process lease could not be reclaimed for Cursor. Issue STOP from another session, then run Start again.'
+            }
+        }
     }
     $checkSession = if ([string]::IsNullOrEmpty($SessionId)) { $Session.SessionId } else { $SessionId }
     $allow = Test-NSLeaseAllows $NightshiftDir $checkSession $HostName $ProcessId $ProcessStart $Nonce $Generation

--- a/plugins/nightshift/lib/ownership.sh
+++ b/plugins/nightshift/lib/ownership.sh
@@ -450,6 +450,29 @@ ns_shift_authorize() { # <host> <pid> <start> <mode:hardhat|gate>
       fi
       return 2
     fi
+  elif [ "$host" = cursor ] && ns_lease_valid "$NS" \
+    && [ "$NS_LEASE_HOST" = claude ] && [ "$NS_LEASE_SID" = "$rec" ] \
+    && [ -z "$NS_LEASE_NONCE" ] && [ -z "${LEASE_NONCE:-}" ]; then
+    # Cursor IDE also ran Claude marketplace hooks, which leased as host claude while
+    # .shift-session already names cursor. Reclaim so the Cursor hardhat can own the shift.
+    ns_lease_lock "$NS" || {
+      if [ "$mode" = hardhat ]; then
+        NS_SHIFT_FAIL="BLOCKED: the shift process lease could not be reclaimed for Cursor. Issue STOP from another session, then run Start again."
+      else
+        NS_SHIFT_FAIL="DO NOT STOP — the shift process lease could not be reclaimed for Cursor. Issue STOP from another session, then run Start again."
+      fi
+      return 2
+    }
+    if ! ns_lease_write_unlocked "$NS" "$rec" cursor 1 "" "$pid" "$start"; then
+      ns_lease_unlock "$NS"
+      if [ "$mode" = hardhat ]; then
+        NS_SHIFT_FAIL="BLOCKED: the shift process lease could not be reclaimed for Cursor. Issue STOP from another session, then run Start again."
+      else
+        NS_SHIFT_FAIL="DO NOT STOP — the shift process lease could not be reclaimed for Cursor. Issue STOP from another session, then run Start again."
+      fi
+      return 2
+    fi
+    ns_lease_unlock "$NS"
   fi
 
   ns_lease_allows "$NS" "$check_sid" "$host" "$pid" "$start" \
@@ -606,6 +629,16 @@ ns_claude_session_host() { # <transcript-path>
     */.cursor/*) printf 'cursor' ;;
     *) printf 'claude' ;;
   esac
+}
+
+# Cursor IDE loads Claude marketplace plugins and runs their hooks in the same Agent tab.
+# Those Claude-entry hooks must not claim or fence a Cursor-owned shift. True when the
+# transcript lives under ~/.cursor, or .shift-session already records host cursor.
+ns_claude_foreign_cursor_surface() { # <ns-dir> <transcript-path>
+  case "$2" in
+    */.cursor/*) return 0 ;;
+  esac
+  [ "$(ns_session_host "$1")" = "cursor" ]
 }
 
 # True when .shift-session is a real file, not a planted symlink.

--- a/tests/cursor/hardhat.bats
+++ b/tests/cursor/hardhat.bats
@@ -25,6 +25,22 @@ is_cursor_deny() {
     env CURSOR_PROJECT_DIR="$p" bash "$CURSOR_HOOKS/hardhat.sh"
   [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "cursor-tab" ]
   [ "$(sed -n 5p "$p/.nightshift/.shift-session")" = "cursor" ]
+  [ "$(sed -n 2p "$p/.nightshift/.shift-lease")" = "cursor" ]
+}
+
+@test "cursor hardhat reclaims a claude-contaminated lease for the same session" {
+  p="$(new_project)"
+  punch_open "$p"
+  printf '%s\n' cursor-tab \
+    '/Users/o/.cursor/projects/x/agent-transcripts/u/u.jsonl' '' '' cursor \
+    >"$p/.nightshift/.shift-session"
+  printf '%s\n' cursor-tab claude 1 '' '' '' >"$p/.nightshift/.shift-lease"
+  chmod 600 "$p/.nightshift/.shift-session" "$p/.nightshift/.shift-lease"
+  jq -nc --arg p "$p" \
+    '{tool_name:"Shell",conversation_id:"cursor-tab",transcript_path:"/Users/o/.cursor/projects/x/agent-transcripts/u/u.jsonl",cwd:$p,tool_input:{command:"echo hi"}}' |
+    env CURSOR_PROJECT_DIR="$p" bash "$CURSOR_HOOKS/hardhat.sh"
+  [ "$(sed -n 1p "$p/.nightshift/.shift-lease")" = "cursor-tab" ]
+  [ "$(sed -n 2p "$p/.nightshift/.shift-lease")" = "cursor" ]
 }
 
 # ---- the site rules bind the shift's session; other conversations keep their tools ----

--- a/tests/hardhat.bats
+++ b/tests/hardhat.bats
@@ -482,16 +482,15 @@ load helpers
   [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "first-tab" ]
 }
 
-# Cursor runs Claude Code's plugin interface, so these hooks execute there too. The record
-# must name the real host: Claude's watchman stands down from a cursor-owned shift instead of
-# firing `claude --resume` at a conversation it can never reach.
-@test "a session working from a cursor transcript records the cursor host" {
+# Cursor IDE loads the Claude marketplace plugin beside the Cursor host plugin. Claude-entry
+# hooks must stand down so they cannot lease as host claude on a Cursor transcript.
+@test "claude hardhat stands down on a cursor transcript without claiming the lease" {
   p="$(new_project)"
   punch_open "$p"
   jq -nc '{tool_name:"Bash",session_id:"cursor-tab",transcript_path:"/Users/o/.cursor/projects/x/agent-transcripts/u/u.jsonl",tool_input:{command:"echo hi"}}' |
     CLAUDE_PROJECT_DIR="$p" bash "$HOOKS/hardhat.sh"
-  [ "$(sed -n 1p "$p/.nightshift/.shift-session")" = "cursor-tab" ]
-  [ "$(sed -n 5p "$p/.nightshift/.shift-session")" = "cursor" ]
+  [ ! -f "$p/.nightshift/.shift-session" ]
+  [ ! -f "$p/.nightshift/.shift-lease" ]
 }
 
 @test "a claude transcript keeps recording the claude host" {


### PR DESCRIPTION
## Summary
- Cursor IDE loads the Claude marketplace Nightshift beside the Cursor host plugin; Claude hardhat was still leasing as host `claude` while `.shift-session` already named `cursor`, which fenced Agent tabs.
- Claude hardhat and clock-out now stand down on Cursor transcripts (and when the session host is already `cursor`).
- Cursor hardhat reclaims a `claude`-contaminated interactive lease for the same session so Start can own the shift cleanly.

## Test plan
- [x] `bats tests/hardhat.bats tests/cursor/hardhat.bats`
- [x] Desktop smoke folder: Start → tick 1 → tick 2 → stop held on item 3 → tick 3 → clean clock-out (with Claude marketplace Nightshift still installed)


Made with [Cursor](https://cursor.com)