### PR TITLE
HOL badge and skip unrelated CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,14 +12,71 @@ on:
 permissions:
   contents: read
 
+# Path buckets decide which expensive steps run. Required job names (shellcheck, validate,
+# bats (1-6), bats-macos (1-6)) always start so a docs-only or Release Please pull request is
+# not left waiting on a check that never reported. Workflow-level `paths` would skip the whole
+# workflow and revive that pending state.
 jobs:
-  shellcheck:
+  changes:
     runs-on: ubuntu-latest
+    outputs:
+      suite: ${{ steps.filter.outputs.runtime == 'true' || steps.filter.outputs.workflow == 'true' }}
+      lint: ${{ steps.filter.outputs.shell == 'true' || steps.filter.outputs.workflow == 'true' }}
+      validate: ${{ steps.filter.outputs.runtime == 'true' || steps.filter.outputs.manifest == 'true' || steps.filter.outputs.workflow == 'true' }}
+      docs: ${{ steps.filter.outputs.docs == 'true' && steps.filter.outputs.runtime != 'true' && steps.filter.outputs.workflow != 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: filter
+        with:
+          filters: |
+            workflow:
+              - '.github/workflows/ci.yaml'
+            shell:
+              - '**/*.sh'
+            runtime:
+              - 'plugins/**'
+              - '!plugins/nightshift/.claude-plugin/plugin.json'
+              - '!plugins/nightshift/.codex-plugin/plugin.json'
+              - '!plugins/nightshift/.cursor-plugin/plugin.json'
+              - 'tests/**'
+              - 'evals/**'
+              - '.claude-plugin/**'
+              - '.agents/**'
+              - '.cursor-plugin/**'
+            docs:
+              - 'README.md'
+              - 'CONTRIBUTING.md'
+              - 'SECURITY.md'
+              - 'docs/**'
+              - 'examples/**'
+              - '.github/ISSUE_TEMPLATE/**'
+              - '.github/PULL_REQUEST_TEMPLATE.md'
+            manifest:
+              - 'plugins/nightshift/.claude-plugin/plugin.json'
+              - 'plugins/nightshift/.codex-plugin/plugin.json'
+              - 'plugins/nightshift/.cursor-plugin/plugin.json'
+              - '.release-please-manifest.json'
+              - 'release-please-config.json'
+              - 'CHANGELOG.md'
+              - '.claude-plugin/marketplace.json'
+              - '.agents/plugins/marketplace.json'
+              - '.cursor-plugin/marketplace.json'
+
+  shellcheck:
+    needs: changes
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip lint
+        if: needs.changes.outputs.lint != 'true'
+        run: echo 'No shell or workflow paths; shellcheck not executed.'
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.lint == 'true'
       - name: Install shellcheck
+        if: needs.changes.outputs.lint == 'true'
         run: sudo apt-get update && sudo apt-get install -y shellcheck
       - name: Lint every shell script
+        if: needs.changes.outputs.lint == 'true'
         run: |
           set -eu
           files=$(git ls-files '*.sh')
@@ -32,16 +89,23 @@ jobs:
           echo "$files" | xargs shellcheck -x
 
   bats:
+    needs: changes
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
+      - name: Skip shard
+        if: needs.changes.outputs.suite != 'true' && (needs.changes.outputs.docs != 'true' || matrix.shard != 1)
+        run: echo 'No suite paths for this shard.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.suite == 'true' || (needs.changes.outputs.docs == 'true' && matrix.shard == 1)
       - name: Install bats and shellcheck
+        if: needs.changes.outputs.suite == 'true'
         run: sudo apt-get update && sudo apt-get install -y bats shellcheck
       - name: Run bats shard ${{ matrix.shard }}/6
+        if: needs.changes.outputs.suite == 'true'
         run: |
           set -eu
           if ! ls tests/*.bats >/dev/null 2>&1; then
@@ -50,18 +114,34 @@ jobs:
           fi
           chmod +x tests/run-shard.sh
           tests/run-shard.sh "${{ matrix.shard }}" 6
+      - name: Install bats
+        if: needs.changes.outputs.suite != 'true' && needs.changes.outputs.docs == 'true' && matrix.shard == 1
+        run: sudo apt-get update && sudo apt-get install -y bats
+      - name: Run docs contract
+        if: needs.changes.outputs.suite != 'true' && needs.changes.outputs.docs == 'true' && matrix.shard == 1
+        run: |
+          set -eu
+          chmod +x tests/run-docs-contract.sh
+          tests/run-docs-contract.sh
 
   bats-macos:
+    needs: changes
     runs-on: macos-latest
     strategy:
       fail-fast: false
       matrix:
         shard: [1, 2, 3, 4, 5, 6]
     steps:
+      - name: Skip shard
+        if: needs.changes.outputs.suite != 'true'
+        run: echo 'No suite paths; macOS shard not executed.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.suite == 'true'
       - name: Install bats
+        if: needs.changes.outputs.suite == 'true'
         run: brew install bats-core
       - name: Run bats shard ${{ matrix.shard }}/6 under macOS system bash
+        if: needs.changes.outputs.suite == 'true'
         run: |
           set -eu
           bats_bin="$(command -v bats)"
@@ -73,6 +153,8 @@ jobs:
           tests/run-shard.sh "${{ matrix.shard }}" 6
 
   windows-native:
+    needs: changes
+    if: needs.changes.outputs.suite == 'true'
     runs-on: windows-latest
     timeout-minutes: 20
     strategy:
@@ -88,6 +170,8 @@ jobs:
         run: ./tests/windows/run.ps1
 
   remote-ssh:
+    needs: changes
+    if: needs.changes.outputs.suite == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -123,6 +207,8 @@ jobs:
           if-no-files-found: ignore
 
   devcontainer:
+    needs: changes
+    if: needs.changes.outputs.suite == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -177,13 +263,21 @@ jobs:
           if-no-files-found: ignore
 
   validate:
+    needs: changes
     runs-on: ubuntu-latest
     steps:
+      - name: Skip validate
+        if: needs.changes.outputs.validate != 'true'
+        run: echo 'No manifest, runtime, or workflow paths; validate not executed.'
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        if: needs.changes.outputs.validate == 'true'
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        if: needs.changes.outputs.validate == 'true'
         with:
           node-version: 20
       - name: Install Claude Code
+        if: needs.changes.outputs.validate == 'true'
         run: npm install -g @anthropic-ai/claude-code
       - name: Validate plugin and marketplace manifests
+        if: needs.changes.outputs.validate == 'true'
         run: claude plugin validate . --strict

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -6,7 +6,19 @@ name: HOL Plugin Scanner
 on:
   push:
     branches: [main]
+    paths:
+      - 'plugins/**'
+      - '.claude-plugin/**'
+      - '.agents/**'
+      - '.cursor-plugin/**'
+      - '.github/workflows/hol-plugin-scanner.yml'
   pull_request:
+    paths:
+      - 'plugins/**'
+      - '.claude-plugin/**'
+      - '.agents/**'
+      - '.cursor-plugin/**'
+      - '.github/workflows/hol-plugin-scanner.yml'
 
 permissions:
   contents: read

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,11 +59,14 @@ Shell must stay Python-free: the plugin ships no `.py` file, and `tests/armed-no
 holds that line together with an armed shift that has neither `jq` nor `python3` installed.
 
 CI ([`ci.yaml`](.github/workflows/ci.yaml)) runs shellcheck, the bats suite, and plugin validation
-on every push. Bats runs as six parallel shards on both Ubuntu and macOS (same partition as
-`tests/run-shard.sh`); the macOS job keeps the system Bash 3.2 first on `PATH`. A `windows-native`
-job runs `tests/windows/run.ps1` under Windows PowerShell 5.1 and PowerShell 7. A `remote-ssh` job
-crosses an ephemeral OpenSSH connection; a `devcontainer` job starts the checked-in fixture. Both
-compare sanitized receipts — they do not load an authenticated host session.
+when the matching trees change. A docs-only edit runs `tests/run-docs-contract.sh` instead of the
+full shard matrix. A Release Please version bump validates manifests and skips Windows, remote, and
+shards. Required job names still report, so merge is not left waiting. Bats runs as six parallel
+shards on both Ubuntu and macOS (same partition as `tests/run-shard.sh`); the macOS job keeps the
+system Bash 3.2 first on `PATH`. A `windows-native` job runs `tests/windows/run.ps1` under Windows
+PowerShell 5.1 and PowerShell 7. A `remote-ssh` job crosses an ephemeral OpenSSH connection; a
+`devcontainer` job starts the checked-in fixture. Both compare sanitized receipts — they do not
+load an authenticated host session.
 
 ## Releasing
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # nightshift
 
+[![HOL Guard](https://img.shields.io/endpoint?url=https%3A%2F%2Fhol.org%2Fapi%2Fregistry%2Fbadges%2Fplugin%3Fslug%3Dorwa-mahmoud%252Fnightshift%26metric%3Dtrust)](https://hol.org/go/guard/orwa-mahmoud-uae?dest=%2Fguard%2Fbilling%3Fpromo%3DGUARD20-ORWA-MAHMOUD-UAE%23upgrade&link_id=9a8e4449-def8-4c8d-9ba9-a4eac24754c3&utm_source=insights_share&utm_medium=affiliate_cta&utm_campaign=share20)
+
 Nightshift gives [Claude Code](https://claude.com/claude-code),
 [OpenAI Codex](https://openai.com/codex/), and [Cursor](https://cursor.com) accountable,
 time-bounded engineering shifts. Hand it your own punch list or let it research the product, rank

--- a/plugins/nightshift/.codex-plugin/plugin.json
+++ b/plugins/nightshift/.codex-plugin/plugin.json
@@ -54,9 +54,9 @@
       "Dated archive of finished runs"
     ],
     "defaultPrompt": [
-      "Set up Nightshift in this project workspace.",
-      "Show me the ready-made shifts I can run tonight.",
-      "Use the next four hours to research and improve this product."
+      "Set up Nightshift and show me the highest-value work it can do in this project.",
+      "Add new features and improve existing ones for 10 hours.",
+      "Raise test coverage and quality for 10 hours. Add safe local development tools when needed."
     ],
     "websiteURL": "https://nightshift.orwamahmoud.com/",
     "privacyPolicyURL": "https://nightshift.orwamahmoud.com/privacy",

--- a/plugins/nightshift/.codex-plugin/plugin.json
+++ b/plugins/nightshift/.codex-plugin/plugin.json
@@ -54,9 +54,9 @@
       "Dated archive of finished runs"
     ],
     "defaultPrompt": [
-      "Set up Nightshift in this project workspace.",
-      "Show me the ready-made shifts I can run tonight.",
-      "Use the next four hours to research and improve this product."
+      "Set up Nightshift and show me the highest-value work it can do in this project.",
+      "Build me a 10-hour shift from the best ready-made jobs, then let me review it.",
+      "Improve this project autonomously for 10 hours. Add safe local development tools when needed."
     ],
     "websiteURL": "https://nightshift.orwamahmoud.com/",
     "privacyPolicyURL": "https://nightshift.orwamahmoud.com/privacy",

--- a/plugins/nightshift/.codex-plugin/plugin.json
+++ b/plugins/nightshift/.codex-plugin/plugin.json
@@ -54,9 +54,9 @@
       "Dated archive of finished runs"
     ],
     "defaultPrompt": [
-      "Set up Nightshift and show me the highest-value work it can do in this project.",
-      "Build me a 10-hour shift from the best ready-made jobs, then let me review it.",
-      "Improve this project autonomously for 10 hours. Add safe local development tools when needed."
+      "Set up Nightshift in this project workspace.",
+      "Show me the ready-made shifts I can run tonight.",
+      "Use the next four hours to research and improve this product."
     ],
     "websiteURL": "https://nightshift.orwamahmoud.com/",
     "privacyPolicyURL": "https://nightshift.orwamahmoud.com/privacy",

--- a/tests/environment-compatibility.bats
+++ b/tests/environment-compatibility.bats
@@ -45,6 +45,12 @@ ENVIRONMENTS="$BATS_TEST_DIRNAME/environments"
   grep -qF 'cmp tests/environments/receipts/devcontainer-linux.json' "$CI"
 }
 
+@test "CI keeps required job names reporting when only docs or manifests change" {
+  grep -qF 'dorny/paths-filter' "$CI"
+  grep -qF 'run-docs-contract.sh' "$CI"
+  grep -qF '!plugins/nightshift/.claude-plugin/plugin.json' "$CI"
+}
+
 @test "devcontainer fixture is native Linux with the required local tools" {
   jq -e '
     .workspaceFolder == "/workspaces/nightshift"

--- a/tests/run-docs-contract.sh
+++ b/tests/run-docs-contract.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Docs-only CI: the bats files that grep README, docs/, examples/, or GitHub templates.
+# Runtime changes still run the full shard matrix, which already includes these files.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+bats \
+  tests/artifact-receipts.bats \
+  tests/bad-night-template.bats \
+  tests/contribution-map.bats \
+  tests/cursor/honesty.bats \
+  tests/doc-refs.bats \
+  tests/first-night-checklist.bats \
+  tests/github-templates.bats \
+  tests/morning-receipt-docs.bats \
+  tests/rule-profiles.bats \
+  tests/schedule.bats \
+  tests/shift-modes.bats \
+  tests/skill-refs.bats \
+  tests/troubleshooting.bats


### PR DESCRIPTION
## Summary
- Add the HOL Guard trust badge HOL's dashboard emitted for this plugin.
- Job-level path filters skip Windows, remote, and the full shard matrix when the diff is only docs or a Release Please version bump.
- Required check names (`bats (1)`–`(6)`, `bats-macos (1)`–`(6)`, `shellcheck`, `validate`) still start, so merge is not left waiting.
- Docs-only runs `tests/run-docs-contract.sh` on `bats (1)` so README greps still execute.

Release Please also bumps the three `plugin.json` files, not only `CHANGELOG.md`. Those version files are excluded from the runtime bucket so that PR stays cheap and still runs `validate`.

Cache is not added: it would still run the suite. The filter is what skips it.

## Test plan
- [ ] This PR changes `ci.yaml`, so the full suite should still run once.
- [ ] After merge, a README-only follow-up should skip Windows/remote/macos shards and run the docs contract on `bats (1)`.
- [ ] The next Release Please PR should run `validate` and skip the shard matrix.


Made with [Cursor](https://cursor.com)