### PR TITLE
Bump the HOL plugin scanner action and gate the suite by path

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,10 +1,8 @@
 name: ci
 
-# Branch work is covered by `pull_request`; `push` covers main, where there is no PR to carry it
-# and where a green run is what lets release publish.
+# Every change reaches main through a pull request whose branch must be up to date with main
+# before it merges, so the merge commit carries the tree the pull request already tested.
 on:
-  push:
-    branches: [main]
   pull_request:
 
 # Nothing here writes to the repository: the suite reads the tree and reports. Declaring it means
@@ -15,17 +13,32 @@ permissions:
 # Path buckets decide which expensive steps run. Required job names (shellcheck, validate,
 # bats (1-6), bats-macos (1-6)) always start so a docs-only or Release Please pull request is
 # not left waiting on a check that never reported. Workflow-level `paths` would skip the whole
-# workflow and revive that pending state.
+# workflow and revive that pending state. A job that only reports a skip runs on Linux, where a
+# runner is available at once.
+#
+# The filter matches a file when any one pattern matches it, and a `!` pattern matches every
+# file but the one it names. The plugin tree is therefore filtered in its own step under the
+# `every` quantifier, where a file must match `plugins/**` and each exclusion.
 jobs:
   changes:
     runs-on: ubuntu-latest
     outputs:
-      suite: ${{ steps.filter.outputs.runtime == 'true' || steps.filter.outputs.workflow == 'true' }}
+      suite: ${{ steps.filter.outputs.runtime == 'true' || steps.plugin.outputs.runtime == 'true' || steps.filter.outputs.workflow == 'true' }}
       lint: ${{ steps.filter.outputs.shell == 'true' || steps.filter.outputs.workflow == 'true' }}
-      validate: ${{ steps.filter.outputs.runtime == 'true' || steps.filter.outputs.manifest == 'true' || steps.filter.outputs.workflow == 'true' }}
-      docs: ${{ steps.filter.outputs.docs == 'true' && steps.filter.outputs.runtime != 'true' && steps.filter.outputs.workflow != 'true' }}
+      validate: ${{ steps.filter.outputs.runtime == 'true' || steps.plugin.outputs.runtime == 'true' || steps.filter.outputs.manifest == 'true' || steps.filter.outputs.workflow == 'true' }}
+      docs: ${{ steps.filter.outputs.docs == 'true' && steps.filter.outputs.runtime != 'true' && steps.plugin.outputs.runtime != 'true' && steps.filter.outputs.workflow != 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
+        id: plugin
+        with:
+          predicate-quantifier: every
+          filters: |
+            runtime:
+              - 'plugins/**'
+              - '!plugins/nightshift/.claude-plugin/plugin.json'
+              - '!plugins/nightshift/.codex-plugin/plugin.json'
+              - '!plugins/nightshift/.cursor-plugin/plugin.json'
       - uses: dorny/paths-filter@d1c1ffe0248fe513906c8e24db8ea791d46f8590 # v3.0.3
         id: filter
         with:
@@ -35,10 +48,6 @@ jobs:
             shell:
               - '**/*.sh'
             runtime:
-              - 'plugins/**'
-              - '!plugins/nightshift/.claude-plugin/plugin.json'
-              - '!plugins/nightshift/.codex-plugin/plugin.json'
-              - '!plugins/nightshift/.cursor-plugin/plugin.json'
               - 'tests/**'
               - 'evals/**'
               - '.claude-plugin/**'
@@ -126,7 +135,7 @@ jobs:
 
   bats-macos:
     needs: changes
-    runs-on: macos-latest
+    runs-on: ${{ needs.changes.outputs.suite == 'true' && 'macos-latest' || 'ubuntu-latest' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/hol-plugin-scanner.yml
+++ b/.github/workflows/hol-plugin-scanner.yml
@@ -30,7 +30,7 @@ jobs:
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: HOL Plugin Scanner
-        uses: hashgraph-online/ai-plugin-scanner-action@6398407f1bd44465c99054442024d4e5ffbed164 # v1.2.555
+        uses: hashgraph-online/ai-plugin-scanner-action@18db10e4a3f4e91b9911288a7be3f077f851de90 # v1.2.641
         with:
           plugin_dir: "."
           mode: scan


### PR DESCRIPTION
Pins `hashgraph-online/ai-plugin-scanner-action` to v1.2.641, which installs plugin-scanner 3.0.131.

Local scan of this branch with 3.0.131: score 96/100 A, `Claude marketplace structure` 4/4. With the previous pin (3.0.23): 94/100 A, `Claude marketplace structure` 0/4.

The `ci` workflow's `runtime` bucket matched every diff because its `!` exclusions each match every other file under the `some` quantifier. The plugin tree is filtered in its own step under `every`. The workflow runs on `pull_request` only, and macOS shards use an Ubuntu runner when they have nothing to run.

Filter outputs by diff, checked against picomatch with dorny's match options:

| Diff | suite | lint | validate | docs |
|---|---|---|---|---|
| `.github/workflows/hol-plugin-scanner.yml` (this PR's first commit) | no | no | no | no |
| Release Please files | no | no | yes | no |
| `README.md`, `docs/**` | no | no | no | yes |
| `plugins/nightshift/hooks/*.sh` | yes | yes | yes | no |
| `plugins/nightshift/skills/**` | yes | no | yes | no |
| `tests/**` | yes | no | yes | no |
| `.claude-plugin/marketplace.json` | yes | no | yes | no |
| `.github/workflows/ci.yaml` | yes | yes | yes | no |

🤖 Generated with [Claude Code](https://claude.com/claude-code)