### PR TITLE
Keep 0.x releases off 1.0.0

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -4,8 +4,9 @@ name: release-please
 # release x.y.z" — holding the next version and its changelog, and refreshes it on every merge.
 # Merging that pull request is the release: it tags the commit and creates the GitHub release.
 #
-# Commit subjects decide the version: `fix:` a patch, `feat:` a minor, `!` or a BREAKING CHANGE
-# footer a major. Subjects that reach no user — docs, chore, ci, test, refactor — open nothing.
+# Commit subjects decide the version: `fix:` a patch, `feat:` a minor. A `!` or BREAKING
+# CHANGE footer is a major only at 1.x; on 0.x it is a minor, so 1.0.0 stays an explicit
+# decision. Subjects that reach no user — docs, chore, ci, test, refactor — open nothing.
 
 on:
   push:

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "bump-minor-pre-major": true,
   "include-component-in-tag": false,
   "tag-separator": "",
   "changelog-path": "CHANGELOG.md",


### PR DESCRIPTION
## Summary
- Release Please treated a bang on a commit subject as permission to cut 1.0.0. Nothing authorized that. The plugin is still 0.x.
- `bump-minor-pre-major` keeps a bang on 0.x as a minor bump. 1.0.0 stays a decision you make, not a robot one.

## Test plan
- [ ] Merge this before the release PR
- [ ] Confirm the next release PR is 0.22.0, not 1.0.0
- [ ] Do not merge https://github.com/orwa-mahmoud/nightshift/pull/147


Made with [Cursor](https://cursor.com)