### PR TITLE
Declare skill licenses and separate Codex sandbox scope from unattended execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,11 @@ link described under [Workspaces and repositories](docs/how-it-works.md#workspac
 Nightshift never guesses which nearby folder owns a shift.
 
 An unattended run cannot answer permission prompts. Claude Code can use a project-local
-`bypassPermissions` setting offered by setup. A Codex run whose contract commits needs
-`codex -a never -s danger-full-access`; `workspace-write` protects `.git` and therefore cannot
-create the per-item commits. Nightshift's configured guards remain active in either mode.
+`bypassPermissions` setting offered by setup. On Codex, unattended execution is `-a never` and the
+sandbox is a separate choice: a contract that does not commit runs under `-s workspace-write`,
+because ticks alone finish a night. Under Codex's `workspace-write` sandbox `.git` is protected, so
+a contract that commits cannot run under it and needs `codex -a never -s danger-full-access`.
+Nightshift's configured guards remain active in either sandbox.
 
 Only four ideas matter on the first run:
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -172,9 +172,11 @@ alternative is pre-allowing the punch list's own tools. nightshift's guards are 
 armed in every permission mode, bypass included. Decline both and a mid-shift prompt costs the
 night; that trade is the owner's.
 
-On Codex, a committing unattended run uses `codex -a never -s danger-full-access`;
-`workspace-write` protects `.git` and cannot create the per-item commits. The owner-defined
-Nightshift guards remain active in either sandbox mode.
+On Codex, unattended execution is `-a never` and the sandbox is a separate choice. A contract
+that does not commit runs under `-s workspace-write`, because ticks alone finish a night. Under
+Codex's `workspace-write` sandbox `.git` is protected, so a contract that commits cannot run under
+it and needs `codex -a never -s danger-full-access`. The owner-defined Nightshift guards remain
+active in either sandbox mode.
 
 ### Start it at a fixed time
 

--- a/plugins/nightshift/skills/archive/SKILL.md
+++ b/plugins/nightshift/skills/archive/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: archive
 description: File finished shift state into a dated archive so the live files stay lean.
+license: MIT
 ---
 
 Archive the finished paperwork for the host-opened project. This files records — it never does

--- a/plugins/nightshift/skills/doctor/SKILL.md
+++ b/plugins/nightshift/skills/doctor/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: doctor
 description: Read-only diagnosis of the workspace, rules, markers, lease, watchman and deadline, with classified next actions.
+license: MIT
 ---
 
 Diagnose the host-opened project **without changing anything**. Doctor is deeper than status: it

--- a/plugins/nightshift/skills/hunt/SKILL.md
+++ b/plugins/nightshift/skills/hunt/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: hunt
 description: Compose a shift from the ready catalog under one time budget, guided or automatic, reviewed first or run directly.
+license: MIT
 ---
 
 Compose a shift for the host-opened project: settle the work, the ending, and the hours, then

--- a/plugins/nightshift/skills/import-issues/SKILL.md
+++ b/plugins/nightshift/skills/import-issues/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: import-issues
 description: Stage explicitly selected GitHub issues onto the drafting table as quoted source; never searches or writes back.
+license: MIT
 ---
 
 Import owner-selected GitHub issues into the host-opened project. This command stages drafts. It

--- a/plugins/nightshift/skills/nightshift/SKILL.md
+++ b/plugins/nightshift/skills/nightshift/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: nightshift
 description: Work a punch list to completion autonomously — overnight, through a todo list, or until a product is polished — parking decisions and leaving receipts.
+license: MIT
 ---
 
 # nightshift — the brain

--- a/plugins/nightshift/skills/nightshift/references/compose/execution-modes.md
+++ b/plugins/nightshift/skills/nightshift/references/compose/execution-modes.md
@@ -122,8 +122,10 @@ Hunt and Quality start the shift themselves rather than printing another command
 run. Both follow Start's whole preflight first — the one-shift check, state and work-target
 validation, stale run-control markers, deadline handling, rules, and unattended permissions — and
 report unsupported permission modes before arming, never mid-shift: Claude Code without
-`bypassPermissions` (or an allowlist covering the gates), Codex without unattended
-`codex -a never -s danger-full-access` when the contract commits. Warn and proceed.
+`bypassPermissions` (or an allowlist covering the gates), and Codex without `-a never`. A contract
+that does not commit arms under `-s workspace-write`; one that commits needs
+`codex -a never -s danger-full-access`, because under Codex's `workspace-write` sandbox `.git` is
+protected. Warn and proceed.
 
 Only then: cut the whole work order out of `work-orders.md`, put the item under `## Items`, write
 the deadline, arm the gate, log the start, run the binding probe, classify the Codex session

--- a/plugins/nightshift/skills/nightshift/references/hosts/codex.md
+++ b/plugins/nightshift/skills/nightshift/references/hosts/codex.md
@@ -1,9 +1,10 @@
 # Start on Codex
 
-Approvals are per launch. A shift meant to run unattended is started
-`codex -a never -s danger-full-access`; the workspace-write sandbox protects `.git`, so a session
-under it can edit but never commit. A contract that does not commit needs only `workspace-write` —
-ticks alone finish a night. The guards remain the fence either way.
+Approvals are per launch, and unattended execution and sandbox scope are two separate choices. A
+shift runs unattended under `-a never`; a contract that does not commit needs only
+`-s workspace-write`, because ticks alone finish a night. Under Codex's `workspace-write` sandbox
+`.git` is protected, so a contract that commits cannot run under it and is started
+`codex -a never -s danger-full-access`. The guards remain the fence either way.
 
 A live conversation is handed back with `codex resume <id>`. Codex SessionEnd (reason `other`) is
 pause-recovery: closing, archiving, or an idle unload stands the watchman down and Start re-arms;

--- a/plugins/nightshift/skills/purge/SKILL.md
+++ b/plugins/nightshift/skills/purge/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: purge
 description: Permanently delete this project's Nightshift state; does not uninstall the plugin.
+license: MIT
 ---
 
 Remove Nightshift from this project. This deletes punch lists, rules, receipts, archives, and

--- a/plugins/nightshift/skills/quality/SKILL.md
+++ b/plugins/nightshift/skills/quality/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: quality
 description: Compose a shift that works the project's quality debt: tests, code, accessibility, contracts, docs, dependencies, security.
+license: MIT
 ---
 
 Quality is the broad entry point for this project's quality work. It uses the same selection and

--- a/plugins/nightshift/skills/reset/SKILL.md
+++ b/plugins/nightshift/skills/reset/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: reset
 description: Drop the runtime markers and deadline without deleting the owner's work or evidence.
+license: MIT
 ---
 
 Reset runtime mechanics for the host-opened project. This recovers from damaged or confusing

--- a/plugins/nightshift/skills/schedule/SKILL.md
+++ b/plugins/nightshift/skills/schedule/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: schedule
 description: Print the launchd, cron or Task Scheduler config that starts a shift at a fixed time; registers nothing.
+license: MIT
 ---
 
 Get the host-opened project ready to start on a clock, then hand the owner the config. Work through

--- a/plugins/nightshift/skills/setup/SKILL.md
+++ b/plugins/nightshift/skills/setup/SKILL.md
@@ -191,13 +191,13 @@ denied means denied. Ask one question:
  project nothing, and the first prompt of the night proves it. Settings on disk are what revivals
  inherit — a mode picked at launch dies with the process.
 - **Yes, on Codex** → there is no settings file to write: approvals are per launch. Tell the owner
- the unattended spelling — `codex -a never -s danger-full-access` — and say the trade plainly:
- the workspace-write sandbox protects `.git`, so a session under it can edit but never commit,
- and the default contract commits once per item. The fence around that access is nightshift's
+ that unattended execution and sandbox scope are two separate choices, and say the trade plainly:
+ a contract that does not commit runs unattended under `-a never -s workspace-write` — ticks alone
+ finish a night, in the gate and the stall guard alike, and the commit rule is theirs to strip
+ from the punch list and `clockOutMessage`. Under Codex's `workspace-write` sandbox `.git` is
+ protected, so the default contract, which commits once per item, cannot run under it and is
+ started `codex -a never -s danger-full-access`. The fence around that access is nightshift's
  own guards, which hold in every mode — the same trade `bypassPermissions` makes on Claude Code.
- An owner whose contract does not commit (the commit rule is theirs to strip from the punch
- list and `clockOutMessage`) runs unattended under plain `workspace-write` — ticks alone finish
- a night, in the gate and the stall guard alike.
 - **No** → respect it and say the cost plainly: *"a permission prompt mid-shift freezes the night
  until morning — if the shift stalls on one, that was tonight's trade."* Suggest the narrower
  alternative: pre-allow just the punch list's tools (test runner, linter, git) in the same file.

--- a/plugins/nightshift/skills/setup/SKILL.md
+++ b/plugins/nightshift/skills/setup/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: setup
 description: Scaffold .nightshift/ and propose quality gates for this stack; asks, never imposes.
+license: MIT
 ---
 
 Set up Nightshift in this project. Do the scaffolding first, then the gates conversation, then

--- a/plugins/nightshift/skills/start/SKILL.md
+++ b/plugins/nightshift/skills/start/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: start
 description: Begin the shift from the punch list without asking, so scheduled and headless runs behave like interactive ones.
+license: MIT
 ---
 
 Start a Nightshift run in the host-opened project.

--- a/plugins/nightshift/skills/status/SKILL.md
+++ b/plugins/nightshift/skills/status/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: status
 description: Read-only shift status: items, parked decisions, snags, deadline, STOP or stall state.
+license: MIT
 ---
 
 Report the shift status for the host-opened project **without starting or changing anything** —

--- a/plugins/nightshift/skills/stop/SKILL.md
+++ b/plugins/nightshift/skills/stop/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: stop
 description: Issue a stop-work order: pause the shift now, leaving unfinished items open.
+license: MIT
 ---
 
 Pause the host-opened project immediately so the owner can edit the punch list and resume later.


### PR DESCRIPTION
Two documentation-only changes.

**Skill licenses.** Every `plugins/nightshift/skills/*/SKILL.md` frontmatter carries the
optional `license` field of the Agent Skills specification, set to the MIT terms already
published in the LICENSE files at the repository root and inside the plugin. A host or
directory that reads a skill on its own gets the license from the skill itself rather than
having to locate the surrounding repository.

**Codex permissions.** Running unattended and choosing a sandbox are two independent flags.
The README, the command reference, the execution-modes and Codex host references, and Setup's
Codex answer each lead with the sandbox the work needs: a contract that does not commit runs
under `-s workspace-write`, because ticks alone finish a night. Only a contract that commits
needs `codex -a never -s danger-full-access`, and the reason is Codex's documented sandbox
behaviour — `.git` is protected under `workspace-write`.

### Verification

- `bats tests/skill-refs.bats tests/workspace-docs.bats tests/state-file-roles.bats` — 40 passed, 0 failed
- `claude plugin validate . --strict` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
